### PR TITLE
fix(ontology): separate human from person

### DIFF
--- a/docs/reading.md
+++ b/docs/reading.md
@@ -384,7 +384,7 @@ consequent and was refused outright (`:not-range-restricted`) — the critic cat
 the reading got wrong, which is the repair path doing its job.
 
 **A coined type where a broader one exists.** The boy who cried wolf came back as
-`(boy Boy1)` where the gold is `(person BoyA)`. `boy` is a legal type name, nothing rejects
+`(boy Boy1)` where the gold is `(human BoyA)`. `boy` is a legal type name, nothing rejects
 it and nothing ever will — and the coining flag put it at the head of the review queue,
 which is exactly the division of labour this design claims. `(sheep Sheep1)` on the same
 fable is the other half of that: a character the prose mentions and the modeller did not,

--- a/docs/skolem.md
+++ b/docs/skolem.md
@@ -12,10 +12,10 @@ some antecedent, so a fired conclusion is ground. A **head existential** relaxes
 for one explicitly marked variable:
 
 ```clojure
-(implies (person ?x) (exists ?y (hasMother ?x ?y)))
+(implies (human ?x) (exists ?y (hasMother ?x ?y)))
 ```
 
-Fired forward on `(person Tom)`, this derives `(hasMother Tom K)` where `K` is a
+Fired forward on `(human Tom)`, this derives `(hasMother Tom K)` where `K` is a
 **deterministic skolem constant** — a fresh witness standing for "the y that exists".
 
 ## The surface form
@@ -60,7 +60,7 @@ on the same binding resolves to that one. The arguments are what key determinism
 - **frontier-values** — the bound values of the consequent variables the antecedents
   supply, less any a post-join literal *outputs* (an aggregate's `?n` is computed from
   the frontier rather than one of its values, so keying on it would mint a fresh
-  individual per count) — distinguish `(person Tom)` from `(person Sue)`. The frontier is
+  individual per count) — distinguish `(human Tom)` from `(human Sue)`. The frontier is
   the same for every conjunct of one head, so `(exists ?y (and (Q ?x ?y) (R ?y)))` gives
   `(Q Tom K)` and `(R K)` the **same** `K`.
 
@@ -77,7 +77,7 @@ and belief tie-breaking reads neither the symbol nor any handle.
 ## Belief-following
 
 The witness `(Q a K)` is justified through the JTMS on `[antecedent-facts, rule]` like
-any derived fact, so retracting `(person Tom)` drops `(hasMother Tom K)`, which orphans
+any derived fact, so retracting `(human Tom)` drops `(hasMother Tom K)`, which orphans
 `K`; the NAT orphan sweep (`remove-orphaned-nats!`) then removes its `termOfUnit`, so no
 raw `nat/` symbol dangles.
 

--- a/resources/kb/upper/CxOrganism.txt
+++ b/resources/kb/upper/CxOrganism.txt
@@ -77,6 +77,10 @@
 (comment horse "A large mammal ridden and used to pull loads.")
 (genl horse mammal)
 
+(comment human "A biological human being — a mammal that is also a person.")
+(genl human mammal)
+(genl human person)
+
 (comment insect "A small six-legged animal.")
 (genl insect animal)
 
@@ -99,8 +103,8 @@
 (comment penguin "A flightless bird — the standard exception to 'birds fly'.")
 (genl penguin bird)
 
-(comment person "A human being — a mammal that is also a social and rational agent.")
-(genl person mammal)
+(comment person "A social agent, whether biological or constructed.")
+(genl person thing)
 
 (comment plant "A living thing that photosynthesizes; disjoint from animal.")
 (genl plant living_thing)

--- a/src/vaelii/impl/examples.clj
+++ b/src/vaelii/impl/examples.clj
@@ -175,7 +175,7 @@
             estimated fan-out before running them."
     :rests-on [['(implies (and (parentOf ?x ?y) (parentOf ?y ?z)) (grandparentOf ?x ?z))
                 'CxKinship]]
-    :premises '[(person AdaEx) (person BenEx) (person CalEx)
+    :premises '[(human AdaEx) (human BenEx) (human CalEx)
                 (parentOf AdaEx BenEx) (parentOf BenEx CalEx)]
     :goal '(grandparentOf AdaEx CalEx) :expect :yes}
 
@@ -223,7 +223,7 @@
                   (implies (and (birthYearOf ?x ?bx) (birthYearOf ?y ?by) (lessThan ?bx ?by))
                            (olderThan ?x ?y)))
                 'CxKinship]]
-    :premises '[(person AdaEx) (person BenEx)
+    :premises '[(human AdaEx) (human BenEx)
                 (birthYearOf AdaEx 1970) (birthYearOf BenEx 1980)]
     :goal '(olderThan AdaEx BenEx) :expect :yes}
 

--- a/src/vaelii/impl/llm/oracle.clj
+++ b/src/vaelii/impl/llm/oracle.clj
@@ -91,10 +91,10 @@
 (defn- situation
   "One supporting fact as a given: the gloss with its apposition cut off.
 
-  A gloss opens with the claim and then defines its terms — *Ann is a person — a human
-  being — a mammal that is also …* — which is what a reader of one sentence wants and
-  the wrong thing entirely in front of a question.  The definition is not part of the
-  situation, and three of them make the situation unreadable.
+  A gloss opens with the claim and then defines its terms — *Ann is a human — a
+  biological human being — a mammal that is also …* — which is what a reader of one
+  sentence wants and the wrong thing entirely in front of a question.  The definition
+  is not part of the situation, and three of them make the situation unreadable.
 
   The full stop goes too, so `line` punctuates the join rather than inheriting whatever
   the cut left behind."

--- a/src/vaelii/impl/llm/score.clj
+++ b/src/vaelii/impl/llm/score.clj
@@ -79,10 +79,10 @@
   "`{individual -> #{predicate …}}` over a set of sentences: every **one-place claim** made
   of each individual.
 
-  Its kind, and also what it did — `(criesWolf BoyA)` counts alongside `(person BoyA)`.
+  Its kind, and also what it did — `(criesWolf BoyA)` counts alongside `(human BoyA)`.
   That is deliberate.  A fable's characters are as much identified by what happens to them
   as by their type, and the type is exactly what a reader is most likely to get differently
-  (`boy` where the modeller wrote `person`); an alignment on kind alone would then fail on
+  (`boy` where the modeller wrote `human`); an alignment on kind alone would then fail on
   a character the reading recovered completely.  Binary facts are left out because their
   argument order is a second thing to be wrong about, and an alignment that used them would
   start fitting the candidates to the gold."

--- a/test/vaelii/llm_oracle_test.clj
+++ b/test/vaelii/llm_oracle_test.clj
@@ -54,9 +54,9 @@
   ;; rests on in front of it, it is an ordinary question about people.
   (let [warm (first (filter #(= '(warmBlooded Ann) (:sentence %)) (derived-claims kb)))]
     (is (some? warm))
-    (is (= ["Ann is a person"] (:givens warm)))
+    (is (= ["Ann is a human"] (:givens warm)))
     (testing "the line reads as a situation and a claim"
-      (is (str/starts-with? (oracle/line warm) (str "[" (:index warm) "] Given: Ann is a person.")))
+      (is (str/starts-with? (oracle/line warm) (str "[" (:index warm) "] Given: Ann is a human.")))
       (is (str/includes? (oracle/line warm) "Claim: Ann holds its own body temperature")))
     (testing "the rule it fired through is not in the line — that would ask about validity"
       (is (not (str/includes? (oracle/line warm) "If")))
@@ -73,12 +73,12 @@
   ;; A gloss defines its terms after the claim, which is what a reader of one sentence
   ;; wants and noise in front of a question.
   (let [cs (derived-claims kb)
-        membership (first (oracle/claims kb [(v/handle-of kb '(person Tom) N)]))]
+        membership (first (oracle/claims kb [(v/handle-of kb '(human Tom) N)]))]
     (is (every? #(not (str/includes? % " — ")) (mapcat :givens cs)))
-    (is (some #(= ["Tom is a person"] (:givens %)) cs)
+    (is (some #(= ["Tom is a human"] (:givens %)) cs)
         "the given is the membership with its definition cut off")
     (testing "the same sentence as a claim keeps whatever the KB composed"
-      (is (str/starts-with? (:text membership) "Tom is a person — a human being")))))
+      (is (str/starts-with? (:text membership) "Tom is a human — a biological human being")))))
 
 (tu/deftest-kb the-prompt-is-a-function-of-the-knowledge-and-not-of-its-order
   ;; Two KBs holding the same knowledge must ask the same question, or one run cannot be

--- a/test/vaelii/meta_test.clj
+++ b/test/vaelii/meta_test.clj
@@ -36,7 +36,7 @@
   (testing "the upper ontology rides in the upper contexts, not the collector"
     (is (seq   (v/sentexes-matching kb '(genl dog mammal) 'CxOrganism)))
     (is (empty? (v/sentexes-matching kb '(genl dog mammal) 'CxUniverse)))
-    (is (seq   (v/sentexes-matching kb '(person Tom) 'CxNaturalWorld)))))
+    (is (seq   (v/sentexes-matching kb '(human Tom) 'CxNaturalWorld)))))
 
 (tu/deftest-kb predicates-classified-by-arity
   (testing "unary — every type, and one-place properties"

--- a/test/vaelii/ontology_test.clj
+++ b/test/vaelii/ontology_test.clj
@@ -197,8 +197,19 @@
       (is (seq (v/sentexes-matching kb (list 'arity p 1) '?ctx))
           (str p " is still a one-place predicate"))))
   (testing "while the kinds they are said of are types, and reach the root"
-    (doseq [t '[animal bird penguin dog person physical_object capability flying]]
+    (doseq [t '[animal bird penguin dog human person physical_object capability flying]]
       (is (v/genl? kb t 'thing) (str t " must reach thing")))))
+
+(tu/deftest-kb human-and-person-keep-biological-and-social-types-distinct
+  (tu/with-terms [IonaUnit]
+    (testing "a human is both a person and a mammal"
+      (is (v/genl? kb 'human 'person))
+      (is (v/genl? kb 'human 'mammal)))
+    (testing "a constructed person need not be a mammal and satisfies a social constraint"
+      (v/assert kb (list 'person IonaUnit) N)
+      (is (v/isa? kb IonaUnit 'person))
+      (is (not (v/isa? kb IonaUnit 'mammal)))
+      (is (empty? (v/check kb (list 'likes IonaUnit 'thing) N))))))
 
 (tu/deftest-kb every-shipped-type-is-placed-under-the-root
   ;; An unplaced type is invisible to every closure the engine reads, so it is a type in

--- a/test/vaelii/starter_test.clj
+++ b/test/vaelii/starter_test.clj
@@ -107,7 +107,7 @@
   (testing "every ontology type carries exactly one comment"
     (doseq [t '[thing intangible physical_object attribute temporal_thing relation_type
                 substance artifact body_part food living_thing vehicle tool building
-                animal plant mammal bird fish reptile insect person dog cat
+                animal plant mammal bird fish reptile insect human person dog cat
                 lion mouse hare wolf tortoise ant grasshopper
                 penguin eagle sparrow tree flower]]
       (is (= 1 (count (core-context/comment-of kb t))) (str "type " t))))

--- a/test/vaelii/stories_test.clj
+++ b/test/vaelii/stories_test.clj
@@ -54,7 +54,10 @@
     (is (v/isa? kb 'MouseA 'animal))
     (is (v/isa? kb 'TortoiseA 'reptile))
     (is (v/isa? kb 'AntA 'insect))
+    (is (v/isa? kb 'BoyA 'human))
     (is (v/isa? kb 'BoyA 'person))
+    (is (v/isa? kb 'BoyA 'mammal))
+    (is (v/isa? kb 'BoyA 'liar))
     (is (v/isa? kb 'WolfA 'mammal))))
 
 (tu/deftest-kb lion-and-mouse-derives-a-repaid-kindness

--- a/test/vaelii/world.clj
+++ b/test/vaelii/world.clj
@@ -33,8 +33,8 @@
 (def individuals
   "The cast's type memberships — in CxNaturalWorld, so the biology and kinship
   conclusions over them land there for the tests to query."
-  '[(person Tom) (person Bob) (person Ann) (person Carol) (person Dave)
-    (person Eve) (person Nancy)
+  '[(human Tom) (human Bob) (human Ann) (human Carol) (human Dave)
+    (human Eve) (human Nancy)
     (dog Muffet) (cat Whiskers) (penguin Tweety) (eagle Sam) (sparrow Jack)
     (fish Nemo) (tree Oak1) (flower Rose1) (vehicle Car1) (food Kibble)
     (building Garage1) (building House1)])

--- a/test/vaelii/world_fables.clj
+++ b/test/vaelii/world_fables.clj
@@ -171,7 +171,7 @@
   ;; the exception be stated at the type rather than at every liar individually.
   (v/assert kb '(genl liar person) 'CxCriedWolf)
   (assert-all kb 'CxCriedWolf
-              '[(person BoyA) (wolf WolfA)
+              '[(human BoyA) (wolf WolfA)
                 (liedBefore BoyA)                     ; he has raised false alarms
                 (criesWolf BoyA)                      ; now he cries wolf again
                 (approaches WolfA BoyA)])             ; and this time the wolf is real


### PR DESCRIPTION
## What changed

- introduce `human` as both a `mammal` and a `person`
- broaden `person` to a social agent rooted directly under `thing`
- migrate biological fixtures and examples to `human` while retaining social-only `person` examples
- update gloss, scoring, and documentation examples to match the ontology
- add regression coverage proving a constructed person satisfies social constraints without becoming a mammal

## Why

`person` previously conflated biological humans with the broader class of social agents. That made it impossible to model constructed persons without also classifying them as mammals.

The split preserves existing human biology and social reasoning while allowing non-biological persons.

Fixes #11.

## Validation

- ontology/starter: 18 tests, 239 assertions
- reading/scoring/world: 98 tests, 628 assertions
- common-sense/examples/ontology/starter: 54 tests, 664 assertions
- skolem/generator/common-sense: 54 tests, 307 assertions
- final independent correctness and test-proof reviews: PASS
- `git diff --check`: PASS

