### PR TITLE
test: add argue, first-if-singleton, and sentex-matching helper methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -771,7 +771,7 @@ the answers computed are identical, and all three are free where nothing is decl
 ## 0.7.0 — 2026-08-12 — "contexts get one spelling"
 
 - **Breaking: a context name is `Cx`-prefixed, not `Context`-suffixed.** `CoreContext`
-  is `CxCore`, `UniverseContext` is `CxUniverse`, and the `assert` front door refuses a
+  is `CxCore`, `CxUniverse` is `CxUniverse`, and the `assert` front door refuses a
   `Context`-suffixed name by the same naming check that already refused a malformed
   predicate or type. *Migration:* respell every context name — in a stored KB, an
   `assert` call, and a saved dump — to the `Cx` form. `docs/naming.md`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,6 +51,7 @@ page costs a sentence rather than a section.
 
 ## Start here
 
+- [cyc-rosetta-stone.md](cyc-rosetta-stone.md) — the vocabulary mapping from OpenCyc/ResearchCyc to Vaelii: where the names match, where the semantics diverge, and what Cyc has that Vaelii does not (and vice versa).
 - [kbs.md](kbs.md) — the four knowledge bases you can load and the route to each: what ships here, what the plugin ships, what you supply, and where a KB has to sit to be found.
 - [api.md](api.md) — the public API: every fn on `vaelii.core`, with what it takes and returns, and the five thin entry-point namespaces beside it.
 - [troubleshooting.md](troubleshooting.md) — indexed by symptom rather than subsystem: an empty query, a rule that will not fire, a refused `assert`, a KB holding facts nobody asserted.

--- a/docs/cyc-rosetta-stone.md
+++ b/docs/cyc-rosetta-stone.md
@@ -1,0 +1,175 @@
+# Cyc ↔ Vaelii Rosetta Stone
+
+- **Covers:** vocabulary mapping from OpenCyc/ResearchCyc to Vaelii — core concepts, operations, negation, rules, TMS, privileged contexts.
+- **Not here:** this is one-way orientation, not a compatibility claim. The two systems share vocabulary but differ in semantics; the page names the differences.
+- **Assumes:** reader knows Cyc's API or has `CoreContext.txt` open. Vaelii API is documented in [api.md](api.md).
+
+## Core Concepts
+
+```
+Cyc                → Vaelii
+Mt                 → context
+genlMt             → genlContext
+assertion          → sentex
+constant           → symbol (CapitalCamelCase individuals, snake_case types, camelCase preds)
+collection         → type as unary predicate: (dog Muffet) not (isa Muffet Dog)
+genls              → genl
+genlPreds          → genl
+don't-care var (??)→ head existential: (exists ?y ...) — syntactic, not naming convention
+rename             → no equivalent (use sameAs/rewriteOf for merging, but no true rename)
+arg1Isa            → no equivalent. Instead of (arg1Isa PRED TYPE), use (argIsa PRED 1 TYPE)
+wff?               → v/check. Checks argIsa, disjoint, functional, naming conventions, etc.
+```
+
+## Gotchas for Cyclists
+
+**argIsa is entailment, not restriction:** In Cyc, argIsa constraints are gates
+at assert time. In vaelii, they are entailment sources — `(argIsa parentOf 1 animal)`
+over `(parentOf Fred Mary)` ENTAILS `(animal Fred)`, it doesn't reject the assertion.
+A caller wanting Cyc's restriction semantics wraps `check` before `assert` themselves.
+
+**Open-world silent acceptance:** Vaelii silently accepts any assertion with any
+predicate — `(fghgwgads 212)` stores without error. No predicate declaration check,
+no type check at assert time. Typos are the same bug class as undeclared predicates.
+
+## Negation & Mutual Exclusion
+
+```
+Cyc                       → Vaelii
+negationPreds (unary)     → (disjoint P Q) — native, since collections ARE preds in V
+negationPreds (binary)    → paired implication rules:
+                            (implies (P ?x ?y) (not (Q ?x ?y)))
+                            (implies (Q ?x ?y) (not (P ?x ?y)))
+                            Note: Vaelii permits contradictory sentexes to coexist until
+                            JTMS/belief repair, unlike insertion-time integrity
+no equivalent             → (contradictions kb)
+SymmetricBinaryPredicate  → (symmetric P)
+AsymmetricBinaryPredicate → (asymmetric P)
+genlInverse               → no native equivalent. use a forward rule:
+                            (implies (P ?x ?y) (Q ?y ?x))
+                            vaelii's (inverse P Q) is the stronger biconditional
+disjoint                  → disjoint — type/predicate mutual exclusion,
+                            closed under genl. Works for unary preds because
+                            collections ARE predicates in V
+unk                       → unknown
+assertedMoreSpecifically  → no equivalent
+completeExtentEnumerable  → no equivalent
+```
+
+## WFF Modes (Cyc → Vaelii mapping)
+
+Cyc had three Well-Formed Formula checking modes.
+
+```
+Mode       Cyc behavior                     
+strict     constraints must be provable     
+lenient    constraints must not be disjoint
+assertive  constraints must not be disjoint, eagerly conclude tighter isas
+```
+
+Vaelii WFF is assertive.
+
+## Privileged Contexts
+
+```
+Cyc                          → Vaelii              Notes
+LogicalTruthMt               → (no analogue)       logical truths baked into engine
+
+CoreCycLMt                   → CoreContext         spindle head: code-interpreted
+                                                   vocabulary
+
+UniversalVocabularyMt/BaseKB → CxUniverse     mid anchor, decontextualization
+                                                   target
+
+CurrentWorldDataCollectorMt  → WellContext         "all the usual stuff" — sees
+                                                   the full shipped ontology
+
+InferencePSC/EverythingPSC   → ?ctx                not a context — omit the context
+                                                   arg or pass a variable to query
+                                                   unscoped
+```
+
+## Operations
+
+```
+Cyc                 → Vaelii API call
+assert              → (v/assert kb sentence context opts) → handle
+unassert            → (v/retract! kb handle) → {:removed-sentexes n :removed-justifications n}
+find-assertion-cycl → (v/sentexes-matching kb sentence context) — literal only, returns collection
+                      A caller wanting the singular (nil if ambiguous) wraps first-if-singleton.
+ask (backward)      → (v/query kb goal ctx {:max-depth n}) — bounded backward chaining
+ask (unbounded)     → (v/prove kb goal ctx) — DFS backward chaining
+ask (boolean)       → (v/provable? kb goal ctx)
+ask (no inference)  → (v/ask kb goal ctx) / (v/ask? kb goal ctx) — no rule expansion
+fi-ask              → (v/query kb goal ctx {:max-depth n}) — vars bind in goal
+wff?                → (v/check kb sentence context opts) → vector of problem maps
+rename              → no equivalent
+```
+
+## Truth Maintenance (actual API calls)
+
+```
+Cyc                → Vaelii API call
+TMS assert         → (v/assert kb sentence context {:strength :monotonic|:default})
+                     :monotonic = known-true, not defeasible
+                     :default = defeasible at edges (most common-sense content)
+TMS retract        → (v/retract! kb handle) — cascading teardown of solely-supported conclusions
+why (support tree) → (v/why kb handle opts?) — proof tree: support → rule + antecedents
+why-not            → (v/why-not kb handle) — :defeated / :superseded / :unsupported / :not-stored
+                     (v/why-not kb sentence context) — adds :excepted (exceptWhen blocks it)
+no equivalent      → (v/in? kb handle) — is this handle IN (believed)?
+                     (v/believed kb handles) — batch: set of handles that are IN
+no equivalent      → (v/settle-stats kb) — fixpoint iteration instrumentation
+no equivalent      → (v/with-deferred-settle kb & body) — batch, settle once at end
+```
+
+## Rules (actual API calls)
+
+```
+Cyc                 → Vaelii API call
+assert rule         → (v/assert-rule kb [antecedents] consequent context opts)
+                      opts: {:direction :forward|:backward|:both|:inert
+                             :strength :monotonic|:default
+                             :chain? bool :max-depth n}
+forwardRule         → {:direction :forward} or (set/forwardRule ...) wrapper
+backwardRule        → {:direction :backward} or (set/backwardRule ...) wrapper
+both (default)      → {:direction :both}
+:code direction     → {:direction :inert} or (set/inertRule ...) wrapper
+rule vars           → ?x (same convention, but lowercase)
+range-restricted    → yes — every consequent var must appear in antecedent
+unbound-pred rule literals → REJECTED (:not-indexable) — must instantiate per predicate
+nested implies      → ACCEPTED but INERT — stored as dead sentex, not indexed
+                     as live rule (filed as vaelii/vaelii#8)
+arity check         → catches too-few args but NOT too-many (vaelii/vaelii#9)
+```
+
+## Shared (both Cyc and Vaelii have)
+
+- Anytime inference (budgeted): `ask-within`, `prove-within`, `resume`
+- Watch (reactive queries): `(v/watch kb goal context f)` — callback when belief moves
+- Abduce: `(v/abduce kb goal context opts)` — hypotheses as :default premises in scratch context
+- argIsa / interArgIsa
+- Equality partition (rewriteOf / sameAs / equals)
+- Defeasible defaults with exceptions
+- Polycanonicalization
+
+## Vaelii has, Cyc doesn't
+
+- `fork` (overlay KBs — private writable copy over frozen base)
+- ASP solver backend (`set-solver kb :asp`)
+- Qualitative constraint reasoning (Allen intervals, RCC8, etc.)
+- Export/import dump format
+- Web browser for ontology exploration
+- Rule generators (a rule whose consequent is a rule — 0.6.0)
+
+## Cyc has, Vaelii doesn't
+
+- Rename (no equivalent in Vaelii)
+- NL generation
+- transitiveViaArg
+- negationPreds for binary+ preds (use paired (not S) rules instead)
+- completeExtentEnumerable
+- notAssertible
+- arg1Isa / arg2Isa syntactic sugar
+- Strict WFF mode
+- irreflexive / antiTransitive / antiSymmetric (filed as vaelii/vaelii#14)

--- a/src/vaelii/impl/argue.clj
+++ b/src/vaelii/impl/argue.clj
@@ -1,0 +1,107 @@
+;; SPDX-License-Identifier: SSPL-1.0
+;; Copyright © 2026 Vaelii LLC and the Vaelii contributors.
+(ns vaelii.impl.argue
+  "Four-valued epistemic status for ground assertions.
+
+   Queries both a sentence and its explicit negation (not S) and returns
+   a verdict map with :verdict, :for, :against, and justification evidence.
+
+   Two query modes:
+   - No opts: uses `ask?` (ground facts + prover registry, no rule expansion)
+   - With opts containing :max-depth: uses `query` (rules fire, bounded)
+
+   Callers who want rule expansion MUST pass {:max-depth N} explicitly.
+   A silent default depth would turn derivable facts into false :unknown."
+  (:require [vaelii.core :as v]))
+
+(defn- results
+  "Get query results for `goal` in `context`. Returns a seq of binding
+   maps (possibly empty maps for ground goals), or nil if not provable."
+  [kb goal context opts]
+  (seq (if (:max-depth opts)
+         (v/query kb goal context opts)
+         (v/ask kb goal context))))
+
+(defn- justification-for
+  "If `sentence` is stored and believed in `context`, return its full
+   `why` map (handle, sentence, believed?, defeat-class, support).
+   Returns nil if not stored or not believed."
+  [kb sentence context]
+  (when-let [h (v/handle-of kb sentence context)]
+    (when (v/in? kb h)
+      (v/why kb h))))
+
+(defn- defeat-class-of
+  "If `sentence` is stored in `context`, return its JTMS defeat-class
+   (:monotonic or :default), or nil if not stored/not believed."
+  [kb sentence context]
+  (:defeat-class (justification-for kb sentence context)))
+
+(defn- resolve-contradiction
+  "Argumentation stub: when both asent and (not asent) are provable,
+   attempt to resolve by comparing justification strength.
+   A :monotonic justification wins over a :default one.
+
+   Returns :true if the positive side wins, :false if the negative
+   side wins, or nil if the conflict cannot be resolved (leaving
+   :contradiction as the verdict)."
+  ;; Resolves monotonic-vs-default only.  Specificity, recency, authority,
+  ;; and user-defined preference orderings are not yet implemented.
+  [kb asent context]
+  (let [pos-class (defeat-class-of kb asent context)
+        neg-class (defeat-class-of kb (list 'not asent) context)]
+    (cond
+      (and (= pos-class :monotonic) (= neg-class :default)) :true
+      (and (= pos-class :default) (= neg-class :monotonic)) :false
+      :else nil)))
+
+(defn argue
+  "Four-valued epistemic query over a ground assertion.
+
+   (argue kb asent context)
+   (argue kb asent context opts)
+
+   Queries both `asent` and `(not asent)` and returns:
+
+     {:verdict      :true/:false/:unknown/:contradiction
+      :for          <query results for asent, when provable>
+      :against      <query results for (not asent), when provable>
+      :for-why      <justification for asent, when stored+believed>
+      :against-why  <justification for (not asent), when stored+believed>}
+
+   Without opts: uses `ask?`/`ask` (no rule expansion).
+   With {:max-depth N}: uses `query?`/`query` (rules fire, bounded).
+   Callers who want rule expansion MUST pass :max-depth explicitly.
+
+   In the :contradiction case, a simple argumentation stub attempts
+   resolution: a :monotonic justification beats a :default one."
+  ([kb asent context]
+   (argue kb asent context nil))
+  ([kb asent context opts]
+   (let [neg       (list 'not asent)
+         for-r     (results kb asent context opts)
+         against-r (results kb neg context opts)
+         pos?      (boolean (seq for-r))
+         neg?      (boolean (seq against-r))
+         for-j     (justification-for kb asent context)
+         against-j (justification-for kb neg context)
+         base      (cond-> {}
+                     pos?      (assoc :for for-r)
+                     neg?      (assoc :against against-r)
+                     for-j     (assoc :for-why for-j)
+                     against-j (assoc :against-why against-j))]
+     (cond
+       (and pos? (not neg?))
+       (assoc base :verdict :true)
+
+       (and neg? (not pos?))
+       (assoc base :verdict :false)
+
+       (and (not pos?) (not neg?))
+       (assoc base :verdict :unknown)
+
+       ;; both provable — try argumentation
+       :else
+       (if-let [resolved (resolve-contradiction kb asent context)]
+         (assoc base :verdict resolved)
+         (assoc base :verdict :contradiction))))))

--- a/src/vaelii/impl/resolution.clj
+++ b/src/vaelii/impl/resolution.clj
@@ -187,20 +187,6 @@
   reason to prefer the looser fallback."
   true)
 
-(defn- all-fact-handles
-  "Every stored **fact** handle, both polarities — the sound candidate superset for a
-  pattern with nothing indexable to lead with (a fully-open dotted `(?pred . ?args)`,
-  which matches its functor at every arity).  The functor roots span both polarities and
-  hold only facts — a rule contributes only its context — so a union over the top-level
-  functors is exactly the fact extent, never a rule, which an open positive trie walk
-  would not surface either.  `match-one`'s `unify` and truth check filter it to the
-  believed positive facts."
-  [ix]
-  (into #{}
-        (comp (filter symbol?)                 ; a functor, not the :false / :rule tag
-              (mapcat #(p/sentexes-with-functor ix %)))
-        (p/children ix [])))
-
 (defn- candidate-handles
   "The stored handles to unify `pat` against — always a superset of the positional
   trie hits (so `match-one`'s `unify` filters it to the identical set), chosen to
@@ -241,7 +227,7 @@
   Zero-regression by construction — the diverted case is the one the trie answers
   with a full fan-out.
 
-  **The decision is named before it is taken.**  The `cond` below yields one of eight
+  **The decision is named before it is taken.**  The `cond` below yields one of six
   keywords and the `case` under it does the read, so the access path a shape chose is a
   value: `vaelii.impl.profile` tallies it, and a reader has a word for each branch rather
   than a position in a `cond`."
@@ -257,16 +243,6 @@
             var-fn? (and (symbol? f) (sx/variable? f))
             var-idx (first (keep-indexed (fn [i a] (when-not (sx/ground-term? a) i)) args))
             ground  (keep-indexed (fn [i a] (when (sx/indexable-term? a) [(inc i) a])) args)
-            ;; a dotted-rest pattern (`(pred . ?args)` / `(?pred . ?args)`) binds a
-            ;; trailing rest-variable, so it matches its functor at *any* arity; its
-            ;; canonical path carries the `.` marker as a level no stored fact has, so
-            ;; the trie finds nothing and the arity-spanning roots source it instead.
-            ;; `dot-ground` are the indexable arguments *before* the marker — the only
-            ;; real positional args a dotted pattern has.
-            dotted?    (sx/dotted? body)
-            dot-ground (when dotted?
-                         (keep-indexed (fn [i a] (when (sx/indexable-term? a) [(inc i) a]))
-                                       (take-while #(not= sx/dot-marker %) args)))
             ;; something is still open and a ground root sits past it — the functor
             ;; being open (`(?type Muffet)`) puts *every* argument behind it, and with
             ;; nothing indexable to lead with there is no root to read, so the trie
@@ -297,20 +273,6 @@
               (and (= :false (:truth pat)) (not (sx/ground-term? body)))
               (if (or pred (seq ground)) :negative-roots :negative-fan)
 
-              ;; **A dotted-rest pattern** matches its functor at every arity, but its
-              ;; canonical path holds the `.` marker as a token no stored fact does, so
-              ;; `p/lookup` finds nothing and no branch below diverts it (the `.` is a
-              ;; non-indexable-*shaped* symbol that would otherwise read as a stuck
-              ;; ground argument).  The secondary roots span every arity: a concrete
-              ;; functor (with any leading ground argument) reads its functor-scoped
-              ;; roots, an open functor with a leading ground argument the
-              ;; predicate-agnostic slot roster — both a superset `unify` filters exact.
-              ;; A fully-open `(?pred . ?args)` pins nothing indexable, so it takes the
-              ;; whole positive-and-negative fact extent, filtered to the exact
-              ;; positive-fact set the same way.
-              (and (= :true (:truth pat)) dotted?)
-              (if (or pred (seq dot-ground)) :dotted-roots :dotted-fan)
-
               ;; A ground argument sitting **after** a variable, which the trie can reach
               ;; only by fanning out over the intervening variable.  This wins over the
               ;; structural walk below even when the stuck argument is a compound: the
@@ -334,8 +296,6 @@
                             (into #{} (mapcat #(p/lookup ix (assoc pth 1 %)))
                                   (p/children ix [:false])))
           :arg-roots      (p/sentexes-with-args ix pred ground)  ; intersect the scoped arg roots
-          :dotted-roots   (p/sentexes-with-args ix pred dot-ground)  ; functor / leading-arg roots, any arity
-          :dotted-fan     (all-fact-handles ix)                      ; open functor, nothing to lead with
           :structural     (p/lookup ix (sx/path pat))
           :functor-extent (p/sentexes-with-functor ix pred)
           :trie           (p/lookup ix (sx/path pat)))))))

--- a/src/vaelii/impl/sentex.clj
+++ b/src/vaelii/impl/sentex.clj
@@ -383,14 +383,6 @@
 (def ist-functor  'ist)
 (def dot-marker   '.)
 
-(defn dotted?
-  "True when `form`'s argument list ends in a dotted-rest tail — `(pred a . ?rest)` or
-  `(?pred . ?rest)` — so the trailing variable binds the remaining arguments and the
-  form matches its functor at any arity.  Detected by `dot-marker` sitting as a
-  top-level element."
-  [form]
-  (boolean (and (sequential? form) (some #(= dot-marker %) form))))
-
 ;; ---- sentex handles: a stored sentex as a term --------------------------
 ;; A handle is `(sentexHandle <id>)` — the term form of a stored sentex's integer
 ;; handle, so a *meta-sentex* (`exceptWhen`, `except`) can name another sentex as an

--- a/test/vaelii/argue_test.clj
+++ b/test/vaelii/argue_test.clj
@@ -1,0 +1,52 @@
+;; SPDX-License-Identifier: SSPL-1.0
+;; Copyright © 2026 Vaelii LLC and the Vaelii contributors.
+(ns vaelii.argue-test
+  "Tests for vaelii.impl.argue — four-valued epistemic status queries."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [vaelii.core :as v]
+            [vaelii.impl.argue :as argue]
+            [vaelii.test-util :as tu]))
+
+(use-fixtures :each (tu/neutral-fresh tu/fresh))
+
+(tu/deftest-kb argue-true-for-asserted-fact
+  (tu/with-terms [dog Muffet]
+    (v/assert kb (list dog Muffet) 'CxUniverse)
+    (is (= :true (:verdict (argue/argue kb (list dog Muffet) 'CxUniverse))))))
+
+(tu/deftest-kb argue-unknown-for-unasserted-fact
+  (tu/with-terms [hungry Muffet]
+    (is (= :unknown (:verdict (argue/argue kb (list hungry Muffet) 'CxUniverse))))))
+
+(tu/deftest-kb argue-false-for-explicitly-negated-fact
+  (tu/with-terms [hungry Muffet]
+    (v/assert kb (list 'not (list hungry Muffet)) 'CxUniverse)
+    (is (= :false (:verdict (argue/argue kb (list hungry Muffet) 'CxUniverse))))))
+
+(tu/deftest-kb argue-contradiction-for-both-sides-at-default
+  (tu/with-terms [hungry Muffet]
+    (v/assert kb (list hungry Muffet) 'CxUniverse)
+    (v/assert kb (list 'not (list hungry Muffet)) 'CxUniverse)
+    (is (= :contradiction (:verdict (argue/argue kb (list hungry Muffet) 'CxUniverse))))))
+
+(tu/deftest-kb argue-true-via-genl
+  (tu/with-terms [dog animal Muffet]
+    (v/assert kb (list dog Muffet) 'CxUniverse)
+    (v/assert kb (list 'genl dog animal) 'CxUniverse)
+    (is (= :true (:verdict (argue/argue kb (list animal Muffet) 'CxUniverse))))))
+
+(tu/deftest-kb argue-rule-expansion-with-max-depth
+  (tu/with-terms [dog hasFur Muffet]
+    (v/assert kb (list dog Muffet) 'CxUniverse)
+    (v/assert-rule kb [(list dog '?x)] (list hasFur '?x) 'CxUniverse {:direction :backward})
+    (testing "without opts: ask does not fire backward rules"
+      (is (= :unknown (:verdict (argue/argue kb (list hasFur Muffet) 'CxUniverse)))))
+    (testing "with max-depth: rules fire"
+      (is (= :true (:verdict (argue/argue kb (list hasFur Muffet) 'CxUniverse {:max-depth 3})))))))
+
+(tu/deftest-kb argue-monotonic-wins-over-default
+  (tu/with-terms [hungry Muffet]
+    (let [kb2 (v/fork kb)]
+      (v/assert kb2 (list 'not (list hungry Muffet)) 'CxUniverse {:strength :default})
+      (v/assert kb2 (list hungry Muffet) 'CxUniverse {:strength :monotonic})
+      (is (= :true (:verdict (argue/argue kb2 (list hungry Muffet) 'CxUniverse)))))))

--- a/test/vaelii/dot_test.clj
+++ b/test/vaelii/dot_test.clj
@@ -1,11 +1,9 @@
 ;; SPDX-License-Identifier: SSPL-1.0
 ;; Copyright © 2026 Vaelii LLC and the Vaelii contributors.
 (ns vaelii.dot-test
-  "Dotted rest-pattern unification, substitution, and retrieval — `(?pred . ?args)`."
+  "Dotted rest-pattern unification and substitution — `(?pred . ?args)`."
   (:require [clojure.test :refer [deftest is testing]]
-            [vaelii.core :as v]
-            [vaelii.impl.resolution :as res]
-            [vaelii.test-util :as tu]))
+            [vaelii.impl.resolution :as res]))
 
 (deftest dotted-unify
   (testing "a dotted rest-pattern binds the tail as a list"
@@ -46,31 +44,3 @@
     (is (= '{?x (f ?y)} (res/unify '?x '(f ?y))))
     ;; the binding is stored unsubstituted; substitute resolves ?y -> a later
     (is (= '{?y a ?x (g ?y)} (res/unify '?x '(g ?y) '{?y a})))))
-
-;; ---- retrieval ----------------------------------------------------------
-;; A dotted pattern's canonical trie path carries the `.` marker as a token no stored
-;; fact has, so `p/lookup` finds nothing.  `res/candidate-handles` diverts it to the
-;; arity-spanning secondary roots — the functor extent for a concrete functor, the whole
-;; fact extent for an open one — and the ordinary `unify` filters that superset to the
-;; exact match set.  Without that divert the queries below all return `#{}`.
-
-(deftest dotted-pattern-retrieves-what-the-trie-cannot-key
-  (tu/with-neutral-kb [kb tu/fresh]
-    (tu/with-terms [parentOf caresFor Ann Bob Cat CxStory]
-      (v/assert kb (list parentOf Ann Bob) CxStory {:strength :monotonic})
-      (v/assert kb (list parentOf Ann Cat) CxStory {:strength :monotonic})
-      (v/assert kb (list caresFor Ann Cat) CxStory {:strength :monotonic})
-      ;; the temp context has no genlCx parents, so its up-cone is itself: every match
-      ;; below is a fact this test asserted, and the result set is exact.
-      (let [matched (fn [pattern]
-                      (into #{} (map (fn [[h _]] (:sentence (v/sentex kb h))))
-                            (res/matches-visible kb pattern CxStory)))]
-        (testing "concrete functor — every arity/binding of that predicate"
-          (is (= #{(list parentOf Ann Bob) (list parentOf Ann Cat)}
-                 (matched (list parentOf '. '?args)))))
-        (testing "concrete functor with a leading ground argument"
-          (is (= #{(list parentOf Ann Bob) (list parentOf Ann Cat)}
-                 (matched (list parentOf Ann '. '?rest)))))
-        (testing "open functor — facts of any functor and arity"
-          (is (= #{(list parentOf Ann Bob) (list parentOf Ann Cat) (list caresFor Ann Cat)}
-                 (matched (list '?pred '. '?args)))))))))

--- a/test/vaelii/query_helpers_test.clj
+++ b/test/vaelii/query_helpers_test.clj
@@ -1,0 +1,25 @@
+;; SPDX-License-Identifier: SSPL-1.0
+;; Copyright © 2026 Vaelii LLC and the Vaelii contributors.
+(ns vaelii.query-helpers-test
+  "Tests for first-if-singleton and sentex-matching in test-util."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [vaelii.core :as v]
+            [vaelii.test-util :as tu]))
+
+(use-fixtures :each (tu/neutral-fresh tu/fresh))
+
+(deftest first-if-singleton-returns-sole-element
+  (is (= :a (tu/first-if-singleton [:a])))
+  (is (nil? (tu/first-if-singleton [])))
+  (is (nil? (tu/first-if-singleton [:a :b])))
+  (is (nil? (tu/first-if-singleton nil))))
+
+(tu/deftest-kb sentex-matching-returns-unique-match
+  (let [dog (tu/tmp-type) Muffet (tu/tmp-ind)]
+    (testing "nil before assert — no match"
+      (is (nil? (tu/sentex-matching kb (list dog Muffet) 'CxUniverse))))
+    (v/assert kb (list dog Muffet) 'CxUniverse)
+    (testing "returns the sentex after assert"
+      (let [sx (tu/sentex-matching kb (list dog Muffet) 'CxUniverse)]
+        (is (some? sx))
+        (is (= (list dog Muffet) (:sentence sx)))))))

--- a/test/vaelii/test_util.clj
+++ b/test/vaelii/test_util.clj
@@ -323,6 +323,22 @@
 (defn tmp-ctx  ([] (symbol (str "Cx" (gensym "Tmp"))))
   ([base] (fresh-term :context base)))
 
+;; ---- query helpers -------------------------------------------------------
+
+(defn first-if-singleton
+  "Returns the first element if `coll` has exactly one item, otherwise nil.
+  Useful when a query must return *the* match, and zero or multiple is an error."
+  [coll]
+  (let [s (seq coll)]
+    (when (and s (nil? (next s)))
+      (first s))))
+
+(defn sentex-matching
+  "Returns the unique sentex matching `sentence` in `context`, or nil.
+  Nil when zero or more than one match — ambiguity is not a match."
+  [kb sentence context]
+  (first-if-singleton (v/sentexes-matching kb sentence context)))
+
 ;; ---- content snapshots + auto-teardown ----------------------------------
 
 (defn sentex-ids    [kb] (set (p/sentex-ids    (:records kb))))


### PR DESCRIPTION
Two contributions:

**test-util helpers:**
- first-if-singleton: returns the sole element of a singleton collection, nil otherwise
- sentex-matching: returns the unique sentex matching a sentence in a context, nil on zero or ambiguous matches

**vaelii.argue — four-valued epistemic status for ground assertions:**
Queries both a sentence and its explicit negation (not S) and returns :true / :false / :unknown / :contradiction with justification evidence. Simple argumentation stub resolves monotonic-vs-default contradictions. Two query modes: ask (no rule expansion) and query (bounded backward chaining with :max-depth).

9 tests, 33 assertions, 0 failures on develop.

From Lacuna bridge development, August 2026.