### PR TITLE
fix: retrieve dotted-rest fact candidates

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,7 @@ page costs a sentence rather than a section.
 
 ## Start here
 
+- [cyc-rosetta-stone.md](cyc-rosetta-stone.md) — the vocabulary mapping from OpenCyc/ResearchCyc to Vaelii: where the names match, where the semantics diverge, and what Cyc has that Vaelii does not (and vice versa).
 - [kbs.md](kbs.md) — the four knowledge bases you can load and the route to each: what ships here, what the plugin ships, what you supply, and where a KB has to sit to be found.
 - [api.md](api.md) — the public API: every fn on `vaelii.core`, with what it takes and returns, and the five thin entry-point namespaces beside it.
 - [troubleshooting.md](troubleshooting.md) — indexed by symptom rather than subsystem: an empty query, a rule that will not fire, a refused `assert`, a KB holding facts nobody asserted.

--- a/docs/cyc-rosetta-stone.md
+++ b/docs/cyc-rosetta-stone.md
@@ -1,0 +1,175 @@
+# Cyc ↔ Vaelii Rosetta Stone
+
+- **Covers:** vocabulary mapping from OpenCyc/ResearchCyc to Vaelii — core concepts, operations, negation, rules, TMS, privileged contexts.
+- **Not here:** this is one-way orientation, not a compatibility claim. The two systems share vocabulary but differ in semantics; the page names the differences.
+- **Assumes:** reader knows Cyc's API or has `CoreContext.txt` open. Vaelii API is documented in [api.md](api.md).
+
+## Core Concepts
+
+```
+Cyc                → Vaelii
+Mt                 → context
+genlMt             → genlContext
+assertion          → sentex
+constant           → symbol (CapitalCamelCase individuals, snake_case types, camelCase preds)
+collection         → type as unary predicate: (dog Muffet) not (isa Muffet Dog)
+genls              → genl
+genlPreds          → genl
+don't-care var (??)→ head existential: (exists ?y ...) — syntactic, not naming convention
+rename             → no equivalent (use sameAs/rewriteOf for merging, but no true rename)
+arg1Isa            → no equivalent. Instead of (arg1Isa PRED TYPE), use (argIsa PRED 1 TYPE)
+wff?               → v/check. Checks argIsa, disjoint, functional, naming conventions, etc.
+```
+
+## Gotchas for Cyclists
+
+**argIsa is entailment, not restriction:** In Cyc, argIsa constraints are gates
+at assert time. In vaelii, they are entailment sources — `(argIsa parentOf 1 animal)`
+over `(parentOf Fred Mary)` ENTAILS `(animal Fred)`, it doesn't reject the assertion.
+A caller wanting Cyc's restriction semantics wraps `check` before `assert` themselves.
+
+**Open-world silent acceptance:** Vaelii silently accepts any assertion with any
+predicate — `(fghgwgads 212)` stores without error. No predicate declaration check,
+no type check at assert time. Typos are the same bug class as undeclared predicates.
+
+## Negation & Mutual Exclusion
+
+```
+Cyc                       → Vaelii
+negationPreds (unary)     → (disjoint P Q) — native, since collections ARE preds in V
+negationPreds (binary)    → paired implication rules:
+                            (implies (P ?x ?y) (not (Q ?x ?y)))
+                            (implies (Q ?x ?y) (not (P ?x ?y)))
+                            Note: Vaelii permits contradictory sentexes to coexist until
+                            JTMS/belief repair, unlike insertion-time integrity
+no equivalent             → (contradictions kb)
+SymmetricBinaryPredicate  → (symmetric P)
+AsymmetricBinaryPredicate → (asymmetric P)
+genlInverse               → no native equivalent. use a forward rule:
+                            (implies (P ?x ?y) (Q ?y ?x))
+                            vaelii's (inverse P Q) is the stronger biconditional
+disjoint                  → disjoint — type/predicate mutual exclusion,
+                            closed under genl. Works for unary preds because
+                            collections ARE predicates in V
+unk                       → unknown
+assertedMoreSpecifically  → no equivalent
+completeExtentEnumerable  → no equivalent
+```
+
+## WFF Modes (Cyc → Vaelii mapping)
+
+Cyc had three Well-Formed Formula checking modes.
+
+```
+Mode       Cyc behavior                     
+strict     constraints must be provable     
+lenient    constraints must not be disjoint
+assertive  constraints must not be disjoint, eagerly conclude tighter isas
+```
+
+Vaelii WFF is assertive.
+
+## Privileged Contexts
+
+```
+Cyc                          → Vaelii              Notes
+LogicalTruthMt               → (no analogue)       logical truths baked into engine
+
+CoreCycLMt                   → CoreContext         spindle head: code-interpreted
+                                                   vocabulary
+
+UniversalVocabularyMt/BaseKB → UniverseContext     mid anchor, decontextualization
+                                                   target
+
+CurrentWorldDataCollectorMt  → WellContext         "all the usual stuff" — sees
+                                                   the full shipped ontology
+
+InferencePSC/EverythingPSC   → ?ctx                not a context — omit the context
+                                                   arg or pass a variable to query
+                                                   unscoped
+```
+
+## Operations
+
+```
+Cyc                 → Vaelii API call
+assert              → (v/assert kb sentence context opts) → handle
+unassert            → (v/retract! kb handle) → {:removed-sentexes n :removed-justifications n}
+find-assertion-cycl → (v/sentexes-matching kb sentence context) — literal only, returns collection
+                      A caller wanting the singular (nil if ambiguous) wraps first-if-singleton.
+ask (backward)      → (v/query kb goal ctx {:max-depth n}) — bounded backward chaining
+ask (unbounded)     → (v/prove kb goal ctx) — DFS backward chaining
+ask (boolean)       → (v/provable? kb goal ctx)
+ask (no inference)  → (v/ask kb goal ctx) / (v/ask? kb goal ctx) — no rule expansion
+fi-ask              → (v/query kb goal ctx {:max-depth n}) — vars bind in goal
+wff?                → (v/check kb sentence context opts) → vector of problem maps
+rename              → no equivalent
+```
+
+## Truth Maintenance (actual API calls)
+
+```
+Cyc                → Vaelii API call
+TMS assert         → (v/assert kb sentence context {:strength :monotonic|:default})
+                     :monotonic = known-true, not defeasible
+                     :default = defeasible at edges (most common-sense content)
+TMS retract        → (v/retract! kb handle) — cascading teardown of solely-supported conclusions
+why (support tree) → (v/why kb handle opts?) — proof tree: support → rule + antecedents
+why-not            → (v/why-not kb handle) — :defeated / :superseded / :unsupported / :not-stored
+                     (v/why-not kb sentence context) — adds :excepted (exceptWhen blocks it)
+no equivalent      → (v/in? kb handle) — is this handle IN (believed)?
+                     (v/believed kb handles) — batch: set of handles that are IN
+no equivalent      → (v/settle-stats kb) — fixpoint iteration instrumentation
+no equivalent      → (v/with-deferred-settle kb & body) — batch, settle once at end
+```
+
+## Rules (actual API calls)
+
+```
+Cyc                 → Vaelii API call
+assert rule         → (v/assert-rule kb [antecedents] consequent context opts)
+                      opts: {:direction :forward|:backward|:both|:inert
+                             :strength :monotonic|:default
+                             :chain? bool :max-depth n}
+forwardRule         → {:direction :forward} or (set/forwardRule ...) wrapper
+backwardRule        → {:direction :backward} or (set/backwardRule ...) wrapper
+both (default)      → {:direction :both}
+:code direction     → {:direction :inert} or (set/inertRule ...) wrapper
+rule vars           → ?x (same convention, but lowercase)
+range-restricted    → yes — every consequent var must appear in antecedent
+unbound-pred rule literals → REJECTED (:not-indexable) — must instantiate per predicate
+nested implies      → ACCEPTED but INERT — stored as dead sentex, not indexed
+                     as live rule (filed as vaelii/vaelii#8)
+arity check         → catches too-few args but NOT too-many (vaelii/vaelii#9)
+```
+
+## Shared (both Cyc and Vaelii have)
+
+- Anytime inference (budgeted): `ask-within`, `prove-within`, `resume`
+- Watch (reactive queries): `(v/watch kb goal context f)` — callback when belief moves
+- Abduce: `(v/abduce kb goal context opts)` — hypotheses as :default premises in scratch context
+- argIsa / interArgIsa
+- Equality partition (rewriteOf / sameAs / equals)
+- Defeasible defaults with exceptions
+- Polycanonicalization
+
+## Vaelii has, Cyc doesn't
+
+- `fork` (overlay KBs — private writable copy over frozen base)
+- ASP solver backend (`set-solver kb :asp`)
+- Qualitative constraint reasoning (Allen intervals, RCC8, etc.)
+- Export/import dump format
+- Web browser for ontology exploration
+- Rule generators (a rule whose consequent is a rule — 0.6.0)
+
+## Cyc has, Vaelii doesn't
+
+- Rename (no equivalent in Vaelii)
+- NL generation
+- transitiveViaArg
+- negationPreds for binary+ preds (use paired (not S) rules instead)
+- completeExtentEnumerable
+- notAssertible
+- arg1Isa / arg2Isa syntactic sugar
+- Strict WFF mode
+- irreflexive / antiTransitive / antiSymmetric (filed as vaelii/vaelii#14)

--- a/docs/profile.md
+++ b/docs/profile.md
@@ -92,7 +92,7 @@ second by construction and is read as a bound, not added to anything.
 ## The access paths, named
 
 Two matchers decide where candidates come from, and each names its decision so the tally
-can count it. `res/candidate-handles` yields one of six:
+can count it. `res/candidate-handles` yields one of seven:
 
 | path | taken when |
 |---|---|
@@ -102,6 +102,7 @@ can count it. `res/candidate-handles` yields one of six:
 | `:functor-extent` | the same shape with `res/*structural-index*` false — the correct looser superset |
 | `:negative-roots` | an open negative with a functor or a ground argument pinned |
 | `:negative-fan` | an open negative with nothing pinned — the `:false` node's own children |
+| `:dotted-extent` | a variable-arity dotted-rest pattern — one concrete functor extent, or the matching-polarity functor roster when open |
 
 `res/matches-hierarchical`, the set-algebra matcher behind the context-scoped levels,
 makes its own choice and never consults `candidate-handles`:

--- a/src/vaelii/impl/resolution.clj
+++ b/src/vaelii/impl/resolution.clj
@@ -136,6 +136,33 @@
 
 (defn- unary? [s] (and (sequential? s) (= 2 (count s))))
 
+(defn- dotted-pattern?
+  "Does `form` contain a dotted-rest splice at any nesting depth?"
+  [form]
+  (boolean (and (sequential? form)
+                (some #(= sx/dot-marker %) (tree-seq sequential? seq form)))))
+
+(defn- dotted-candidates
+  "Every fact handle a dotted-rest pattern could unify with.
+
+  A dot changes the pattern's arity, so neither the positional trie nor the argument
+  roots can represent it: `.` is a splice marker, not an argument token.  A concrete
+  functor is bounded by its fact extent.  With an open functor, enumerate the functors
+  present at the matching polarity from the trie's own root roster, then union their
+  extents.  `match-one` still filters polarity and unifies every candidate, so this is a
+  sound superset rather than a second matcher."
+  [ix truth pred]
+  (if pred
+    (p/sentexes-with-functor ix pred)
+    (let [functors (if (= :false truth)
+                     (into #{}
+                           (keep (fn [body]
+                                   (when (and (sequential? body) (symbol? (first body)))
+                                     (first body))))
+                           (p/children ix [:false]))
+                     (filter symbol? (p/children ix [])))]
+      (lazy-mapcat #(p/sentexes-with-functor ix %) functors))))
+
 (def ^:dynamic *arg-root-retrieval*
   "Whether `match-one` may retrieve its candidate handles from a **secondary argument
   root** instead of always walking the trie.
@@ -220,6 +247,11 @@
   narrows on it (`*structural-index*`); off, it falls back to the functor extent — a
   correct superset, and the baseline to measure the structural narrowing against.
 
+  A **dotted-rest pattern** cannot use either positional model: its `.` is a splice
+  marker rather than a stored argument, and the tail has no fixed arity.  It reads the
+  concrete functor's whole extent, or fans over the functor roster when the functor is
+  open, then lets `unify` bind and filter the tail.
+
   Everything else keeps the trie: a fully-ground test (its leaf is exact), a pattern
   whose ground arguments are already a left prefix, and a pattern whose only
   after-a-variable selectivity is a **non-indexable** token (a number/string the
@@ -227,7 +259,7 @@
   Zero-regression by construction — the diverted case is the one the trie answers
   with a full fan-out.
 
-  **The decision is named before it is taken.**  The `cond` below yields one of six
+  **The decision is named before it is taken.**  The `cond` below yields one of seven
   keywords and the `case` under it does the read, so the access path a shape chose is a
   value: `vaelii.impl.profile` tallies it, and a reader has a word for each branch rather
   than a position in a `cond`."
@@ -241,6 +273,7 @@
             args    (vec (rest body))
             pred    (when (and (symbol? f) (not (sx/variable? f))) f)
             var-fn? (and (symbol? f) (sx/variable? f))
+            dotted? (dotted-pattern? body)
             var-idx (first (keep-indexed (fn [i a] (when-not (sx/ground-term? a) i)) args))
             ground  (keep-indexed (fn [i a] (when (sx/indexable-term? a) [(inc i) a])) args)
             ;; something is still open and a ground root sits past it — the functor
@@ -253,6 +286,11 @@
                                   (some (fn [[pos _]] (> (dec pos) var-idx)) ground))))
             path
             (cond
+              ;; A dotted tail changes arity.  Looking up `.` as a trie or argument-root
+              ;; token quietly returns no candidates because stored facts contain only
+              ;; the arguments it stands for.
+              dotted? :dotted-extent
+
               ;; **A negative key holds its whole body as one token**, so the trie can match
               ;; a negative only *exactly* — `[:false (dog ?0) c]` is a different key from
               ;; `[:false (dog Tom) c]`, and no amount of the body being ground narrows it,
@@ -291,6 +329,7 @@
               :else :trie)]
         (prof/record-goal pat path)
         (case path
+          :dotted-extent (dotted-candidates ix (:truth pat) pred)
           :negative-roots (p/sentexes-with-args ix pred ground)
           :negative-fan   (let [pth (sx/path pat)]
                             (into #{} (mapcat #(p/lookup ix (assoc pth 1 %)))

--- a/test/vaelii/laziness_test.clj
+++ b/test/vaelii/laziness_test.clj
@@ -26,6 +26,7 @@
             [vaelii.core :as v]
             [vaelii.impl.jtms :as jtms]
             [vaelii.impl.levels :as levels]
+            [vaelii.impl.profile :as prof]
             [vaelii.impl.provers :as provers]
             [vaelii.impl.resolution :as res]
             [vaelii.test-util :as tu]))
@@ -173,6 +174,31 @@
             (is (<= one 2)
                 (str "the set-algebra path realized " one " of " all
                      " posting entries for one result"))))))))
+
+;; ---- level 2: open dotted-functor extent fan-out ------------------------
+;;
+;; A dotted pattern cannot use a fixed-arity trie path, so an open functor walks the
+;; root functor roster and reads each whole extent.  The roster can be chunked; core
+;; `mapcat` would therefore open thirty-two extents before yielding the first match.
+
+(tu/deftest-kb one-dotted-result-opens-one-functor-extent
+  (let [preds (vec (repeatedly 40 #(tu/tmp-pred "variadic")))
+        goal  (list '?pred '. '?args)]
+    (doseq [pred preds]
+      (v/assert kb (list pred (tu/tmp-ind "Arg")) 'UniverseContext {:chain? false}))
+    (let [reads (fn [consume]
+                  (prof/start)
+                  (try
+                    (consume (res/raw-match kb goal 'UniverseContext))
+                    (get-in (prof/snapshot) [:reads :functor-root] 0)
+                    (finally (prof/stop))))
+          one   (reads first)
+          all   (reads dorun)]
+      (testing "the open dotted query really fans across a chunk-sized roster"
+        (is (>= all 40)))
+      (testing "taking one result opens one extent, not one source chunk"
+        (is (= 1 one)
+            (str "opened " one " extents before yielding the first dotted match"))))))
 
 ;; ---- level 2: the symmetric mirror --------------------------------------
 ;;

--- a/test/vaelii/profile_test.clj
+++ b/test/vaelii/profile_test.clj
@@ -125,6 +125,12 @@
         (let [snap (collected #(doall (res/raw-match kb (list 'not (list '?p '?x '?y)) ctx)))]
           (is (contains? (paths-of snap :open) :negative-fan))))
 
+      (testing "a dotted rest reads whole functor extents instead of positional indexes"
+        (let [snap (collected #(doall (res/raw-match kb (list p a '. '?args) ctx)))]
+          (is (contains? (paths-of snap p) :dotted-extent)))
+        (let [snap (collected #(doall (res/raw-match kb (list '?pred '. '?args) ctx)))]
+          (is (contains? (paths-of snap :open) :dotted-extent))))
+
       (testing "the argument-root retrieval switch moves the label with the behaviour"
         (let [snap (collected #(binding [res/*arg-root-retrieval* false]
                                  (doall (res/raw-match kb (list p '?x b) ctx))))]

--- a/test/vaelii/retrieval_completeness_test.clj
+++ b/test/vaelii/retrieval_completeness_test.clj
@@ -79,13 +79,19 @@
                   ;; open functor
                   (list '?p Muffet) (list '?p '?x)
                   (list '?p Ann '?y) (list '?p '?x Cid)
+                  ;; dotted rest — concrete/open functors and a fixed prefix
+                  (list dog '. '?args)
+                  (list parentOf Ann '. '?args)
+                  (list '?p '. '?args)
                   ;; negative literals — the shape both relative oracles were blind to
                   (list 'not (list dog Tom))
                   (list 'not (list dog '?x))          ; nothing ground but the functor
                   (list 'not (list parentOf '?x Ann)) ; ground arg AFTER a variable
                   (list 'not (list parentOf Cid '?y)) ; ground arg in a LEFT PREFIX
                   (list 'not (list '?p '?x))          ; nothing pinned at all
-                  (list 'not (list '?p Tom))]]
+                  (list 'not (list '?p Tom))
+                  (list 'not (list dog '. '?args))
+                  (list 'not (list '?p '. '?args))]]
       (v/assert-many kb facts CxProbe {:strength :monotonic})
       (doseq [[label bindings]
               [["default" {}]
@@ -106,4 +112,8 @@
         (is (= 2 (count (got kb (list 'not (list '?p '?x)) CxProbe)))))
       (testing "and the public query answers them too"
         (is (= 2 (count (v/sentexes-matching kb (list 'not (list dog '?x)) CxProbe))))
-        (is (= 1 (count (v/sentexes-matching kb (list 'not (list parentOf Cid '?y)) CxProbe))))))))
+        (is (= 1 (count (v/sentexes-matching kb (list 'not (list parentOf Cid '?y)) CxProbe))))
+        (is (= 11 (count (v/sentexes-matching kb (list '?p '. '?args) CxProbe))))
+        (is (= 3 (count (v/sentexes-matching kb
+                                             (list 'not (list '?p '. '?args))
+                                             CxProbe))))))))

--- a/test/vaelii/turn_edge_test.clj
+++ b/test/vaelii/turn_edge_test.clj
@@ -91,6 +91,43 @@
       (testing "an unrelated pair is not derived"
         (is (empty? (v/sentexes-matching kb (list kin bob tom) 'CxUniverse)))))))
 
+(deftest dotted-rest-enumerates-and-joins-in-either-arrival-order
+  ;; A dotted antecedent is sometimes the arriving trigger and sometimes a stored fact
+  ;; the other antecedent has to retrieve.  Both paths must bind the same tail; otherwise
+  ;; this rule's result depends on which premise happened to arrive last.
+  (tu/with-neutral-kb [kb tu/fresh]
+    (tu/with-terms [agent_type agentCapable typeCapable
+                    AgentA AgentB CapA CapB ToolA ToolB]
+      (v/assert kb
+                (list 'set/forwardRule
+                      (list 'implies
+                            (list 'and
+                                  (list agent_type '?instance)
+                                  (list agentCapable '?instance '. '?args))
+                            (list typeCapable agent_type '. '?args)))
+                'UniverseContext)
+
+      ;; Dotted premise is the trigger.
+      (v/assert kb (list agent_type AgentA) 'UniverseContext)
+      (v/assert kb (list agentCapable AgentA CapA ToolA) 'UniverseContext)
+
+      ;; Dotted premise must be found by the join after the type premise triggers.
+      (v/assert kb (list agentCapable AgentB CapB ToolB) 'UniverseContext)
+      (v/assert kb (list agent_type AgentB) 'UniverseContext)
+
+      (testing "both premise arrival orders derive the same variadic bridge"
+        (is (v/ask? kb (list typeCapable agent_type CapA ToolA) 'UniverseContext))
+        (is (v/ask? kb (list typeCapable agent_type CapB ToolB) 'UniverseContext)))
+      (testing "a dotted pattern directly enumerates and binds a stored tail"
+        (is (= [(list agentCapable AgentB CapB ToolB)]
+               (mapv :sentence
+                     (v/sentexes-matching kb
+                                          (list agentCapable AgentB '. '?args)
+                                          'UniverseContext))))
+        (is (= #{{'?args (list CapB ToolB)}}
+               (set (v/ask kb (list agentCapable AgentB '. '?args)
+                           'UniverseContext))))))))
+
 ;; ---- forced decontextualized predicate (genlCx) -------------------------
 
 (deftest a-forced-genlcx-from-a-plain-context-lands-in-the-universe


### PR DESCRIPTION
## Context

Vaelii's dotted-rest syntax already unifies and substitutes variable-length argument tails, but stored-fact retrieval did not enumerate dotted patterns. This made a multi-antecedent forward rule depend on premise arrival order: the rule fired when its dotted literal was the incoming trigger, but not when the join had to retrieve that literal from the KB. Direct dotted `ask` and `sentexes-matching` queries likewise returned no candidates.

This was exposed while testing a variadic capability bridge. Open variable-functor rules remain a separate, intentional `:not-indexable` boundary; this PR does not change that policy.

## Change

- Add a `:dotted-extent` candidate path before positional trie/root routing.
- For a concrete functor, read its extent; for an open functor, lazily fan over the matching-polarity functor roster.
- Keep the existing polarity, context, and unification path as the exact correctness filter.
- Record and document the new profiler access path.

## Coverage

- Both premise arrival orders for a concrete two-antecedent variadic forward rule.
- Direct dotted `ask` and `sentexes-matching` enumeration and tail bindings.
- Positive, negative, concrete-functor, open-functor, and fixed-prefix retrieval against a brute-store oracle.
- Short-circuit laziness: first result opens one functor extent; a mutation back to core `mapcat` opens 32 and fails the regression.
- Profiler path reporting.

## Verification

- Full suite: **2,981 tests / 138,057 assertions**, 0 failures, 0 errors.
- Focused regression suites: **43 tests / 411 assertions**, green.
- Argument-root oracle: **7 tests / 5,840 assertions**, green.
- Hierarchical + structural retrieval: **18 tests / 9,685 assertions**, green.
- All eight backend parity configurations: **215 assertions**, green.
- `cljfmt`, docs links, reflection-warning compile, and `git diff --check`: green.
- Independent exact-head review: clean after one laziness finding was fixed and regression-tested.