### PR TITLE
fix(core): preserve meta-constraints through hierarchies

### DIFF
--- a/resources/kb/CoreContext.txt
+++ b/resources/kb/CoreContext.txt
@@ -50,6 +50,8 @@
 (argIsa argGenl 1 predicate)
 (argIsa argGenl 2 integer)
 (argGenl argGenl 3 thing)
+(argPreserving argGenl 1 genl)
+(argPreservingInverse argGenl 3 genl)
 
 (comment argIsa
          "(argIsa ?predicate ?position ?type) means that argument ?position of ?predicate must be of ?type. Checked through genl transitivity whenever a sentex is asserted, and open-world: an argument whose type is unknown cannot violate it, so this narrows what can be said without demanding that everything be typed.")
@@ -57,12 +59,17 @@
 (argIsa argIsa 1 predicate)
 (argIsa argIsa 2 integer)
 (argGenl argIsa 3 thing)
+(argPreserving argIsa 1 genl)
+(argPreservingInverse argIsa 3 genl)
 
 (comment interArgIsa
          "(interArgIsa ?predicate ?position1 ?type1 ?position2 ?type2) means that whenever argument ?position1 of ?predicate is a ?type1, argument ?position2 must be a ?type2. The conditional argument constraint, and it says what argIsa cannot: (interArgIsa eats 1 carnivore 2 meat) types the second argument only for the eaters that are carnivores, where (argIsa eats 2 meat) would demand meat of every eater. Open-world in both directions, and they point opposite ways — silence about the trigger argument's type leaves the constraint dormant rather than firing it, while silence about the target argument's is what convicts. Checked through genl transitivity from the writing context, like argIsa, and it entails the same way under assertive argument types.")
 (arity interArgIsa 5)
 (instanceRelationPredicate interArgIsa)
 (argIsa interArgIsa 1 predicate)
+(argPreserving interArgIsa 1 genl)
+(argPreserving interArgIsa 3 genl)
+(argPreservingInverse interArgIsa 5 genl)
 
 (comment arity
          "(arity ?predicate ?n) means that ?predicate takes ?n arguments. One for a unaryPredicate, two for a binaryPredicate, three for a ternaryPredicate. The arity and the predicate-type membership derive each other, so asserting either keeps the whole cycle believed, and retracting the one that was actually asserted collapses it.")

--- a/test/vaelii/core_context_test.clj
+++ b/test/vaelii/core_context_test.clj
@@ -55,3 +55,39 @@
     (v/assert kb (list 'binaryPredicate rel) 'CoreContext)
     (is (thrown? clojure.lang.ExceptionInfo
                  (v/assert kb (list 'arity rel 7) 'CoreContext)))))
+
+(tu/deftest-kb arity-does-not-inherit-across-predicate-specialization
+  ;; Predicate specialization does not currently require a child to share its
+  ;; parent's signature.  Preserving arity down genl would therefore let this
+  ;; functional relation answer both 2 and 3 for child.
+  (tu/with-terms [parent child]
+    (v/with-deferred-settle kb
+      (v/assert kb (list 'genl child parent) 'CoreContext)
+      (v/assert kb (list 'arity parent 2) 'CoreContext)
+      (v/assert kb (list 'arity child 3) 'CoreContext))
+    (is (v/ask? kb (list 'arity child 3) 'CoreContext))
+    (is (not (v/ask? kb (list 'arity child 2) 'CoreContext)))))
+
+(tu/deftest-kb meta-constraints-inherit-through-predicate-and-type-hierarchies
+  (tu/with-terms [parent child mammal animal food]
+    (v/with-deferred-settle kb
+      (v/assert kb (list 'genl child parent) 'CoreContext)
+      (v/assert kb (list 'genl mammal animal) 'CoreContext)
+      (v/assert kb (list 'genl animal 'thing) 'CoreContext)
+      (v/assert kb (list 'genl food 'thing) 'CoreContext)
+      (v/assert kb (list 'argIsa parent 1 mammal) 'CoreContext)
+      (v/assert kb (list 'argGenl parent 2 mammal) 'CoreContext)
+      (v/assert kb (list 'interArgIsa parent 1 animal 2 food) 'CoreContext))
+    (testing "constraints on a predicate reach its specializations"
+      (is (v/ask? kb (list 'argIsa child 1 mammal) 'CoreContext))
+      (is (v/ask? kb (list 'argGenl child 2 mammal) 'CoreContext))
+      (is (v/ask? kb (list 'interArgIsa child 1 animal 2 food) 'CoreContext)))
+    (testing "unconditional constraint types answer through their supertypes"
+      (is (v/ask? kb (list 'argIsa parent 1 animal) 'CoreContext))
+      (is (v/ask? kb (list 'argGenl parent 2 animal) 'CoreContext)))
+    (testing "conditional constraints narrow the trigger and widen the target"
+      (is (v/ask? kb (list 'interArgIsa parent 1 mammal 2 food) 'CoreContext))
+      (is (v/ask? kb (list 'interArgIsa parent 1 animal 2 'thing) 'CoreContext))
+      (is (v/ask? kb (list 'interArgIsa parent 1 mammal 2 'thing) 'CoreContext))
+      (is (not (v/ask? kb (list 'interArgIsa parent 1 'thing 2 food) 'CoreContext))
+          "a constraint triggered by animal says nothing about non-animal things"))))


### PR DESCRIPTION
## Summary

- declare hierarchy preservation for `argIsa`, `argGenl`, and `interArgIsa`
- preserve conditional trigger constraints contravariantly and target constraints covariantly
- keep `arity` out of the preservation set because predicate specialization currently permits mixed signatures

## Context

Closes #20.

The issue's proposed `interArgIsa` trigger declaration needed one direction change. In `(interArgIsa P n T m U)`, `T` is the antecedent: a constraint triggered by `animal` entails one triggered by subtype `mammal`, not one triggered by supertype `thing`. Argument 3 therefore uses `argPreserving`; argument 5, the consequent type, uses `argPreservingInverse`.

`arity` is intentionally excluded. Vaelii currently allows a specialized predicate to have a different signature from its parent. Preserving parent arity downward could then make functional `arity` answer both the inherited and explicit value for the child. The regression test pins that boundary.

The first version of this PR also fixed an order-dependent orphan-NAT cleanup bug exposed by the new declarations. Vaelii 0.6.0 independently shipped the same eager-snapshot fix on `develop`; the rebase keeps upstream's implementation and removes the now-redundant `core.clj` delta from this PR.

## Scope

This adds ground positive-query entailment through the declared hierarchies. It does not make the WFF checker inherit a parent's constraints, enumerate open-query bindings, or materialize inferred declarations.

## Validation

- rebased onto `develop` at `1960af8` (`0.6.1-SNAPSHOT`)
- `lein test vaelii.core-context-test vaelii.nat-test vaelii.order-independence-test` — 50 tests, 352 assertions
- `lein lint` — 9/9 clean using CI-pinned `clj-kondo` 2026.08.04
- `git diff --check`
- independent review converged with no High/Medium/Low findings
