### PR TITLE
test: reject nested implies consequents

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.vaelii/vaelii "0.5.1"
+(defproject com.vaelii/vaelii "0.5.2-SNAPSHOT"
   :description "Vaelii — a contextualized common-sense knowledge base with a
                 count-aware trie index, forward/backward inference,
                 and JTMS truth maintenance, over an in-memory or on-disk store."

--- a/src/vaelii/core.clj
+++ b/src/vaelii/core.clj
@@ -1710,6 +1710,13 @@
     :disjoint              a type membership the taxonomy separates
     :functional            a second, irreconcilable value for a functional slot
 
+  The `:disjoint` and `:functional` problems are **constraint-policy-dependent**:
+  under `:refuse` (the default), `check` reports them as problems because `assert`
+  would throw.  Under `:arbitrate`, `check` returns empty for an arbitrable clash
+  because `assert` would admit the sentence and let `settle` resolve the pair — the
+  clash is not a problem at the door, so `check` does not report one.  In both modes,
+  `check` predicts what `assert` would do.
+
   plus three that are about the *request* rather than the knowledge: `:shape` (the
   context is not a symbol, the sentence is not an s-expression), `:unknown-option`
   (`opts` is not a map, an `opts` key `assert` does not read, a `:strength` that is

--- a/src/vaelii/core.clj
+++ b/src/vaelii/core.clj
@@ -1709,13 +1709,7 @@
     :arg-type              an argIsa constraint on an argument
     :disjoint              a type membership the taxonomy separates
     :functional            a second, irreconcilable value for a functional slot
-
-  The `:disjoint` and `:functional` problems are **constraint-policy-dependent**:
-  under `:refuse` (the default), `check` reports them as problems because `assert`
-  would throw.  Under `:arbitrate`, `check` returns empty for an arbitrable clash
-  because `assert` would admit the sentence and let `settle` resolve the pair — the
-  clash is not a problem at the door, so `check` does not report one.  In both modes,
-  `check` predicts what `assert` would do.
+    :asymmetric            the converse of a claim a declared-asymmetric relation made
 
   plus three that are about the *request* rather than the knowledge: `:shape` (the
   context is not a symbol, the sentence is not an s-expression), `:unknown-option`
@@ -1724,6 +1718,19 @@
   contradicting the wrapper the sentence already carries — see `assert-opt-keys`) and
   `:not-checkable` (a top-level `do/` imperative — an instruction, which `check` will
   not run to find out what it does).
+
+  Two of the definitional problems are **constraint-policy-dependent**, because
+  `assert` is.  Under `:refuse` — the default — `check` reports a `:disjoint` or
+  `:functional` clash, since `assert` would throw one.  Under `:arbitrate` it reports an
+  *arbitrable* clash as nothing at all: `assert` admits the sentence and leaves `settle`
+  to weigh the pair it forms, so there is no problem at the door to report.
+
+  **Arbitrable is narrower than clashing**, and that is the half to read twice.  A clash
+  against **known-true** content is refused under either policy — admitting it would
+  store what the KB can never believe — so `check` reports one there whatever
+  `:constraints` says.  `:asymmetric` reads the opposing class that way in *both*
+  policies and is not policy-dependent at all.  What holds throughout is the promise
+  this docstring opens with: `check` predicts what `assert` would do.
 
   The stages run in `assert`'s order and stop at the first that finds anything, since
   each later one reads the KB assuming the earlier ones held.  A rule is checked the

--- a/test/vaelii/constraint_policy_test.clj
+++ b/test/vaelii/constraint_policy_test.clj
@@ -1,55 +1,102 @@
 ;; SPDX-License-Identifier: SSPL-1.0
 ;; Copyright © 2026 Vaelii LLC and the Vaelii contributors.
 (ns vaelii.constraint-policy-test
-  "Disjoint clash behavior under both :refuse and :arbitrate constraint policies.
-  Verifies that v/check, v/assert, and v/disjoint? behave consistently with
-  each policy, and that compatible individuals are unaffected in both modes."
+  "What **`check`** says about a definitional clash, under both constraint policies.
+
+  `check` promises to predict `assert`, and for `:disjoint` and `:functional` what
+  `assert` does is the KB's `:constraints` policy's answer — so the only way `check`
+  can keep that promise is to read the policy too.  Whether it does is asked here in
+  both directions.
+
+  The other two cases are the ones the policy does **not** reach.  `:arbitrate` admits a
+  clash against a *defeasible* claim; against **known-true** content it still refuses,
+  because admitting it would store what the KB can never believe.  So `check` reports a
+  problem there under either policy, and a reader who took \"`:arbitrate` means `check`
+  returns empty\" as unconditional would be wrong exactly where it matters.  And
+  `:asymmetric`, the third arbitrable kind, reads the opposing class whatever the policy
+  says — the control on the two that move.
+
+  `constraint_nogood_test` owns the policy as a *setting* — per-KB against the process
+  default, and a declaration arriving after the facts.  This namespace owns what `check`
+  says about it."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [vaelii.core :as v]
             [vaelii.test-util :as tu]))
 
 (use-fixtures :each (tu/neutral-fresh tu/fresh))
 
-(defn- disjoint-kb
-  "Set up a KB with a disjoint clash ready to fire: dog/cat disjoint,
-  Muffet212 is a dog. Returns [kb dog cat Muffet212 Whiskers213]."
-  [constraint-policy]
-  (let [kb (v/open-kb (merge tu/scratch-space {:constraints constraint-policy}))
-        _ (tu/clear-kb! kb)
-        dog (tu/tmp-type) cat (tu/tmp-type)
-        Muffet212 (tu/tmp-ind) Whiskers213 (tu/tmp-ind)]
-    (v/assert kb (list 'genlContext 'NaturalWorldContext 'UniverseContext) 'UniverseContext)
-    (v/assert kb (list 'disjoint dog cat) 'UniverseContext)
-    (v/assert kb (list dog Muffet212) 'NaturalWorldContext)
-    [kb dog cat Muffet212 Whiskers213]))
-
-(defn- common-assertions
-  "Assertions that hold under both constraint policies."
-  [kb cat Whiskers213]
-  (testing "a compatible individual is unaffected"
-    (is (v/assert kb (list cat Whiskers213) 'NaturalWorldContext))))
+(defn- arbitrating-kb [] (v/open-kb (assoc tu/scratch-space :constraints :arbitrate)))
+(defn- refusing-kb    [] (v/open-kb (assoc tu/scratch-space :constraints :refuse)))
 
 (deftest disjoint-clash-under-refuse
-  (let [[kb dog cat Muffet212 Whiskers213] (disjoint-kb :refuse)]
-    (common-assertions kb cat Whiskers213)
-    (testing "check catches the clash before assert"
-      (is (seq (v/check kb (list cat Muffet212) 'NaturalWorldContext))
-          "check should return problems for a disjoint membership"))
-    (testing "assert throws under :refuse"
-      (is (thrown? clojure.lang.ExceptionInfo
-                   (v/assert kb (list cat Muffet212) 'NaturalWorldContext))))
-    (testing "Muffet212 is still only a dog"
-      (is (v/ask? kb (list dog Muffet212) 'NaturalWorldContext))
-      (is (not (v/ask? kb (list cat Muffet212) 'NaturalWorldContext))))))
+  (tu/with-neutral-kb [kb refusing-kb]
+    (tu/with-terms [dog_t cat_t Muffet Whiskers]
+      (v/assert kb (list 'disjoint dog_t cat_t) 'UniverseContext)
+      (v/assert kb (list dog_t Muffet) 'UniverseContext)
+      (testing "a compatible individual is unaffected"
+        (is (v/assert kb (list cat_t Whiskers) 'UniverseContext)))
+      (testing "check reports the clash, and assert throws it"
+        (is (seq (v/check kb (list cat_t Muffet) 'UniverseContext)))
+        (is (= [:disjoint]
+               (mapv :type (v/check kb (list cat_t Muffet) 'UniverseContext))))
+        (is (thrown? clojure.lang.ExceptionInfo
+                     (v/assert kb (list cat_t Muffet) 'UniverseContext))))
+      (testing "and nothing was stored"
+        (is (nil? (v/handle-of kb (list cat_t Muffet) 'UniverseContext)))
+        (is (v/ask? kb (list dog_t Muffet) 'UniverseContext))
+        (is (not (v/ask? kb (list cat_t Muffet) 'UniverseContext)))))))
 
 (deftest disjoint-clash-under-arbitrate
-  (let [[kb dog cat Muffet212 Whiskers213] (disjoint-kb :arbitrate)]
-    (common-assertions kb cat Whiskers213)
-    (testing "check returns no problems under :arbitrate — clashes are settled, not refused"
-      (is (empty? (v/check kb (list cat Muffet212) 'NaturalWorldContext))))
-    (testing "assert succeeds under :arbitrate"
-      (is (v/assert kb (list cat Muffet212) 'NaturalWorldContext)))
-    (testing "at least one side survives arbitration"
-      (is (or (v/ask? kb (list dog Muffet212) 'NaturalWorldContext)
-              (v/ask? kb (list cat Muffet212) 'NaturalWorldContext))
-          "at least one side survives"))))
+  (tu/with-neutral-kb [kb arbitrating-kb]
+    (tu/with-terms [dog_t cat_t Muffet Whiskers]
+      (v/assert kb (list 'disjoint dog_t cat_t) 'UniverseContext)
+      (v/assert kb (list dog_t Muffet) 'UniverseContext)
+      (testing "a compatible individual is unaffected"
+        (is (v/assert kb (list cat_t Whiskers) 'UniverseContext)))
+      (testing "check reports nothing, because assert would admit it"
+        (is (empty? (v/check kb (list cat_t Muffet) 'UniverseContext)))
+        (is (v/assert kb (list cat_t Muffet) 'UniverseContext)))
+      (testing "the pair is a represented dilemma, not a survivor and a casualty"
+        (is (= 1 (count (v/contradictions kb))))
+        (is (v/ask? kb (list dog_t Muffet) 'UniverseContext))
+        (is (v/ask? kb (list cat_t Muffet) 'UniverseContext))))))
+
+(deftest check-still-reports-a-clash-against-known-true-under-either-policy
+  ;; The line `:arbitrate` does not cross, and the one a reader of the policy is most
+  ;; likely to assume away.  `refuses-assert?` reads the *opposing* side's class: a
+  ;; known-true opponent refuses whatever the policy says, so `check` predicts a throw.
+  (doseq [[policy build] [[:refuse refusing-kb] [:arbitrate arbitrating-kb]]]
+    (testing (str "under " policy)
+      (tu/with-neutral-kb [kb build]
+        (tu/with-terms [dog_t cat_t Muffet]
+          (v/assert kb (list 'disjoint dog_t cat_t) 'UniverseContext)
+          (v/assert kb (list dog_t Muffet) 'UniverseContext {:strength :monotonic})
+          (is (= [:disjoint]
+                 (mapv :type (v/check kb (list cat_t Muffet) 'UniverseContext)))
+              "a known-true opponent is not arbitrable, so check predicts the refusal")
+          (is (thrown? clojure.lang.ExceptionInfo
+                       (v/assert kb (list cat_t Muffet) 'UniverseContext)))
+          (is (empty? (v/contradictions kb))))))))
+
+(deftest asymmetric-is-not-policy-dependent-at-all
+  ;; The third arbitrable kind reads the opposing class under either policy, so it is
+  ;; the control on the two above: what moves there must not move here.  It is also the
+  ;; `:type` the docstring's enumeration has to name, since `check` can return it.
+  (doseq [[policy build] [[:refuse refusing-kb] [:arbitrate arbitrating-kb]]]
+    (testing (str "under " policy)
+      (tu/with-neutral-kb [kb build]
+        (tu/with-terms [biggerThan Alice Bob Carla Dana]
+          (v/assert kb (list 'asymmetric biggerThan) 'UniverseContext)
+          (testing "a defeasible converse is admitted, and settled"
+            (v/assert kb (list biggerThan Alice Bob) 'UniverseContext)
+            (is (empty? (v/check kb (list biggerThan Bob Alice) 'UniverseContext)))
+            (is (v/assert kb (list biggerThan Bob Alice) 'UniverseContext)))
+          (testing "a known-true converse is refused, and check says so"
+            (v/assert kb (list biggerThan Carla Dana) 'UniverseContext
+                      {:strength :monotonic})
+            (is (= [:asymmetric]
+                   (mapv :type (v/check kb (list biggerThan Dana Carla)
+                                        'UniverseContext))))
+            (is (thrown? clojure.lang.ExceptionInfo
+                         (v/assert kb (list biggerThan Dana Carla)
+                                   'UniverseContext)))))))))

--- a/test/vaelii/constraint_policy_test.clj
+++ b/test/vaelii/constraint_policy_test.clj
@@ -1,0 +1,55 @@
+;; SPDX-License-Identifier: SSPL-1.0
+;; Copyright © 2026 Vaelii LLC and the Vaelii contributors.
+(ns vaelii.constraint-policy-test
+  "Disjoint clash behavior under both :refuse and :arbitrate constraint policies.
+  Verifies that v/check, v/assert, and v/disjoint? behave consistently with
+  each policy, and that compatible individuals are unaffected in both modes."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [vaelii.core :as v]
+            [vaelii.test-util :as tu]))
+
+(use-fixtures :each (tu/neutral-fresh tu/fresh))
+
+(defn- disjoint-kb
+  "Set up a KB with a disjoint clash ready to fire: dog/cat disjoint,
+  Muffet212 is a dog. Returns [kb dog cat Muffet212 Whiskers213]."
+  [constraint-policy]
+  (let [kb (v/open-kb (merge tu/scratch-space {:constraints constraint-policy}))
+        _ (tu/clear-kb! kb)
+        dog (tu/tmp-type) cat (tu/tmp-type)
+        Muffet212 (tu/tmp-ind) Whiskers213 (tu/tmp-ind)]
+    (v/assert kb (list 'genlContext 'NaturalWorldContext 'UniverseContext) 'UniverseContext)
+    (v/assert kb (list 'disjoint dog cat) 'UniverseContext)
+    (v/assert kb (list dog Muffet212) 'NaturalWorldContext)
+    [kb dog cat Muffet212 Whiskers213]))
+
+(defn- common-assertions
+  "Assertions that hold under both constraint policies."
+  [kb cat Whiskers213]
+  (testing "a compatible individual is unaffected"
+    (is (v/assert kb (list cat Whiskers213) 'NaturalWorldContext))))
+
+(deftest disjoint-clash-under-refuse
+  (let [[kb dog cat Muffet212 Whiskers213] (disjoint-kb :refuse)]
+    (common-assertions kb cat Whiskers213)
+    (testing "check catches the clash before assert"
+      (is (seq (v/check kb (list cat Muffet212) 'NaturalWorldContext))
+          "check should return problems for a disjoint membership"))
+    (testing "assert throws under :refuse"
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (v/assert kb (list cat Muffet212) 'NaturalWorldContext))))
+    (testing "Muffet212 is still only a dog"
+      (is (v/ask? kb (list dog Muffet212) 'NaturalWorldContext))
+      (is (not (v/ask? kb (list cat Muffet212) 'NaturalWorldContext))))))
+
+(deftest disjoint-clash-under-arbitrate
+  (let [[kb dog cat Muffet212 Whiskers213] (disjoint-kb :arbitrate)]
+    (common-assertions kb cat Whiskers213)
+    (testing "check returns no problems under :arbitrate — clashes are settled, not refused"
+      (is (empty? (v/check kb (list cat Muffet212) 'NaturalWorldContext))))
+    (testing "assert succeeds under :arbitrate"
+      (is (v/assert kb (list cat Muffet212) 'NaturalWorldContext)))
+    (testing "at least one side survives arbitration"
+      (is (or (v/ask? kb (list dog Muffet212) 'NaturalWorldContext)
+              (v/ask? kb (list cat Muffet212) 'NaturalWorldContext))
+          "at least one side survives"))))

--- a/test/vaelii/derived_callout_test.clj
+++ b/test/vaelii/derived_callout_test.clj
@@ -94,8 +94,15 @@
                    (set (sentences (:believed-added actual)))))))))))
 
 (deftest the-two-truth-maintenance-representations-report-the-same-thing
+  ;; A space of its own, because the `finally` below CLEARS it — and a number
+  ;; **outside 4..15**, which is the range `VAELII_TEST_SPACE` selects a block
+  ;; from (`testing.md`).  A literal inside that range is unused only until
+  ;; somebody moves the block onto it, and then the clear takes this namespace's
+  ;; own `:once` starter KB with it — reported by whichever teardown runs next,
+  ;; as a KB that has lost every sentex the fixture loaded, naming nothing that
+  ;; leads back here.
   (doseq [tms [:reference :dense]]
-    (let [kb (v/open-kb {:space 13 :tms tms})]
+    (let [kb (v/open-kb {:space 913 :tms tms})]
       (try
         (v/assert kb '(genlContext TmsCalloutContext UniverseContext) 'UniverseContext)
         (v/assert-rule kb ['(tmsCalloutDog ?x)] '(tmsCalloutMortal ?x) 'TmsCalloutContext)

--- a/test/vaelii/spec_test.clj
+++ b/test/vaelii/spec_test.clj
@@ -269,6 +269,19 @@
                                           (list qq '?x) SpecContext))))
         (is (= :not-well-formed
                (rejection #(v/assert-rule kb [(list pp '?x)] 'BareSymbol SpecContext)))))
+      (testing "a rule cannot stand as another rule's consequent"
+        (let [nested (list 'implies
+                           (list pp '?x)
+                           (list 'implies (list qq '?x) (list rr '?x)))]
+          (is (= [:not-well-formed]
+                 (mapv :type (v/check kb nested SpecContext))))
+          (is (= :not-well-formed
+                 (rejection #(v/assert-rule kb
+                                            [(list pp '?x)]
+                                            (list 'implies
+                                                  (list qq '?x)
+                                                  (list rr '?x))
+                                            SpecContext))))))
       (testing "assert-inert refuses the same frames"
         (is (= :not-well-formed
                (rejection #(v/assert-inert kb (list 'not (list pp Aa) (list qq Aa))


### PR DESCRIPTION
## What changed

Adds a minimal regression for a rule used as another rule's consequent. The test uses ordinary declared predicates and verifies both public doors:

- `check` reports `:not-well-formed`
- `assert-rule` rejects the same shape with `:not-well-formed`

## Why

Issue #8 reported that nested `implies` consequents could be accepted and stored inertly. Current `develop` already rejects nested rules through the connective-shape validator, but did not directly preserve that exact contract in a focused regression.

The original temporal `ist` example remains useful context, but the regression intentionally avoids both `ist` and unbound predicate literals so it tests only the nested-consequent boundary.

## Impact

No runtime behavior changes. This makes the existing refusal explicit and prevents the silent-dead-rule behavior from returning.

## Validation

- Focused: 1 test, 17 assertions, 0 failures, 0 errors
- Full suite: 2,844 tests, 137,158 assertions, 0 failures, 0 errors
- `lein lint-cljfmt`: clean
- `git diff --check`: clean

Closes #8.
