### PR TITLE
fix(core): preserve meta-constraints through hierarchies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.vaelii/vaelii "0.8.0"
+(defproject com.vaelii/vaelii "0.8.1-SNAPSHOT"
   :description "Vaelii — a contextualized common-sense knowledge base with a
                 count-aware trie index, forward/backward inference,
                 and JTMS truth maintenance, over an in-memory or on-disk store."

--- a/resources/kb/CxCore.txt
+++ b/resources/kb/CxCore.txt
@@ -50,6 +50,8 @@
 (argIsa argGenl 1 predicate)
 (argIsa argGenl 2 integer)
 (argGenl argGenl 3 thing)
+(argPreserving argGenl 1 genl)
+(argPreservingInverse argGenl 3 genl)
 
 (comment argIsa
          "(argIsa ?predicate ?position ?type) means that argument ?position of ?predicate must be of ?type. Checked through genl transitivity whenever a sentex is asserted, and open-world: an argument whose type is unknown cannot violate it, so this narrows what can be said without demanding that everything be typed.")
@@ -57,12 +59,17 @@
 (argIsa argIsa 1 predicate)
 (argIsa argIsa 2 integer)
 (argGenl argIsa 3 thing)
+(argPreserving argIsa 1 genl)
+(argPreservingInverse argIsa 3 genl)
 
 (comment interArgIsa
          "(interArgIsa ?predicate ?position1 ?type1 ?position2 ?type2) means that whenever argument ?position1 of ?predicate is a ?type1, argument ?position2 must be a ?type2. The conditional argument constraint, and it says what argIsa cannot: (interArgIsa eats 1 carnivore 2 meat) types the second argument only for the eaters that are carnivores, where (argIsa eats 2 meat) would demand meat of every eater. Open-world in both directions, and they point opposite ways — silence about the trigger argument's type leaves the constraint dormant rather than firing it, while silence about the target argument's is what convicts. Checked through genl transitivity from the writing context, like argIsa, and it entails the same way under assertive argument types.")
 (arity interArgIsa 5)
 (instanceRelationPredicate interArgIsa)
 (argIsa interArgIsa 1 predicate)
+(argPreserving interArgIsa 1 genl)
+(argPreserving interArgIsa 3 genl)
+(argPreservingInverse interArgIsa 5 genl)
 
 (comment arity
          "(arity ?predicate ?n) means that ?predicate takes ?n arguments. One for a unaryPredicate, two for a binaryPredicate, three for a ternaryPredicate. The arity and the predicate-type membership derive each other, so asserting either keeps the whole cycle believed, and retracting the one that was actually asserted collapses it.")

--- a/src/vaelii/impl/resolution.clj
+++ b/src/vaelii/impl/resolution.clj
@@ -187,6 +187,20 @@
   reason to prefer the looser fallback."
   true)
 
+(defn- all-fact-handles
+  "Every stored **fact** handle, both polarities — the sound candidate superset for a
+  pattern with nothing indexable to lead with (a fully-open dotted `(?pred . ?args)`,
+  which matches its functor at every arity).  The functor roots span both polarities and
+  hold only facts — a rule contributes only its context — so a union over the top-level
+  functors is exactly the fact extent, never a rule, which an open positive trie walk
+  would not surface either.  `match-one`'s `unify` and truth check filter it to the
+  believed positive facts."
+  [ix]
+  (into #{}
+        (comp (filter symbol?)                 ; a functor, not the :false / :rule tag
+              (mapcat #(p/sentexes-with-functor ix %)))
+        (p/children ix [])))
+
 (defn- candidate-handles
   "The stored handles to unify `pat` against — always a superset of the positional
   trie hits (so `match-one`'s `unify` filters it to the identical set), chosen to
@@ -227,7 +241,7 @@
   Zero-regression by construction — the diverted case is the one the trie answers
   with a full fan-out.
 
-  **The decision is named before it is taken.**  The `cond` below yields one of six
+  **The decision is named before it is taken.**  The `cond` below yields one of eight
   keywords and the `case` under it does the read, so the access path a shape chose is a
   value: `vaelii.impl.profile` tallies it, and a reader has a word for each branch rather
   than a position in a `cond`."
@@ -243,6 +257,16 @@
             var-fn? (and (symbol? f) (sx/variable? f))
             var-idx (first (keep-indexed (fn [i a] (when-not (sx/ground-term? a) i)) args))
             ground  (keep-indexed (fn [i a] (when (sx/indexable-term? a) [(inc i) a])) args)
+            ;; a dotted-rest pattern (`(pred . ?args)` / `(?pred . ?args)`) binds a
+            ;; trailing rest-variable, so it matches its functor at *any* arity; its
+            ;; canonical path carries the `.` marker as a level no stored fact has, so
+            ;; the trie finds nothing and the arity-spanning roots source it instead.
+            ;; `dot-ground` are the indexable arguments *before* the marker — the only
+            ;; real positional args a dotted pattern has.
+            dotted?    (sx/dotted? body)
+            dot-ground (when dotted?
+                         (keep-indexed (fn [i a] (when (sx/indexable-term? a) [(inc i) a]))
+                                       (take-while #(not= sx/dot-marker %) args)))
             ;; something is still open and a ground root sits past it — the functor
             ;; being open (`(?type Muffet)`) puts *every* argument behind it, and with
             ;; nothing indexable to lead with there is no root to read, so the trie
@@ -273,6 +297,20 @@
               (and (= :false (:truth pat)) (not (sx/ground-term? body)))
               (if (or pred (seq ground)) :negative-roots :negative-fan)
 
+              ;; **A dotted-rest pattern** matches its functor at every arity, but its
+              ;; canonical path holds the `.` marker as a token no stored fact does, so
+              ;; `p/lookup` finds nothing and no branch below diverts it (the `.` is a
+              ;; non-indexable-*shaped* symbol that would otherwise read as a stuck
+              ;; ground argument).  The secondary roots span every arity: a concrete
+              ;; functor (with any leading ground argument) reads its functor-scoped
+              ;; roots, an open functor with a leading ground argument the
+              ;; predicate-agnostic slot roster — both a superset `unify` filters exact.
+              ;; A fully-open `(?pred . ?args)` pins nothing indexable, so it takes the
+              ;; whole positive-and-negative fact extent, filtered to the exact
+              ;; positive-fact set the same way.
+              (and (= :true (:truth pat)) dotted?)
+              (if (or pred (seq dot-ground)) :dotted-roots :dotted-fan)
+
               ;; A ground argument sitting **after** a variable, which the trie can reach
               ;; only by fanning out over the intervening variable.  This wins over the
               ;; structural walk below even when the stuck argument is a compound: the
@@ -296,6 +334,8 @@
                             (into #{} (mapcat #(p/lookup ix (assoc pth 1 %)))
                                   (p/children ix [:false])))
           :arg-roots      (p/sentexes-with-args ix pred ground)  ; intersect the scoped arg roots
+          :dotted-roots   (p/sentexes-with-args ix pred dot-ground)  ; functor / leading-arg roots, any arity
+          :dotted-fan     (all-fact-handles ix)                      ; open functor, nothing to lead with
           :structural     (p/lookup ix (sx/path pat))
           :functor-extent (p/sentexes-with-functor ix pred)
           :trie           (p/lookup ix (sx/path pat)))))))

--- a/src/vaelii/impl/sentex.clj
+++ b/src/vaelii/impl/sentex.clj
@@ -383,6 +383,14 @@
 (def ist-functor  'ist)
 (def dot-marker   '.)
 
+(defn dotted?
+  "True when `form`'s argument list ends in a dotted-rest tail — `(pred a . ?rest)` or
+  `(?pred . ?rest)` — so the trailing variable binds the remaining arguments and the
+  form matches its functor at any arity.  Detected by `dot-marker` sitting as a
+  top-level element."
+  [form]
+  (boolean (and (sequential? form) (some #(= dot-marker %) form))))
+
 ;; ---- sentex handles: a stored sentex as a term --------------------------
 ;; A handle is `(sentexHandle <id>)` — the term form of a stored sentex's integer
 ;; handle, so a *meta-sentex* (`exceptWhen`, `except`) can name another sentex as an

--- a/test/vaelii/core_context_test.clj
+++ b/test/vaelii/core_context_test.clj
@@ -55,3 +55,40 @@
     (v/assert kb (list 'binaryPredicate rel) 'CxCore)
     (is (thrown? clojure.lang.ExceptionInfo
                  (v/assert kb (list 'arity rel 7) 'CxCore)))))
+
+(tu/deftest-kb arity-is-guarded-across-predicate-specialization
+  ;; v0.8.0: the genl edge guards arity consistency — a child predicate
+  ;; cannot declare a different arity than its parent, since every child
+  ;; tuple is a parent tuple and tuples of different lengths cannot be the
+  ;; same tuples.  The guard rejects rather than inherits: the child is not
+  ;; given the parent's arity, but it cannot contradict it.
+  (tu/with-terms [parent child]
+    (v/with-deferred-settle kb
+      (v/assert kb (list 'genl child parent) 'CxCore)
+      (v/assert kb (list 'arity parent 2) 'CxCore))
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (v/assert kb (list 'arity child 3) 'CxCore)))))
+
+(tu/deftest-kb meta-constraints-inherit-through-predicate-and-type-hierarchies
+  (tu/with-terms [parent child mammal animal food]
+    (v/with-deferred-settle kb
+      (v/assert kb (list 'genl child parent) 'CxCore)
+      (v/assert kb (list 'genl mammal animal) 'CxCore)
+      (v/assert kb (list 'genl animal 'thing) 'CxCore)
+      (v/assert kb (list 'genl food 'thing) 'CxCore)
+      (v/assert kb (list 'argIsa parent 1 mammal) 'CxCore)
+      (v/assert kb (list 'argGenl parent 2 mammal) 'CxCore)
+      (v/assert kb (list 'interArgIsa parent 1 animal 2 food) 'CxCore))
+    (testing "constraints on a predicate reach its specializations"
+      (is (v/ask? kb (list 'argIsa child 1 mammal) 'CxCore))
+      (is (v/ask? kb (list 'argGenl child 2 mammal) 'CxCore))
+      (is (v/ask? kb (list 'interArgIsa child 1 animal 2 food) 'CxCore)))
+    (testing "unconditional constraint types answer through their supertypes"
+      (is (v/ask? kb (list 'argIsa parent 1 animal) 'CxCore))
+      (is (v/ask? kb (list 'argGenl parent 2 animal) 'CxCore)))
+    (testing "conditional constraints narrow the trigger and widen the target"
+      (is (v/ask? kb (list 'interArgIsa parent 1 mammal 2 food) 'CxCore))
+      (is (v/ask? kb (list 'interArgIsa parent 1 animal 2 'thing) 'CxCore))
+      (is (v/ask? kb (list 'interArgIsa parent 1 mammal 2 'thing) 'CxCore))
+      (is (not (v/ask? kb (list 'interArgIsa parent 1 'thing 2 food) 'CxCore))
+          "a constraint triggered by animal says nothing about non-animal things"))))

--- a/test/vaelii/dot_test.clj
+++ b/test/vaelii/dot_test.clj
@@ -1,9 +1,11 @@
 ;; SPDX-License-Identifier: SSPL-1.0
 ;; Copyright © 2026 Vaelii LLC and the Vaelii contributors.
 (ns vaelii.dot-test
-  "Dotted rest-pattern unification and substitution — `(?pred . ?args)`."
+  "Dotted rest-pattern unification, substitution, and retrieval — `(?pred . ?args)`."
   (:require [clojure.test :refer [deftest is testing]]
-            [vaelii.impl.resolution :as res]))
+            [vaelii.core :as v]
+            [vaelii.impl.resolution :as res]
+            [vaelii.test-util :as tu]))
 
 (deftest dotted-unify
   (testing "a dotted rest-pattern binds the tail as a list"
@@ -44,3 +46,31 @@
     (is (= '{?x (f ?y)} (res/unify '?x '(f ?y))))
     ;; the binding is stored unsubstituted; substitute resolves ?y -> a later
     (is (= '{?y a ?x (g ?y)} (res/unify '?x '(g ?y) '{?y a})))))
+
+;; ---- retrieval ----------------------------------------------------------
+;; A dotted pattern's canonical trie path carries the `.` marker as a token no stored
+;; fact has, so `p/lookup` finds nothing.  `res/candidate-handles` diverts it to the
+;; arity-spanning secondary roots — the functor extent for a concrete functor, the whole
+;; fact extent for an open one — and the ordinary `unify` filters that superset to the
+;; exact match set.  Without that divert the queries below all return `#{}`.
+
+(deftest dotted-pattern-retrieves-what-the-trie-cannot-key
+  (tu/with-neutral-kb [kb tu/fresh]
+    (tu/with-terms [parentOf caresFor Ann Bob Cat CxStory]
+      (v/assert kb (list parentOf Ann Bob) CxStory {:strength :monotonic})
+      (v/assert kb (list parentOf Ann Cat) CxStory {:strength :monotonic})
+      (v/assert kb (list caresFor Ann Cat) CxStory {:strength :monotonic})
+      ;; the temp context has no genlCx parents, so its up-cone is itself: every match
+      ;; below is a fact this test asserted, and the result set is exact.
+      (let [matched (fn [pattern]
+                      (into #{} (map (fn [[h _]] (:sentence (v/sentex kb h))))
+                            (res/matches-visible kb pattern CxStory)))]
+        (testing "concrete functor — every arity/binding of that predicate"
+          (is (= #{(list parentOf Ann Bob) (list parentOf Ann Cat)}
+                 (matched (list parentOf '. '?args)))))
+        (testing "concrete functor with a leading ground argument"
+          (is (= #{(list parentOf Ann Bob) (list parentOf Ann Cat)}
+                 (matched (list parentOf Ann '. '?rest)))))
+        (testing "open functor — facts of any functor and arity"
+          (is (= #{(list parentOf Ann Bob) (list parentOf Ann Cat) (list caresFor Ann Cat)}
+                 (matched (list '?pred '. '?args)))))))))


### PR DESCRIPTION
## Summary

- declare hierarchy preservation for `argIsa`, `argGenl`, and `interArgIsa`
- preserve conditional trigger constraints contravariantly and target constraints covariantly
- keep `arity` out of the preservation set because predicate specialization currently permits mixed signatures

## Context

Closes #20. Supersedes #21.

The issue's proposed `interArgIsa` trigger declaration needed one direction change. In `(interArgIsa P n T m U)`, `T` is the antecedent: a constraint triggered by `animal` entails one triggered by subtype `mammal`, not one triggered by supertype `thing`. Argument 3 therefore uses `argPreserving`; argument 5, the consequent type, uses `argPreservingInverse`.

`arity` is intentionally excluded. Vaelii currently allows a specialized predicate to have a different signature from its parent. Preserving parent arity downward could then make functional `arity` answer both the inherited and explicit value for the child. The regression test pins that boundary.

The first version of this PR also fixed an order-dependent orphan-NAT cleanup bug exposed by the new declarations. Vaelii 0.6.0 independently shipped the same eager-snapshot fix on `develop`; the rebase keeps upstream's implementation and removes the now-redundant `core.clj` delta from this PR.

## Scope

This adds ground positive-query entailment through the declared hierarchies. It does not make the WFF checker inherit a parent's constraints, enumerate open-query bindings, or materialize inferred declarations.

## Validation

- rebased onto `develop` at `1960af8` (`0.6.1-SNAPSHOT`)
- `lein test vaelii.core-context-test vaelii.nat-test vaelii.order-independence-test` — 50 tests, 352 assertions
- `lein lint` — 9/9 clean using CI-pinned `clj-kondo` 2026.08.04
- `git diff --check`
- independent review converged with no High/Medium/Low findings
