### PR TITLE
fix: retrieve dotted-rest fact candidates

### DIFF
--- a/docs/profile.md
+++ b/docs/profile.md
@@ -92,7 +92,7 @@ second by construction and is read as a bound, not added to anything.
 ## The access paths, named
 
 Two matchers decide where candidates come from, and each names its decision so the tally
-can count it. `res/candidate-handles` yields one of six:
+can count it. `res/candidate-handles` yields one of seven:
 
 | path | taken when |
 |---|---|
@@ -102,6 +102,7 @@ can count it. `res/candidate-handles` yields one of six:
 | `:functor-extent` | the same shape with `res/*structural-index*` false — the correct looser superset |
 | `:negative-roots` | an open negative with a functor or a ground argument pinned |
 | `:negative-fan` | an open negative with nothing pinned — the `:false` node's own children |
+| `:dotted-extent` | a variable-arity dotted-rest pattern — one concrete functor extent, or the matching-polarity functor roster when open |
 
 `res/matches-hierarchical`, the set-algebra matcher behind the context-scoped levels,
 makes its own choice and never consults `candidate-handles`:

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.vaelii/vaelii "0.6.0"
+(defproject com.vaelii/vaelii "0.6.1-SNAPSHOT"
   :description "Vaelii — a contextualized common-sense knowledge base with a
                 count-aware trie index, forward/backward inference,
                 and JTMS truth maintenance, over an in-memory or on-disk store."

--- a/src/vaelii/impl/resolution.clj
+++ b/src/vaelii/impl/resolution.clj
@@ -136,6 +136,33 @@
 
 (defn- unary? [s] (and (sequential? s) (= 2 (count s))))
 
+(defn- dotted-pattern?
+  "Does `form` contain a dotted-rest splice at any nesting depth?"
+  [form]
+  (boolean (and (sequential? form)
+                (some #(= sx/dot-marker %) (tree-seq sequential? seq form)))))
+
+(defn- dotted-candidates
+  "Every fact handle a dotted-rest pattern could unify with.
+
+  A dot changes the pattern's arity, so neither the positional trie nor the argument
+  roots can represent it: `.` is a splice marker, not an argument token.  A concrete
+  functor is bounded by its fact extent.  With an open functor, enumerate the functors
+  present at the matching polarity from the trie's own root roster, then union their
+  extents.  `match-one` still filters polarity and unifies every candidate, so this is a
+  sound superset rather than a second matcher."
+  [ix truth pred]
+  (if pred
+    (p/sentexes-with-functor ix pred)
+    (let [functors (if (= :false truth)
+                     (into #{}
+                           (keep (fn [body]
+                                   (when (and (sequential? body) (symbol? (first body)))
+                                     (first body))))
+                           (p/children ix [:false]))
+                     (filter symbol? (p/children ix [])))]
+      (lazy-mapcat #(p/sentexes-with-functor ix %) functors))))
+
 (def ^:dynamic *arg-root-retrieval*
   "Whether `match-one` may retrieve its candidate handles from a **secondary argument
   root** instead of always walking the trie.
@@ -220,6 +247,11 @@
   narrows on it (`*structural-index*`); off, it falls back to the functor extent — a
   correct superset, and the baseline to measure the structural narrowing against.
 
+  A **dotted-rest pattern** cannot use either positional model: its `.` is a splice
+  marker rather than a stored argument, and the tail has no fixed arity.  It reads the
+  concrete functor's whole extent, or fans over the functor roster when the functor is
+  open, then lets `unify` bind and filter the tail.
+
   Everything else keeps the trie: a fully-ground test (its leaf is exact), a pattern
   whose ground arguments are already a left prefix, and a pattern whose only
   after-a-variable selectivity is a **non-indexable** token (a number/string the
@@ -227,7 +259,7 @@
   Zero-regression by construction — the diverted case is the one the trie answers
   with a full fan-out.
 
-  **The decision is named before it is taken.**  The `cond` below yields one of six
+  **The decision is named before it is taken.**  The `cond` below yields one of seven
   keywords and the `case` under it does the read, so the access path a shape chose is a
   value: `vaelii.impl.profile` tallies it, and a reader has a word for each branch rather
   than a position in a `cond`."
@@ -241,6 +273,7 @@
             args    (vec (rest body))
             pred    (when (and (symbol? f) (not (sx/variable? f))) f)
             var-fn? (and (symbol? f) (sx/variable? f))
+            dotted? (dotted-pattern? body)
             var-idx (first (keep-indexed (fn [i a] (when-not (sx/ground-term? a) i)) args))
             ground  (keep-indexed (fn [i a] (when (sx/indexable-term? a) [(inc i) a])) args)
             ;; something is still open and a ground root sits past it — the functor
@@ -253,6 +286,11 @@
                                   (some (fn [[pos _]] (> (dec pos) var-idx)) ground))))
             path
             (cond
+              ;; A dotted tail changes arity.  Looking up `.` as a trie or argument-root
+              ;; token quietly returns no candidates because stored facts contain only
+              ;; the arguments it stands for.
+              dotted? :dotted-extent
+
               ;; **A negative key holds its whole body as one token**, so the trie can match
               ;; a negative only *exactly* — `[:false (dog ?0) c]` is a different key from
               ;; `[:false (dog Tom) c]`, and no amount of the body being ground narrows it,
@@ -291,6 +329,7 @@
               :else :trie)]
         (prof/record-goal pat path)
         (case path
+          :dotted-extent (dotted-candidates ix (:truth pat) pred)
           :negative-roots (p/sentexes-with-args ix pred ground)
           :negative-fan   (let [pth (sx/path pat)]
                             (into #{} (mapcat #(p/lookup ix (assoc pth 1 %)))

--- a/test/vaelii/laziness_test.clj
+++ b/test/vaelii/laziness_test.clj
@@ -26,6 +26,7 @@
             [vaelii.core :as v]
             [vaelii.impl.jtms :as jtms]
             [vaelii.impl.levels :as levels]
+            [vaelii.impl.profile :as prof]
             [vaelii.impl.provers :as provers]
             [vaelii.impl.resolution :as res]
             [vaelii.test-util :as tu]))
@@ -173,6 +174,31 @@
             (is (<= one 2)
                 (str "the set-algebra path realized " one " of " all
                      " posting entries for one result"))))))))
+
+;; ---- level 2: open dotted-functor extent fan-out ------------------------
+;;
+;; A dotted pattern cannot use a fixed-arity trie path, so an open functor walks the
+;; root functor roster and reads each whole extent.  The roster can be chunked; core
+;; `mapcat` would therefore open thirty-two extents before yielding the first match.
+
+(tu/deftest-kb one-dotted-result-opens-one-functor-extent
+  (let [preds (vec (repeatedly 40 #(tu/tmp-pred "variadic")))
+        goal  (list '?pred '. '?args)]
+    (doseq [pred preds]
+      (v/assert kb (list pred (tu/tmp-ind "Arg")) 'UniverseContext {:chain? false}))
+    (let [reads (fn [consume]
+                  (prof/start)
+                  (try
+                    (consume (res/raw-match kb goal 'UniverseContext))
+                    (get-in (prof/snapshot) [:reads :functor-root] 0)
+                    (finally (prof/stop))))
+          one   (reads first)
+          all   (reads dorun)]
+      (testing "the open dotted query really fans across a chunk-sized roster"
+        (is (>= all 40)))
+      (testing "taking one result opens one extent, not one source chunk"
+        (is (= 1 one)
+            (str "opened " one " extents before yielding the first dotted match"))))))
 
 ;; ---- level 2: the symmetric mirror --------------------------------------
 ;;

--- a/test/vaelii/profile_test.clj
+++ b/test/vaelii/profile_test.clj
@@ -125,6 +125,12 @@
         (let [snap (collected #(doall (res/raw-match kb (list 'not (list '?p '?x '?y)) ctx)))]
           (is (contains? (paths-of snap :open) :negative-fan))))
 
+      (testing "a dotted rest reads whole functor extents instead of positional indexes"
+        (let [snap (collected #(doall (res/raw-match kb (list p a '. '?args) ctx)))]
+          (is (contains? (paths-of snap p) :dotted-extent)))
+        (let [snap (collected #(doall (res/raw-match kb (list '?pred '. '?args) ctx)))]
+          (is (contains? (paths-of snap :open) :dotted-extent))))
+
       (testing "the argument-root retrieval switch moves the label with the behaviour"
         (let [snap (collected #(binding [res/*arg-root-retrieval* false]
                                  (doall (res/raw-match kb (list p '?x b) ctx))))]

--- a/test/vaelii/retrieval_completeness_test.clj
+++ b/test/vaelii/retrieval_completeness_test.clj
@@ -79,13 +79,19 @@
                   ;; open functor
                   (list '?p Muffet) (list '?p '?x)
                   (list '?p Ann '?y) (list '?p '?x Cid)
+                  ;; dotted rest — concrete/open functors and a fixed prefix
+                  (list dog '. '?args)
+                  (list parentOf Ann '. '?args)
+                  (list '?p '. '?args)
                   ;; negative literals — the shape both relative oracles were blind to
                   (list 'not (list dog Tom))
                   (list 'not (list dog '?x))          ; nothing ground but the functor
                   (list 'not (list parentOf '?x Ann)) ; ground arg AFTER a variable
                   (list 'not (list parentOf Cid '?y)) ; ground arg in a LEFT PREFIX
                   (list 'not (list '?p '?x))          ; nothing pinned at all
-                  (list 'not (list '?p Tom))]]
+                  (list 'not (list '?p Tom))
+                  (list 'not (list dog '. '?args))
+                  (list 'not (list '?p '. '?args))]]
       (v/assert-many kb facts ProbeContext {:strength :monotonic})
       (doseq [[label bindings]
               [["default" {}]
@@ -106,4 +112,8 @@
         (is (= 2 (count (got kb (list 'not (list '?p '?x)) ProbeContext)))))
       (testing "and the public query answers them too"
         (is (= 2 (count (v/sentexes-matching kb (list 'not (list dog '?x)) ProbeContext))))
-        (is (= 1 (count (v/sentexes-matching kb (list 'not (list parentOf Cid '?y)) ProbeContext))))))))
+        (is (= 1 (count (v/sentexes-matching kb (list 'not (list parentOf Cid '?y)) ProbeContext))))
+        (is (= 11 (count (v/sentexes-matching kb (list '?p '. '?args) ProbeContext))))
+        (is (= 3 (count (v/sentexes-matching kb
+                                             (list 'not (list '?p '. '?args))
+                                             ProbeContext))))))))

--- a/test/vaelii/turn_edge_test.clj
+++ b/test/vaelii/turn_edge_test.clj
@@ -91,6 +91,43 @@
       (testing "an unrelated pair is not derived"
         (is (empty? (v/sentexes-matching kb (list kin bob tom) 'UniverseContext)))))))
 
+(deftest dotted-rest-enumerates-and-joins-in-either-arrival-order
+  ;; A dotted antecedent is sometimes the arriving trigger and sometimes a stored fact
+  ;; the other antecedent has to retrieve.  Both paths must bind the same tail; otherwise
+  ;; this rule's result depends on which premise happened to arrive last.
+  (tu/with-neutral-kb [kb tu/fresh]
+    (tu/with-terms [agent_type agentCapable typeCapable
+                    AgentA AgentB CapA CapB ToolA ToolB]
+      (v/assert kb
+                (list 'set/forwardRule
+                      (list 'implies
+                            (list 'and
+                                  (list agent_type '?instance)
+                                  (list agentCapable '?instance '. '?args))
+                            (list typeCapable agent_type '. '?args)))
+                'UniverseContext)
+
+      ;; Dotted premise is the trigger.
+      (v/assert kb (list agent_type AgentA) 'UniverseContext)
+      (v/assert kb (list agentCapable AgentA CapA ToolA) 'UniverseContext)
+
+      ;; Dotted premise must be found by the join after the type premise triggers.
+      (v/assert kb (list agentCapable AgentB CapB ToolB) 'UniverseContext)
+      (v/assert kb (list agent_type AgentB) 'UniverseContext)
+
+      (testing "both premise arrival orders derive the same variadic bridge"
+        (is (v/ask? kb (list typeCapable agent_type CapA ToolA) 'UniverseContext))
+        (is (v/ask? kb (list typeCapable agent_type CapB ToolB) 'UniverseContext)))
+      (testing "a dotted pattern directly enumerates and binds a stored tail"
+        (is (= [(list agentCapable AgentB CapB ToolB)]
+               (mapv :sentence
+                     (v/sentexes-matching kb
+                                          (list agentCapable AgentB '. '?args)
+                                          'UniverseContext))))
+        (is (= #{{'?args (list CapB ToolB)}}
+               (set (v/ask kb (list agentCapable AgentB '. '?args)
+                           'UniverseContext))))))))
+
 ;; ---- forced decontextualized predicate (genlContext) -------------------------
 
 (deftest a-forced-genlcontext-from-a-plain-context-lands-in-the-universe


### PR DESCRIPTION
## Context

Vaelii's dotted-rest syntax already unifies and substitutes variable-length argument tails, but stored-fact retrieval did not enumerate dotted patterns. This made a multi-antecedent forward rule depend on premise arrival order: the rule fired when its dotted literal was the incoming trigger, but not when the join had to retrieve that literal from the KB. Direct dotted `ask` and `sentexes-matching` queries likewise returned no candidates.

This was exposed while testing a variadic capability bridge. Open variable-functor rules remain a separate, intentional `:not-indexable` boundary; this PR does not change that policy.

## Change

- Add a `:dotted-extent` candidate path before positional trie/root routing.
- For a concrete functor, read its extent; for an open functor, lazily fan over the matching-polarity functor roster.
- Keep the existing polarity, context, and unification path as the exact correctness filter.
- Record and document the new profiler access path.

## Coverage

- Both premise arrival orders for a concrete two-antecedent variadic forward rule.
- Direct dotted `ask` and `sentexes-matching` enumeration and tail bindings.
- Positive, negative, concrete-functor, open-functor, and fixed-prefix retrieval against a brute-store oracle.
- Short-circuit laziness: first result opens one functor extent; a mutation back to core `mapcat` opens 32 and fails the regression.
- Profiler path reporting.

## Verification

- Full suite: **2,981 tests / 138,057 assertions**, 0 failures, 0 errors.
- Focused regression suites: **43 tests / 411 assertions**, green.
- Argument-root oracle: **7 tests / 5,840 assertions**, green.
- Hierarchical + structural retrieval: **18 tests / 9,685 assertions**, green.
- All eight backend parity configurations: **215 assertions**, green.
- `cljfmt`, docs links, reflection-warning compile, and `git diff --check`: green.
- Independent exact-head review: clean after one laziness finding was fixed and regression-tested.

No merge performed.
