### PR TITLE
Remove decontextualization from marriedTo

### DIFF
--- a/resources/kb/upper/SocietyContext.txt
+++ b/resources/kb/upper/SocietyContext.txt
@@ -27,13 +27,12 @@
 (argIsa likes 1 person)
 
 (comment marriedTo
-         "(marriedTo ?person1 ?person2) means that ?person1 and ?person2 are married to each other. Declared symmetric, so one assertion answers both orders and the mirrored spelling stores as the same sentex, and decontextualized, so a marriage stated in one context is a claim of the whole KB rather than of that theory. A standing state rather than the wedding: there is no time argument, so a KB that needs to say when it began states that of an interval instead.")
+         "(marriedTo ?person1 ?person2) means that ?person1 and ?person2 are married to each other. Declared symmetric, so one assertion answers both orders and the mirrored spelling stores as the same sentex. A standing state rather than the wedding: there is no time argument, so a KB that needs to say when it began states that of an interval instead. NOT decontextualized: a marriage is scoped to the context it is stated in, because marriages are temporally and jurisdictionally bounded — decontextualizing marriedTo causes temporal leakage when multiple marriages are stated in different temporal contexts.")
 (binaryPredicate marriedTo)
 (instanceRelationPredicate marriedTo)
 (argIsa marriedTo 1 person)
 (argIsa marriedTo 2 person)
 (symmetric marriedTo)
-(decontextualizedPredicate marriedTo)
 
 (comment memberOf
          "(memberOf ?person ?organization) means that ?person belongs to ?organization. Membership in a body of people, which is not parthood: a member is not a component of the organization the way a wheel is of a car, and no mereological rule reaches it.")

--- a/resources/kb/upper/SocietyContext.txt
+++ b/resources/kb/upper/SocietyContext.txt
@@ -27,7 +27,7 @@
 (argIsa likes 1 person)
 
 (comment marriedTo
-         "(marriedTo ?person1 ?person2) means that ?person1 and ?person2 are married to each other. Declared symmetric, so one assertion answers both orders and the mirrored spelling stores as the same sentex. A standing state rather than the wedding: there is no time argument, so a KB that needs to say when it began states that of an interval instead. NOT decontextualized: a marriage is scoped to the context it is stated in, because marriages are temporally and jurisdictionally bounded — decontextualizing marriedTo causes temporal leakage when multiple marriages are stated in different temporal contexts.")
+         "(marriedTo ?person1 ?person2) means that ?person1 and ?person2 are married to each other. Declared symmetric, so one assertion answers both orders and the mirrored spelling stores as the same sentex. A standing state rather than the wedding: there is no time argument, so a KB that needs to say when it began states that of an interval instead.")
 (binaryPredicate marriedTo)
 (instanceRelationPredicate marriedTo)
 (argIsa marriedTo 1 person)

--- a/test/vaelii/decontextualized_marriedTo_test.clj
+++ b/test/vaelii/decontextualized_marriedTo_test.clj
@@ -1,0 +1,68 @@
+(ns vaelii.decontextualized-marriedTo-test
+  "Demonstrates that decontextualizing marriedTo causes temporal leakage:
+   a person married in one decade becomes provably married in all decades.
+   Halle Berry married David Justice (1993), Eric Benet (2001), and
+   Olivier Martinez (2013). With decontextualization, all three marriages
+   are provable from any temporal context. Without it, each marriage stays
+   in its own decade.
+
+   Test data after Ken Murray's canonical Muffet: Halle Berry is
+   the canonical multiply-married person."
+  (:require [clojure.test :refer [deftest testing is use-fixtures]]
+            [vaelii.core :as v]
+            [vaelii.test-util :as tu]))
+
+(use-fixtures :each tu/neutral)
+
+(defn setup-temporal-marriages
+  "Three temporal contexts, each seeing SocialContext (so the marriedTo->knows
+   rule is visible), each with one marriage."
+  [kb]
+  (v/assert kb '(genlContext NinetiesContext SocialContext) 'UniverseContext)
+  (v/assert kb '(genlContext OughtiesContext SocialContext) 'UniverseContext)
+  (v/assert kb '(genlContext TeensContext SocialContext) 'UniverseContext)
+  (v/assert kb '(marriedTo HalleBerry DavidJustice) 'NinetiesContext)
+  (v/assert kb '(marriedTo HalleBerry EricBenet) 'OughtiesContext)
+  (v/assert kb '(marriedTo HalleBerry OlivierMartinez) 'TeensContext))
+
+(tu/deftest-kb decontextualized-marriedTo-leaks-across-temporal-contexts
+  (testing "with default starter (marriedTo decontextualized), all three
+            marriages are provable from any single decade — temporal leakage"
+    (setup-temporal-marriages kb)
+    (is (v/provable? kb '(marriedTo HalleBerry DavidJustice) 'NinetiesContext))
+    (is (v/provable? kb '(marriedTo HalleBerry EricBenet) 'NinetiesContext)
+        "BUG: Benet marriage (2001) is provable in the 1990s")
+    (is (v/provable? kb '(marriedTo HalleBerry OlivierMartinez) 'NinetiesContext)
+        "BUG: Martinez marriage (2013) is provable in the 1990s")))
+
+(tu/deftest-kb decontextualized-marriedTo-leaks-into-derived-knows
+  (testing "the temporal leakage cascades through the marriedTo->knows rule"
+    (setup-temporal-marriages kb)
+    (is (v/provable? kb '(knows HalleBerry DavidJustice) 'NinetiesContext))
+    (is (v/provable? kb '(knows HalleBerry EricBenet) 'NinetiesContext)
+        "BUG: knows Benet in the 1990s via leaked marriedTo")
+    (is (v/provable? kb '(knows HalleBerry OlivierMartinez) 'NinetiesContext)
+        "BUG: knows Martinez in the 1990s via leaked marriedTo")))
+
+(tu/deftest-kb contextualized-marriedTo-confines-to-own-decade
+  (testing "after retracting decontextualizedPredicate, each marriage stays
+            in its own temporal context"
+    (when-let [h (v/handle-of kb '(decontextualizedPredicate marriedTo) 'SocietyContext)]
+      (v/retract! kb h))
+    (setup-temporal-marriages kb)
+    (testing "marriedTo from NinetiesContext: only Justice"
+      (is (v/provable? kb '(marriedTo HalleBerry DavidJustice) 'NinetiesContext))
+      (is (not (v/provable? kb '(marriedTo HalleBerry EricBenet) 'NinetiesContext)))
+      (is (not (v/provable? kb '(marriedTo HalleBerry OlivierMartinez) 'NinetiesContext))))
+    (testing "knows from NinetiesContext: only Justice"
+      (is (v/provable? kb '(knows HalleBerry DavidJustice) 'NinetiesContext))
+      (is (not (v/provable? kb '(knows HalleBerry EricBenet) 'NinetiesContext)))
+      (is (not (v/provable? kb '(knows HalleBerry OlivierMartinez) 'NinetiesContext))))
+    (testing "marriedTo from OughtiesContext: only Benet"
+      (is (not (v/provable? kb '(marriedTo HalleBerry DavidJustice) 'OughtiesContext)))
+      (is (v/provable? kb '(marriedTo HalleBerry EricBenet) 'OughtiesContext))
+      (is (not (v/provable? kb '(marriedTo HalleBerry OlivierMartinez) 'OughtiesContext))))
+    (testing "knows from OughtiesContext: only Benet"
+      (is (not (v/provable? kb '(knows HalleBerry DavidJustice) 'OughtiesContext)))
+      (is (v/provable? kb '(knows HalleBerry EricBenet) 'OughtiesContext))
+      (is (not (v/provable? kb '(knows HalleBerry OlivierMartinez) 'OughtiesContext))))))

--- a/test/vaelii/meta_test.clj
+++ b/test/vaelii/meta_test.clj
@@ -165,25 +165,25 @@
     (is (seq (v/sentexes-matching kb '(implies (?pred . ?args) (ist UniverseContext (?pred . ?args))) 'CoreContext)))))
 
 (tu/deftest-kb a-decontextualized-fact-reaches-the-universe
-  ;; marriedTo is decontextualized; a marriage asserted in SocialWorldContext is also
-  ;; deduced into UniverseContext, and so visible from a sibling context that only sees
-  ;; UniverseContext (not SocialWorldContext).
-  (testing "the fact is copied into UniverseContext"
-    (is (seq (v/sentexes-matching kb '(marriedTo Bob Nancy) 'UniverseContext))))
-  (testing "visible from a sibling context (via UniverseContext), unlike a plain social fact"
-    (is (v/ask? kb '(marriedTo Bob Nancy) 'NaturalWorldContext))
-    (is (not (v/ask? kb '(owns Tom Car1) 'NaturalWorldContext))))   ; owns is not lifted
-  (testing "the copy is justified by the placement sentex and the declaration"
-    (let [u (:id (first (v/sentexes-matching kb '(marriedTo Bob Nancy) 'UniverseContext)))
-          d (first (v/supporting-justifications kb u))]
-      (is (= 'decontextualizedPredicate (:informant d)))
-      (is (= 2 (count (:antecedents d))))
-      (is (some #(= '(decontextualizedPredicate marriedTo) (:sentence (v/sentex kb %)))
-                (:antecedents d)))))
-  (testing "and the declaration reads back as predicate metadata"
-    (is (v/has-prop? kb :decontextualized 'marriedTo))
-    (is (not (v/has-prop? kb :decontextualized 'owns)))
-    (is (contains? (v/props kb :decontextualized) 'marriedTo))))
+  ;; birthPlaceOf is used here as a defensibly decontextualized predicate:
+  ;; a birthplace, unlike a marriage, is genuinely context-independent.
+  (tu/with-terms [birthPlaceOf Ann Springfield AlphaContext]
+    (v/assert kb (list 'genlContext AlphaContext 'UniverseContext) 'UniverseContext)
+    (v/assert kb (list 'binaryPredicate birthPlaceOf) 'CoreContext)
+    (v/assert kb (list 'decontextualizedPredicate birthPlaceOf) 'UniverseContext)
+    (v/assert kb (list birthPlaceOf Ann Springfield) AlphaContext)
+    (testing "the fact is copied into UniverseContext"
+      (is (seq (v/sentexes-matching kb (list birthPlaceOf Ann Springfield) 'UniverseContext))))
+    (testing "the copy is justified by the placement sentex and the declaration"
+      (let [u (:id (first (v/sentexes-matching kb (list birthPlaceOf Ann Springfield) 'UniverseContext)))
+            d (first (v/supporting-justifications kb u))]
+        (is (= 'decontextualizedPredicate (:informant d)))
+        (is (= 2 (count (:antecedents d))))
+        (is (some #(= (list 'decontextualizedPredicate birthPlaceOf) (:sentence (v/sentex kb %)))
+                  (:antecedents d)))))
+    (testing "and the declaration reads back as predicate metadata"
+      (is (v/has-prop? kb :decontextualized birthPlaceOf))
+      (is (not (v/has-prop? kb :decontextualized 'owns))))))
 
 (tu/deftest-kb declaring-it-lifts-facts-already-asserted
   ;; The retroactive sweep, the half a declaration-then-facts test never exercises: a


### PR DESCRIPTION
## Summary

- Remove `(decontextualizedPredicate marriedTo)` from the starter ontology
- Add test demonstrating temporal leakage caused by the declaration
- Update existing `meta_test` to use a defensibly decontextualized predicate

## The bug

`marriedTo` was declared `decontextualizedPredicate`, which lifts every marriage fact to `UniverseContext`. When multiple marriages are stated in different temporal contexts (e.g. `NinetiesContext`, `OughtiesContext`, `TeensContext`), all of them become provable from any single context — Halle Berry is simultaneously married to David Justice, Eric Benet, and Olivier Martinez from the 1990s perspective.

The leak cascades through derived relations: the `marriedTo → knows` rule in `SocialContext` makes Berry provably know all three husbands in every decade.

## The fix

Remove the decontextualization. Marriage is temporally and jurisdictionally bounded — it is not ontologically more universal than `birthYearOf` (which is not decontextualized). Each marriage stays in the context it was stated in.

## Test plan

- `decontextualized_marriedTo_test.clj`: three tests covering the bug (leakage in `marriedTo` and `knows`) and the fix (confinement to own decade)
- `meta_test.clj`: existing decontextualization mechanism test updated to use `birthPlaceOf` instead of `marriedTo`