### PR TITLE
feat(rules): a generator may stamp a generator, and an enclosing level fills the functor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.7.1 — unreleased
+
+- **A rule generator may stamp a generator, at any depth, and a variable an enclosing
+  level fills may head a literal.** `(implies (typeVersion ?ipred ?tpred) (implies
+  (?tpred ?type ?cap) (implies (?type ?instance) (?ipred ?instance ?cap))))` states a
+  type-level/instance-level bridge once instead of once per predicate pair, and what
+  reaches the index at the bottom is still an ordinary rule over concrete functors. The
+  scoping rule needed nothing added to it: a variable belongs to the outermost level
+  whose antecedents mention it. **A top-level rule antecedent is untouched** — nothing
+  encloses it, so a variable functor there is refused as it always was, and so is one a
+  literal *beside* it binds. Each level owes what a generator owes, at both doors.
+  *Class:* **Additive** — a shape that was refused (`:not-well-formed`, "a rule
+  generator nests one level") is now accepted.
+  [docs/generators.md](docs/generators.md).
+
 ## 0.7.0 — 2026-08-12
 
 - **Breaking: a context name is `Cx`-prefixed, not `Context`-suffixed.** `CoreContext`

--- a/docs/README.md
+++ b/docs/README.md
@@ -73,7 +73,7 @@ page costs a sentence rather than a section.
 ## Inference & belief
 
 - [inference.md](inference.md) — rules as sentexes, rule direction, forward/backward chaining, predicate subsumption, incremental matching, the prover engine.
-- [generators.md](generators.md) — a rule whose consequent is a rule: the hole/own-variable split that needs no declaring, what a firing stamps out, why a mint retracts like any conclusion, and the one level of nesting.
+- [generators.md](generators.md) — a rule whose consequent is a rule: the hole/own-variable split that needs no declaring, what a firing stamps out, why a mint retracts like any conclusion, and the nesting that lets a level further out fill a functor.
 - [anytime.md](anytime.md) — resource-bounded / anytime inference: the budget, the resumable partial-result contract, the qualitative `cost` tier.
 - [levels.md](levels.md) — the lookup-to-query stack: eight named levels from a raw index read to full backchaining.
 - [abduction.md](abduction.md) — `abduce`: what would have to be true for a goal to be provable, minted as a defeasible hypothesis in a scratch context — the dead-end observer, the grant that gates it, and the isolation that makes an ignored call free.

--- a/docs/generators.md
+++ b/docs/generators.md
@@ -1,7 +1,8 @@
 # Rule generators: a rule whose consequent is a rule
 
-- **Covers:** the generator form, the hole/own-variable scoping rule, what a firing
-  mints, how a mint is retracted, and the four things a generator is refused for.
+- **Covers:** the generator form, the hole/own-variable scoping rule, nesting and what
+  the extra level buys, what a firing mints, how a mint is retracted, and the things a
+  generator is refused for.
 - **Not here:** the direction wrappers a stamped rule carries →
   [inference.md](inference.md); why a *variable-predicate* rule is refused →
   [indexing.md](indexing.md); skolemizing a head existential →
@@ -37,7 +38,7 @@ marks them apart** — the split is computed:
 
 | | which variables | what happens to them |
 |---|---|---|
-| **holes** | those the generator's own antecedents also mention | bound by the join, ground in the mint |
+| **holes** | those an *enclosing* level's antecedents also mention | bound by that level's join, ground in what it stamps |
 | **the stamped rule's own** | everything else | survive as variables; they belong to the rule being stamped |
 
 In the example `?outcome` and `?emotion` are holes; `?a` and `?p` are the stamped
@@ -50,13 +51,73 @@ Two consequences worth stating, because both are easy to trip over:
 - **A hole may stand in functor position.** `(?outcome ?a ?p)` is legal here and
   nowhere else, because by mint time it holds `succeededAt`. This is what lets one
   generator range over a family of predicates while every rule the index ever keys on
-  has a concrete functor. A variable functor that is *not* a hole is refused
+  has a concrete functor. A variable functor no enclosing level binds is refused
   (`:not-indexable`) — nothing will ever bind it.
 - **Range restriction moves one level in.** The generator's own is vacuous: its
   consequent is a rule rather than a conclusion, and the stamped rule's free variables
   are unbound on purpose. What is checked is the *stamped* rule's, with the holes
   counted as bound. So `(implies (marker ?p) (implies (?p ?x) (dst ?x ?loose)))` is
   refused for `?loose`, at the generator, before any firing.
+
+## Nesting
+
+A stamped rule may itself be a generator, and then the mint stamps in turn. The nesting
+is **not capped**, because the scoping rule composes without needing anything added to
+it: a variable belongs to the **outermost** level whose antecedents mention it, which is
+the level whose firing grounds it. One reading of the sentence decides every level, and
+`rules/nesting` is that reading — it peels a rule into levels and carries each level's
+`:bound` set down.
+
+What the extra level buys is a **functor**. A hole is ground before the rule holding it
+is stored; a variable bound by a literal *beside* it is not, because both are stored at
+once. So these two say the same join and only one of them can be stored:
+
+```clojure
+;; refused :not-indexable — ?type is bound by the antecedent next to it, so the rule
+;; that gets stored still has a variable in functor position
+(implies (typeVersion ?ipred ?tpred)
+         (implies (and (?tpred ?type ?cap) (?type ?instance))
+                  (?ipred ?instance ?cap)))
+
+;; accepted — ?type is a hole of the middle level, so it is filled before the rule
+;; using it as a functor is stored
+(implies (typeVersion ?ipred ?tpred)
+         (implies (?tpred ?type ?cap)
+                  (implies (?type ?instance)
+                           (?ipred ?instance ?cap))))
+```
+
+The second is a type-level/instance-level bridge stated once rather than once per pair.
+`(typeVersion hasCapability capabilityType)` stamps a generator:
+
+```clojure
+(implies (capabilityType ?type ?cap)
+         (implies (?type ?instance) (hasCapability ?instance ?cap)))
+```
+
+`(capabilityType bird flying)` stamps that generator's rule:
+
+```clojure
+(implies (bird ?instance) (hasCapability ?instance flying))
+```
+
+and `(bird Tweety)` concludes `(hasCapability Tweety flying)`. Three levels, three
+firings, and the only thing ever keyed by the index is the concrete rule at the bottom
+and the two generators above it — filed under `implies`, which is where every generator
+is filed at every depth.
+
+**Every level owes what a generator owes**, because every level reaches the store as a
+rule in its own right and the mint reads the same check list the assert door does. A
+`set/backwardRule` around a middle level is `:not-indexable` at the sentence rather than
+one firing later; an `exceptWhen` on any stamped level is `:not-well-formed`; and a level
+that fills **no hole an enclosing level has not already filled** is
+`:not-range-restricted` — it would stamp the same rule at every firing, which is a rule
+its author could have written.
+
+**A top-level rule antecedent is not covered by any of this.** Nothing encloses it, so a
+variable functor there is what it always was: a key no fact and no goal can spell
+([indexing.md](indexing.md)). The nesting rule admits a variable functor exactly where a
+level further out fills it.
 
 ## The stamped rule's direction
 
@@ -69,7 +130,9 @@ The **generator itself is forward-only**. Its conclusion is a rule, and no backw
 goal asks for one — `res/concluding-rule-handles` reads a goal's predicate, and a
 generator's consequent predicate is `implies`, which nothing queries. A
 `set/backwardRule` generator is refused rather than stored claiming a capability it
-cannot exercise. `set/inertRule` stays legal, since it claims nothing.
+cannot exercise. `set/inertRule` stays legal, since it claims nothing. Under nesting the
+same holds of each level that stamps: only the **innermost** rule's wrapper is a free
+choice, and it is the one that sets the direction of the rule that concludes a fact.
 
 ## A mint is derived content
 
@@ -99,9 +162,14 @@ the same way, so it too sees what is already there.
 
 The mint goes through the same check list the assert door runs
 (`checks/check-rule!`, read by both doors so neither can drift): range restriction,
-indexability, naming, stratification, no imperative. A stamped rule concluding a
-conjunction is polycanonicalized into one rule per conjunct, exactly as an asserted one
-is.
+indexability, naming, stratification, no imperative, and the generator's own three. A
+stamped rule concluding a conjunction is polycanonicalized into one rule per conjunct,
+exactly as an asserted one is.
+
+That the list is one list is what makes nesting safe rather than merely legal: a middle
+level is checked **twice** — once as the pattern its author wrote, and again as the rule
+it became, with the outer fills substituted in. A fill that turns a middle level into
+junk is caught at the second reading, where the sentence alone could not have said so.
 
 A mint that **cannot stand is dropped and recorded**, never thrown — a fixpoint may not
 abort halfway through itself, and an exception escaping a firing would make the belief
@@ -112,34 +180,41 @@ set depend on which rule fired first. The drop lands in the violation ledger
 
 | written | refused as |
 |---|---|
-| a rule generating a generator (three levels) | `:not-well-formed` |
-| an `exceptWhen` on the stamped rule | `:not-well-formed` |
-| `set/backwardRule` on the generator | `:not-indexable` |
-| a stamped variable functor that is not a hole | `:not-indexable` |
-| a generator sharing no variable with the rule it stamps | `:not-range-restricted` |
-| a stamped rule that is not range-restricted | `:not-range-restricted` |
+| an `exceptWhen` on a stamped rule, at any level | `:not-well-formed` |
+| `set/backwardRule` on a level that stamps | `:not-indexable` |
+| a stamped variable functor no enclosing level binds | `:not-indexable` |
+| a level sharing no *new* variable with the rule it stamps | `:not-range-restricted` |
+| the innermost rule not range-restricted | `:not-range-restricted` |
 | a generator cycle | `:not-stratified` |
 
-**An `exceptWhen` on the stamped rule** is refused because an exception is not a rule
+**An `exceptWhen` on a stamped rule** is refused because an exception is not a rule
 field: it is a separate meta-sentex keyed by the rule's handle, split off and stored by
 the assert path, which a firing does not run. The mint would be a rule whose guard had
 evaporated in silence, firing on exactly the bindings its author wrote it not to — so
 it is refused rather than dropped. Two things do work: an `(unknown …)` antecedent
 *inside* the stamped rule, which lives in the rule sentence and so survives
-substitution; and an `exceptWhen` on the **generator**, which says when not to stamp.
+substitution; and an `exceptWhen` on the **outermost** rule, which says when not to
+stamp.
+
+**A level sharing no new variable** is the per-level form of "every firing stamps the
+same rule", and under nesting it is a mistake an outer fill *creates*: in
+`(implies (aa ?x) (implies (bb ?x) (implies (cc ?x) (dd ?x))))` the middle level's only
+shared variable is `?x`, which the first level has already ground, so the rule it stamps
+is fixed before it is stored. Share a variable the levels above it do not.
 
 A head existential *inside* the stamped rule is fine, and skolemizes one firing later,
 against the stamped rule's own handle — the generator's firing deliberately does not
 skolemize, since the stamped rule's free variables are its own ([skolem.md](skolem.md)).
 
-**One level of nesting**, and the third is refused rather than recursed into. The
-scoping rule that makes a generator readable is that the stamped rule's free variables
-are its own; a rule stamping a generator would need two such splits in one sentence
-with nothing in the spelling to say which variable belongs to which.
+**What bounds a generator is the cycle check, not the depth.** A nested generator stamps
+one level further and stops; a cycle stamps forever. That is why the refusal is on the
+cycle and the nesting is left to the author.
 
-**A generator cycle** is a generator whose stamped rule concludes a predicate some
-generator reads in an antecedent — itself included. That is a rule set minting rules
-that mint rules, and unlike ordinary recursion nothing bounds it: each round adds
+**A generator cycle** is a generator whose **innermost** conclusion is a predicate some
+generator reads in an antecedent it stamps from — itself included. The innermost, because
+that is the only level that concludes a fact: the levels above it conclude rules, filed
+under `implies`, which no fact carries and no goal asks for. That is a rule set minting
+rules that mint rules, and unlike ordinary recursion nothing bounds it: each round adds
 *rules*, and the next round's rules are the ones the last round wrote. Refused outright
 rather than depth-capped, because a cap would make the KB's contents a function of how
 long the chainer happened to run, and "how many rules does this KB have" would stop
@@ -158,11 +233,11 @@ fact that exists, and the family grows and shrinks with the data. Matching cost 
 unchanged either way — the rule index is keyed by predicate, so N concrete rules are
 never scanned, and each is reachable only through its own functors.
 
-**Not a variable-predicate rule.** A rule with a variable functor is still refused
-(`:not-indexable`, [indexing.md](indexing.md)): the index has two cells and both are
-keyed on a concrete symbol. A generator is how that refusal's advice — *assert the
-instantiated rules, one per predicate it ranges over* — stops being manual labour,
-without the index having to learn to read a variable.
+**Not a variable-predicate rule.** A rule that reaches the store with a variable functor
+is still refused (`:not-indexable`, [indexing.md](indexing.md)): the index has two cells
+and both are keyed on a concrete symbol. Nesting does not weaken that — it is what makes
+it affordable, since a functor an enclosing level fills is concrete by the time anything
+is keyed on it. A rule nothing encloses is exactly as refused as it was.
 
 **Not a rule about rules.** A generator concludes a rule; nothing reads one as a term,
 and no rule can take a rule as an antecedent. The one way to speak *about* a stored
@@ -171,16 +246,17 @@ rule remains the `(sentexHandle H)` meta-sentex layer
 
 ## Where the code is
 
-- `vaelii.impl.rules` — `generated-rule`, `generator?`, `holes`, the generator arm of
-  `range-problems`, and the hole-aware `variable-functor-literals`.
-- `vaelii.impl.sentex` — `connective-problems`, whose consequent arm admits a rule at
-  depth 1 and refuses it at depth 2.
+- `vaelii.impl.rules` — `generated-rule`, `generator?`, `holes`, `nesting` (the peel
+  every generator question is read off), `innermost-rule`, the generator arm of
+  `range-problems`, and the level-aware `variable-functor-literals`.
+- `vaelii.impl.sentex` — `connective-problems`, whose consequent arm reads a rule in
+  consequent position as the next level and recurses.
 - `vaelii.impl.naming` — `applied-literals`, which tags a stamped rule's literals
-  `:generated-antecedent` / `:generated-consequent` so the index check can tell them
-  from the generator's own.
-- `vaelii.impl.checks` — `check-rule!` (the list both doors read), `rule-violation`
-  (its value form, for the firing), `generator-cycle`.
+  `:generated-antecedent` / `:generated-consequent` — at every depth — so the index
+  check can tell them from the author's own.
+- `vaelii.impl.checks` — `check-rule!` (the list both doors read), `check-generator!`
+  (the three a generator owes, per level), `rule-violation` (the value form, for the
+  firing), `generator-cycle`.
 - `vaelii.impl.chain` — `mint-rule`, and the `place-conclusion` dispatch that routes a
-  rule-valued conclusion to it.
+  rule-valued conclusion to it — including a minted rule that is itself a generator.
 - `vaelii.impl.resolution` — `rule-believed?`, which is what makes a mint retractable.
-- `vaelii.core` — `check-generator`, the forward-only and cycle refusals.

--- a/docs/indexing.md
+++ b/docs/indexing.md
@@ -561,5 +561,9 @@ than failing:
   A **generator's** stamped rule is the other exemption, and it is the one that buys
   something back: a variable functor there is a *hole*, filled with a concrete predicate
   before anything is keyed on it, so one generator ranges over a family of predicates
-  while every rule the index sees has a concrete functor.  A stamped variable functor
-  that is not a hole is refused like any other.  See [generators.md](generators.md).
+  while every rule the index sees has a concrete functor.  The generator may itself be
+  stamped by one, and then the fill happens a level earlier — but the claim is unchanged
+  either way, because it is about what reaches the index rather than about what is
+  written: a functor **no enclosing level binds** is refused like any other, and a rule
+  nothing encloses has no enclosing level to bind one.  See
+  [generators.md](generators.md).

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -31,8 +31,9 @@ the **vector** of handles in that case (a single handle otherwise).
 
 A rule that concludes a **rule** is a *generator*, and its firing stores the rule it
 concludes rather than a fact — the one place range restriction is asked one level in,
-since the stamped rule's own variables are unbound on purpose. See
-[generators.md](generators.md).
+since the stamped rule's own variables are unbound on purpose. The rule it stamps may
+stamp one in turn, at any depth, and a variable an enclosing level fills may head a
+literal. See [generators.md](generators.md).
 
 ## Rule direction (virtual predicates)
 

--- a/docs/namespaces.md
+++ b/docs/namespaces.md
@@ -31,7 +31,7 @@ src/vaelii/impl/
   protocols.clj     RecordStore, IndexStore (trie + roots + rule index + term index)
   naming.clj        naming-invariant predicates + functor/args/arity
   sentex.clj        Atomic / Rule records (connectives → truth/antecedent/consequent), split so a fact drops the rule-only slots; canonical vars + varmap, literal order, symmetric args, comparison folding/chains; canon (+ symbol interning); α-renamed path; index-terms
-  rules.clj         rule-as-sentex helpers (implies form, predicates, range check, exception closure, conjunctive-consequent expand, the generator's hole split — [generators.md](generators.md))
+  rules.clj         rule-as-sentex helpers (implies form, predicates, range check, exception closure, conjunctive-consequent expand, the generator's hole split and its nesting — [generators.md](generators.md))
   taxonomy.clj      cached genl / genlCx closures; the equality partition (representative / equiv-class / deprecated?); maximal-common-descendant-contexts
   strength.clj      assumption strengths + defeat-class lattice (monotonic>default)
   kv.clj            KvBackend protocol + the one KvIndexStore over it: trie + context/functor/arg roots + rule predicate index + exception re-check index + term index; `index-layout-version`, the number that says which key shapes a build reads

--- a/src/vaelii/core.clj
+++ b/src/vaelii/core.clj
@@ -819,67 +819,14 @@
   (jtms/add-premise (:tms kb) h strength)
   (p/mark-premise (:records kb) h strength))
 
-(defn- check-generator
-  "The three refusals that are a **generator**'s alone — a rule whose consequent is a
-  rule (docs/generators.md).  Everything else it must satisfy it satisfies as a rule,
-  through `checks/check-rule!`.
-
-  **Forward-only.** A generator's conclusion is a rule, and there is no backward goal
-  whose answer is one — `concluding-rule-handles` reads a goal's predicate, and a
-  generator's consequent predicate is `implies`, which names nothing a query asks for.
-  A `set/backwardRule` generator would therefore be stored claiming a capability it
-  cannot exercise, which is the accepted-and-inert state the indexability refusal
-  exists to keep out of the KB.  `:inert` stays legal: it claims nothing.
-
-  **No `exceptWhen` on the stamped rule.** An exception is not a rule field — it is a
-  separate meta-sentex keyed by the rule's handle, split off and stored by the assert
-  path (`assert-exceptWhen-meta!`), which a firing does not run.  So a stamped
-  `exceptWhen` would reach the store as nothing at all: the mint would be a rule whose
-  guard had silently evaporated, firing on exactly the bindings its author wrote it not
-  to.  A guard that is dropped in silence is worse than one refused, so it is refused.
-  An `exceptWhen` on the **generator** is a different and legal thing — it says when not
-  to stamp — and the message points there.
-
-  **No generator cycle.** A stamped rule whose conclusion feeds some generator's
-  antecedent is a rule set that mints rules that mint rules, with no fixpoint anybody
-  has bounded.  Refused outright rather than capped, the same call stratification makes
-  for a cycle through negation: the alternative is a KB whose size depends on how long
-  the chainer was allowed to run."
-  [kb sentence context]
-  (let [inner     (rules/inner-rule sentence)
-        consequent (rules/consequent inner)
-        generated (rules/generated-rule consequent)
-        ;; `peel-rule-wrapper` reports the wrapper it found, and a bare rule has none —
-        ;; the record's default is what nil means here, as it does at the constructor
-        direction (or (first (sx/peel-rule-wrapper sentence)) :both)]
-    (when (seq (nth (sx/peel-rule-wrapper consequent) 2))
-      (throw (ex-info (str "the rule a generator generates cannot carry an exceptWhen:"
-                           " an exception is stored as a meta-sentex against the rule's"
-                           " handle, and a firing has no way to split one off, so it"
-                           " would be dropped in silence.  Put the condition in the"
-                           " generated rule's antecedents as an (unknown …), or put the"
-                           " exceptWhen on the generator to say when not to generate")
-                      {:type :not-well-formed :sentence sentence :context context})))
-    (when-not (contains? #{:forward :both :inert} direction)
-      (throw (ex-info (str "a rule generator is forward-only: its conclusion is a rule,"
-                           " and no backward goal asks for one.  Drop the"
-                           " set/backwardRule wrapper — the wrapper on the rule it"
-                           " generates is what sets that rule's direction")
-                      {:type :not-indexable :direction direction :sentence sentence})))
-    (when-let [cyc (checks/generator-cycle kb inner generated context)]
-      (throw (ex-info (str "a rule generator cannot generate a rule that feeds a"
-                           " generator: " cyc)
-                      {:type :not-stratified :sentence sentence :context context
-                       :cycle cyc})))))
-
 (defn- check-rule-sentence
   "Every pre-storage check a rule must pass, as a step that writes nothing —
   `checks/check-rule!`, the list both storage doors read (the other being a generator
-  firing, `chain/place-conclusion`), plus the two a generator alone owes."
+  firing, `chain/place-conclusion`).  A generator's own three are in that list rather
+  than beside it, because a *minted* rule can be a generator too (docs/generators.md)
+  and a check only this door ran would be one the fixpoint could store around."
   [kb sentence context]
-  (checks/check-rule! kb sentence context)
-  (when (rules/generator? sentence)
-    (check-generator kb sentence context)))
+  (checks/check-rule! kb sentence context))
 
 (defn- join-direction
   "The direction a rule stated two ways holds in: the **least restrictive** of the two.

--- a/src/vaelii/impl/checks.clj
+++ b/src/vaelii/impl/checks.clj
@@ -1302,6 +1302,156 @@
     (throw (ex-info (str "a do/ imperative cannot appear in a rule: " (pr-str bad))
                     {:type :not-assertible :form bad :sentence sentence}))))
 
+;; ---- generators: the refusals a rule concluding a rule owes ---------------
+;; A generator is a rule and passes everything a rule passes.  What follows is what it
+;; owes *as* a generator, and every one of them is asked of each nesting level, since a
+;; stamped rule may stamp one in turn and each level reaches the store as a rule in its
+;; own right (docs/generators.md).
+
+(defn- stored-generators
+  "Every stored generator, as `[handle sentex]` pairs.
+
+  One index lookup, and the cell it reads is the one that looks like a junk posting:
+  `rules/consequent-predicate` reads the functor of what a rule concludes, and what a
+  generator concludes is a rule — so every generator in the KB is filed under `implies`
+  and nothing else is, at any nesting depth.  Nothing backward-chains through it (a
+  generator is forward-only, and no goal's functor is `implies`), which leaves it doing
+  exactly this one job."
+  [kb]
+  (into []
+        (comp (keep (fn [h] (when-let [s (p/get-sentex (:records kb) h)] [h s])))
+              (filter (fn [[_ s]] (rules/generator-sentex? s))))
+        (p/rules-by-consequent (:index kb) sx/rule-functor)))
+
+(defn- stamped-predicate
+  "The predicate a generator eventually concludes — the **innermost** rule's, through
+  however many levels of stamping stand between.  The levels in between conclude rules,
+  and `implies` is a key nothing reads as a fact; what reaches the fact store is the
+  innermost conclusion, so that is the predicate a cycle can run through."
+  [sentence]
+  (rules/consequent-predicate (rules/innermost-rule sentence)))
+
+(defn- generator-reads
+  "The predicates whose arrival makes this generator **stamp** — the antecedents of
+  every level but the innermost.  The innermost rule's antecedents are excluded on
+  purpose: they trigger the rule that was stamped, which concludes a fact, and a fact is
+  not what makes the rule set grow."
+  [sentence]
+  (into #{} (mapcat #(keep nm/functor (:antecedents %)))
+        (butlast (rules/nesting sentence))))
+
+(defn generator-cycle
+  "A description of the cycle adding this generator would put in the rule set, or nil.
+
+  The graph is generators only, and one hop: an edge runs from a generator to any
+  generator that reads — in an antecedent it stamps from — the predicate its stamped
+  rule concludes.  A cycle there is a rule set that mints rules that mint rules, and
+  unlike ordinary recursion nothing bounds it: each round adds *rules* rather than
+  facts, and the next round's rules are the ones the last round wrote.
+
+  Refused outright rather than depth-capped.  A cap would make the KB's contents a
+  function of how long the chainer happened to run, and \"how many rules does this KB
+  have\" would stop having an answer — the same call stratification makes for a cycle
+  through negation (docs/exceptions.md).  It is also why *nesting* is not a cap worth
+  having: a nested generator stamps one level further before it stops, and what makes a
+  rule set unbounded is the cycle, not the depth.
+
+  **Both directions, because either can be the new edge**: the arriving generator may
+  stamp what a stored one reads, or read what a stored one stamps, and a self-loop is
+  the case where it does both to itself.  Checking only one direction would let the
+  cycle in whenever the two generators were asserted in the other order — which is the
+  order dependence every check here exists to keep out."
+  [kb inner context]
+  (when (rules/generated-rule (rules/consequent inner))
+    (let [stamps (stamped-predicate inner)
+          reads  (generator-reads inner)
+          gens   (stored-generators kb)
+          where  (or (when (and stamps (reads stamps)) "itself")
+                     (some (fn [[h s]]
+                             (when (and stamps (contains? (generator-reads (:sentence s))
+                                                          stamps))
+                               (str "the generator at handle " h)))
+                           gens)
+                     (some (fn [[h s]]
+                             (when-let [p (stamped-predicate (:sentence s))]
+                               (when (reads p)
+                                 (str "the generator at handle " h ", which stamps "
+                                      p))))
+                           gens))]
+      (when where
+        (str "the rule it generates concludes " stamps
+             ", and that predicate is read by " where
+             (when context (str " (asserting into " context ")")))))))
+
+(defn check-generator!
+  "The three refusals that are a **generator**'s alone — a rule whose consequent is a
+  rule (docs/generators.md).  Everything else it must satisfy it satisfies as a rule,
+  through the list below.
+
+  **Forward-only.** A generator's conclusion is a rule, and there is no backward goal
+  whose answer is one — `concluding-rule-handles` reads a goal's predicate, and a
+  generator's consequent predicate is `implies`, which names nothing a query asks for.
+  A `set/backwardRule` generator would therefore be stored claiming a capability it
+  cannot exercise, which is the accepted-and-inert state the indexability refusal
+  exists to keep out of the KB.  `:inert` stays legal: it claims nothing.  Asked of
+  **every** generator level, since a `set/backwardRule` around a middle level would be
+  minted as a backward generator and refused one firing later, in the ledger rather
+  than at the sentence.
+
+  **No `exceptWhen` on a stamped rule.** An exception is not a rule field — it is a
+  separate meta-sentex keyed by the rule's handle, split off and stored by the assert
+  path (`assert-exceptWhen-meta!`), which a firing does not run.  So a stamped
+  `exceptWhen` would reach the store as nothing at all: the mint would be a rule whose
+  guard had silently evaporated, firing on exactly the bindings its author wrote it not
+  to.  A guard that is dropped in silence is worse than one refused, so it is refused.
+  An `exceptWhen` on the **outermost** rule is a different and legal thing — it says
+  when not to stamp — and the message points there.
+
+  **No generator cycle.** A stamped rule whose conclusion feeds some generator's
+  antecedent is a rule set that mints rules that mint rules, with no fixpoint anybody
+  has bounded.  Refused outright rather than capped, the same call stratification makes
+  for a cycle through negation: the alternative is a KB whose size depends on how long
+  the chainer was allowed to run.
+
+  Read by both storage doors through `check-rule!`, so a generator a *firing* stamps
+  owes exactly what one an author wrote owes — which is the whole of what makes nesting
+  safe: the middle level is checked twice, once as a pattern and once as the rule it
+  became."
+  [kb sentence context]
+  (let [inner  (rules/inner-rule sentence)
+        levels (rules/nesting sentence)
+        ;; `peel-rule-wrapper` reports the wrapper it found, and a bare rule has none —
+        ;; the record's default is what nil means here, as it does at the constructor.
+        ;; A level's own wrapper rides the consequent of the level above it, which is
+        ;; where a stamped rule's direction is written.
+        dirs   (cons (or (first (sx/peel-rule-wrapper sentence)) :both)
+                     (map #(or (first (sx/peel-rule-wrapper (:consequent %))) :both)
+                          levels))]
+    (doseq [[i level dir] (map vector (range) levels dirs)
+            :when         (:generated level)]
+      (when (seq (nth (sx/peel-rule-wrapper (:consequent level)) 2))
+        (throw (ex-info (str "the rule a generator generates cannot carry an exceptWhen:"
+                             " an exception is stored as a meta-sentex against the rule's"
+                             " handle, and a firing has no way to split one off, so it"
+                             " would be dropped in silence.  Put the condition in the"
+                             " generated rule's antecedents as an (unknown …), or put the"
+                             " exceptWhen on the outermost rule to say when not to"
+                             " generate")
+                        {:type :not-well-formed :sentence sentence :context context
+                         :nesting-level (inc i)})))
+      (when-not (contains? #{:forward :both :inert} dir)
+        (throw (ex-info (str "a rule generator is forward-only: its conclusion is a rule,"
+                             " and no backward goal asks for one.  Drop the"
+                             " set/backwardRule wrapper — the wrapper on the innermost"
+                             " rule is what sets that rule's direction")
+                        {:type :not-indexable :direction dir :sentence sentence
+                         :nesting-level (inc i)}))))
+    (when-let [cyc (generator-cycle kb inner context)]
+      (throw (ex-info (str "a rule generator cannot generate a rule that feeds a"
+                           " generator: " cyc)
+                      {:type :not-stratified :sentence sentence :context context
+                       :cycle cyc})))))
+
 (defn check-rule!
   "Every pre-storage check a rule must pass, as a step that writes nothing.
 
@@ -1317,7 +1467,11 @@
   `(implies A (and C1 C2))` is split into one rule per conjunct and then `mapv`d,
   and a `mapv` is not a transaction: with the checks inline, a refusal on C2 left
   C1 already stored, indexed, and chained from, while the caller saw a throw and
-  reasonably concluded nothing had been asserted."
+  reasonably concluded nothing had been asserted.
+
+  A **generator** owes three more (`check-generator!`), and they run last so the
+  sharper complaint comes first: a rule that is unbound *and* backward-only is refused
+  for the unbound variable, which is the one its author can act on."
   [kb sentence context]
   (let [inner       (rules/inner-rule sentence)
         [direction] (sx/peel-rule-wrapper sentence)]
@@ -1346,68 +1500,9 @@
     ;; the rule-set check, before anything is stored: an `exceptWhen` is negation as
     ;; failure, and a cycle through it would make the settled state depend on
     ;; arrival order (docs/exceptions.md)
-    (check-stratified kb sentence inner context)))
-
-(defn- stored-generators
-  "Every stored generator, as `[handle sentex]` pairs.
-
-  One index lookup, and the cell it reads is the one that looks like a junk posting:
-  `rules/consequent-predicate` reads the functor of what a rule concludes, and what a
-  generator concludes is a rule — so every generator in the KB is filed under `implies`
-  and nothing else is.  Nothing backward-chains through it (a generator is forward-only,
-  and no goal's functor is `implies`), which leaves it doing exactly this one job."
-  [kb]
-  (into []
-        (comp (keep (fn [h] (when-let [s (p/get-sentex (:records kb) h)] [h s])))
-              (filter (fn [[_ s]] (rules/generator-sentex? s))))
-        (p/rules-by-consequent (:index kb) sx/rule-functor)))
-
-(defn- stamped-predicate
-  "The predicate the rule a generator stamps out concludes."
-  [sentex]
-  (some-> (:consequent sentex) rules/generated-rule rules/consequent-predicate))
-
-(defn generator-cycle
-  "A description of the cycle adding this generator would put in the rule set, or nil.
-
-  The graph is generators only, and one hop: an edge runs from a generator to any
-  generator that reads — in an antecedent — the predicate its stamped rule concludes.
-  A cycle there is a rule set that mints rules that mint rules, and unlike ordinary
-  recursion nothing bounds it: each round adds *rules* rather than facts, and the next
-  round's rules are the ones the last round wrote.
-
-  Refused outright rather than depth-capped.  A cap would make the KB's contents a
-  function of how long the chainer happened to run, and \"how many rules does this KB
-  have\" would stop having an answer — the same call stratification makes for a cycle
-  through negation (docs/exceptions.md).
-
-  **Both directions, because either can be the new edge**: the arriving generator may
-  stamp what a stored one reads, or read what a stored one stamps, and a self-loop is
-  the case where it does both to itself.  Checking only one direction would let the
-  cycle in whenever the two generators were asserted in the other order — which is the
-  order dependence every check here exists to keep out."
-  [kb inner generated context]
-  (when generated
-    (let [stamps (rules/consequent-predicate generated)
-          reads  (set (rules/antecedent-predicates inner))
-          gens   (stored-generators kb)
-          where  (or (when (and stamps (reads stamps)) "itself")
-                     (some (fn [[h s]]
-                             (when (and stamps
-                                        (some #{stamps} (rules/antecedent-predicates
-                                                         (:sentence s))))
-                               (str "the generator at handle " h)))
-                           gens)
-                     (some (fn [[h s]]
-                             (when-let [p (stamped-predicate s)]
-                               (when (reads p)
-                                 (str "the generator at handle " h ", which stamps "
-                                      p))))
-                           gens))]
-      (when where
-        (str "the rule it generates concludes " stamps
-             ", and that predicate is read by " where
-             (when context (str " (asserting into " context ")")))))))
+    (check-stratified kb sentence inner context)
+    (when (rules/generator? sentence)
+      (check-generator! kb sentence context))))
 
 (defn rule-violation
   "`check-rule!` as a **value** in the shape the derivation path files — a

--- a/src/vaelii/impl/naming.clj
+++ b/src/vaelii/impl/naming.clj
@@ -213,8 +213,13 @@
          ;; *index* has no claim on them, because what gets indexed is the mint and
          ;; not the pattern.  `rules/variable-functor-literals` reads the tag to draw
          ;; that line, which is what lets a hole stand in functor position.
+         ;;
+         ;; A stamped rule may stamp one in turn, so a *stamped* consequent is a
+         ;; generator's head by the same reading: the tag survives the whole nesting,
+         ;; and a literal three levels in still reads as stamped rather than as the
+         ;; author's own.
          (and (= sx/rule-functor h) (= 3 n))
-         (let [gen?  (= :consequent role)
+         (let [gen?  (contains? #{:consequent :generated-consequent} role)
                arole (if gen? :generated-antecedent :antecedent)
                crole (if gen? :generated-consequent :consequent)]
            (into (vec (mapcat #(applied-literals arole %) (sx/rule-antecedents form)))

--- a/src/vaelii/impl/rules.clj
+++ b/src/vaelii/impl/rules.clj
@@ -422,7 +422,13 @@
 ;; firing stamps the inner rule out with its holes filled.  The scoping rule is
 ;; computed, not annotated: the inner rule's variables that its enclosing antecedents
 ;; also mention are **holes**, bound by the join and ground at mint; the rest are the
-;; stamped rule's own, and belong to it.  See docs/generators.md.
+;; stamped rule's own, and belong to it.
+;;
+;; The nesting is not capped.  A stamped rule may itself be a generator, and then the
+;; mint stamps in turn — each level's firing grounds that level's holes and stores the
+;; level below it.  One reading decides every level, because the scoping rule composes:
+;; a variable belongs to the **outermost** level whose antecedents mention it, which is
+;; the level whose firing makes it ground.  See docs/generators.md.
 
 (defn generated-rule
   "The bare rule form a generator's `consequent` stamps out — the `(implies …)` inside
@@ -454,10 +460,55 @@
   Computed rather than declared, which is the whole reason a generator needs no
   vocabulary of its own: sharing a variable name with the antecedents *is* how an
   author says \"fill this in\", and the remaining variables are the stamped rule's own
-  by the same token.  Two spellings cannot disagree, because there is only one."
+  by the same token.  Two spellings cannot disagree, because there is only one.
+
+  One level's question.  Under nesting each level asks it of the level below, and
+  `nesting` carries the answers down as `:bound`."
   [antecedents generated]
   (let [ante-vars (into #{} (mapcat deep-vars antecedents))]
     (into #{} (filter ante-vars) (deep-vars generated))))
+
+(defn nesting
+  "A rule sentence peeled into its **levels**, outermost first — one map per `implies`:
+
+      {:antecedents …  ; that level's antecedent patterns
+       :consequent  …  ; what it concludes, wrapper and all
+       :generated   …  ; the bare rule it stamps, nil at the innermost level
+       :bound       …} ; the variables an *enclosing* level's antecedents bind
+
+  An ordinary rule is one level with no `:generated`; a generator is two; a generator
+  that stamps a generator is three, and so on with no cap.
+
+  `:bound` is the whole of the scoping rule, accumulated on the way down: by the time a
+  level's rule is stored, every enclosing level has fired and substituted its own holes,
+  so those variables are **ground** there — which is what lets one stand in functor
+  position, and what counts as bound when the innermost rule's range restriction is
+  checked.  A variable an enclosing level does *not* bind belongs to the level it is
+  written at or further in.
+
+  One peel rather than a recursion per question: the holes, the variable functors and
+  the range restriction are all read off these levels, so they cannot disagree about
+  which level owns a variable.
+
+  An ordinary rule stops after one level, so a rule that stamps nothing pays one peel
+  and one map for being read this way."
+  [sentence]
+  (loop [r (inner-rule sentence) bound #{} acc []]
+    (let [as    (antecedents r)
+          c     (consequent r)
+          g     (generated-rule c)
+          level {:antecedents as :consequent c :generated g :bound bound}]
+      (if g
+        (recur g (into bound (mapcat deep-vars) as) (conj acc level))
+        (conj acc level)))))
+
+(defn innermost-rule
+  "The rule at the bottom of a generator's nesting — the one whose consequent is a
+  **conclusion** rather than another rule, and so the only level of a generator that
+  ever concludes a fact.  `inner-rule` for a rule that stamps nothing."
+  [sentence]
+  (let [{:keys [antecedents consequent]} (peek (nesting sentence))]
+    (rule-sentence antecedents consequent)))
 
 (defn- ordinary-range-problems
   "`range-problems` for a rule that concludes a *fact* — every rule but a generator.
@@ -498,27 +549,40 @@
   antecedent-bound nor existentially marked is still a problem — so an accidental
   typo is caught while a deliberate `∃` is allowed (docs/skolem.md).
 
-  A **generator** is checked one level in, and the two claims are about *different*
-  rules.  The generator's own range restriction is vacuous — its consequent is a rule
-  rather than a conclusion, and the stamped rule's free variables are unbound on
-  purpose — so what is checked is the **stamped** rule's, with the holes counted as
-  bound because substitution makes them ground before anything is stored.  Checking it
-  here rather than at firing is what makes the refusal reach the author: a generator
-  that can only ever stamp junk is refused where it is written, not once per binding at
-  the far end of a fixpoint."
+  A **generator** is checked at its innermost level, and the two claims are about
+  *different* rules.  Every generator level's own range restriction is vacuous — its
+  consequent is a rule rather than a conclusion, and what it stamps has free variables on
+  purpose — so what is checked is the **innermost** rule's, with every enclosing level's
+  holes counted as bound because substitution makes them ground before anything is
+  stored.  Checking it here rather than at firing is what makes the refusal reach the
+  author: a generator that can only ever stamp junk is refused where it is written, not
+  once per binding at the far end of a fixpoint.
+
+  Each generator level owes one claim of its own: it must fill a hole **no enclosing
+  level has already filled**.  A level whose every shared variable is already ground
+  stamps the same rule at every firing, which is a rule its author could have written —
+  and under nesting that is a mistake the outer fill *creates*, so saying it here is
+  what keeps the refusal at the sentence instead of once per mint in the ledger."
   [antecedents consequent]
-  (if-let [generated (generated-rule consequent)]
-    (let [hs (holes antecedents generated)]
-      (cond-> []
-        (empty? hs)
-        (conj (str "rule generator shares no variable with the rule it generates, so"
-                   " every firing stamps the same rule: share the variable that is"
-                   " meant to vary, or write the rule itself"))
-        :always
-        (into (ordinary-range-problems (sx/rule-antecedents generated)
-                                       (sx/rule-consequent generated)
-                                       hs))))
-    (ordinary-range-problems antecedents consequent nil)))
+  (let [levels (nesting (rule-sentence antecedents consequent))
+        inner  (peek levels)]
+    (-> (into []
+              (comp (map-indexed vector)
+                    (keep (fn [[i {:keys [antecedents generated bound]}]]
+                            (when (every? bound (holes antecedents generated))
+                              (if (pos? i)
+                                (str "rule generator at nesting level " (inc i)
+                                     " shares no variable with the rule it generates"
+                                     " that a level further out has not already filled,"
+                                     " so every firing stamps the same rule: share a"
+                                     " variable the levels above it do not")
+                                (str "rule generator shares no variable with the rule it"
+                                     " generates, so every firing stamps the same rule:"
+                                     " share the variable that is meant to vary, or"
+                                     " write the rule itself"))))))
+              (butlast levels))
+        (into (ordinary-range-problems (:antecedents inner) (:consequent inner)
+                                       (:bound inner))))))
 
 (defn check-range-restricted
   "Throw `:type :not-range-restricted` unless every consequent variable is bound by
@@ -538,38 +602,49 @@
 
 ;; ---- the functor a rule is indexed by ------------------------------------
 
-(def ^:private generated-roles
-  "The `applied-literals` roles that sit inside a generator's stamped rule."
-  #{:generated-antecedent :generated-consequent})
-
 (defn variable-functor-literals
   "The `[role literal]` pairs of a rule whose functor is a **variable** — `(?p ?x ?y)`,
-  or the dotted rest `(?pred . ?args)`.  Read through `naming/applied-literals`, so the
-  frames descended into are the ones the naming check descends: a negated antecedent, an
-  `ist` consequent, a head existential, an aggregate's body.
+  or the dotted rest `(?pred . ?args)`.  Read through `naming/applied-literals` one
+  level at a time, so the frames descended into are the ones the naming check descends:
+  a negated antecedent, an `ist` consequent, a head existential, an aggregate's body.
 
   Inside a generator's stamped rule the question is asked of **non-holes only**, and
   that is the carve the whole feature rests on.  The index's claim is on what gets
   stored as a rule; a stamped rule is a pattern, and what gets stored is the mint —
-  checked in its own right, by this function, when it is minted.  A **hole** in functor
-  position is therefore fine, because substitution makes it concrete before anything is
-  keyed on it, and that is what lets one generator range over a family of predicates
-  while every rule the index ever sees has a concrete functor.
+  checked in its own right, by this function, when it is minted.  A variable an
+  **enclosing** level binds is therefore fine in functor position, because that level's
+  firing makes it concrete before anything is keyed on it, and that is what lets one
+  generator range over a family of predicates while every rule the index ever sees has a
+  concrete functor.
 
-  A stamped variable functor that is *not* a hole is refused as loudly as any other,
+  **Enclosing, not same-level**, and the distinction is the whole of what nesting buys.
+  `(implies (and (?tpred ?type ?cap) (?type ?instance)) …)` stamped by a generator that
+  binds `?tpred` fills the first functor and not the second: `?type` is bound by a
+  literal of the rule *being stored*, so the mint is a rule the index cannot key, and
+  refusing it is refusing exactly what would otherwise be stored inert.  Written a level
+  further in — `(implies (?tpred ?type ?cap) (implies (?type ?instance) …))` — `?type` is
+  a hole of the middle level, ground before its rule is stored, and both functors are
+  concrete by the time anything is indexed.
+
+  A stamped variable functor no enclosing level binds is refused as loudly as any other,
   and it has to be: nothing will ever bind it, so every mint it produces is the
   accepted-and-inert rule this check exists to keep out — and refusing it here names
   the generator, where refusing it at the mint would name a rule the author never
   wrote."
   [sentence]
-  (let [inner     (inner-rule sentence)
-        generated (generated-rule (consequent inner))
-        hs        (if generated (holes (antecedents inner) generated) #{})]
-    (filterv (fn [[role lit]]
-               (let [f (nm/functor lit)]
-                 (and (sx/variable? f)
-                      (not (and (generated-roles role) (hs f))))))
-             (nm/applied-literals sentence))))
+  (letfn [(level-literals [i {:keys [antecedents consequent generated]}]
+            ;; only the innermost level's consequent is a conclusion; every other one is
+            ;; the level below, read there as that level's own literals
+            (let [arole (if (pos? i) :generated-antecedent :antecedent)
+                  crole (if (pos? i) :generated-consequent :consequent)]
+              (cond-> (into [] (mapcat #(nm/applied-literals arole %)) antecedents)
+                (nil? generated) (into (nm/applied-literals crole consequent)))))
+          (level-problems [i level]
+            (filter (fn [[_ lit]]
+                      (let [f (nm/functor lit)]
+                        (and (sx/variable? f) (not ((:bound level) f)))))
+                    (level-literals i level)))]
+    (vec (mapcat level-problems (range) (nesting sentence)))))
 
 (defn check-indexable-functors
   "Throw `:type :not-indexable` when a literal of the rule `sentence` puts a variable in
@@ -586,18 +661,34 @@
   orders, two answers, from a rule the engine reported as accepted.
 
   The workaround the message names is the instantiated rule: one rule per predicate the
-  metarule was meant to range over, each with a functor the index can read.
+  metarule was meant to range over, each with a functor the index can read — written by
+  hand, or by the **generator** that stamps them, which is what a variable functor
+  usually wants to be (docs/generators.md).  So the message names the level to move it
+  to when the rule is one a generator stamps: a functor a level *further out* binds is
+  ground before its rule is stored, and only the ones nothing binds are left.
 
-  An `:inert` rule is exempt at the caller (`core/check-rule-sentence`): it runs in
-  neither engine by construction, so it claims nothing the index has to honour."
+  An `:inert` rule is exempt at the caller (`checks/check-rule!`): it runs in neither
+  engine by construction, so it claims nothing the index has to honour."
   [sentence]
   (when-let [bad (seq (variable-functor-literals sentence))]
-    (let [[role lit] (first bad)]
+    (let [[role lit] (first bad)
+          stamped?   (contains? #{:generated-antecedent :generated-consequent} role)]
       (throw (ex-info (str "a rule's predicate cannot be a variable: " (pr-str lit)
-                           " in the " (case role :consequent "consequent" "antecedent")
+                           " in the "
+                           (case role
+                             :consequent           "consequent"
+                             :generated-consequent "generated rule's consequent"
+                             :generated-antecedent "generated rule's antecedent"
+                             "antecedent")
                            " — the rule index is keyed by predicate, so a variable"
                            " functor is stored under a key no fact and no goal ever"
-                           " reads, and the rule answers no query.  Assert the"
-                           " instantiated rules, one per predicate it ranges over.")
+                           " reads, and the rule answers no query.  "
+                           (if stamped?
+                             (str "Nothing an enclosing generator binds fills it: move"
+                                  " the literal that binds it out one level, so the"
+                                  " functor is ground before the rule is stamped.")
+                             (str "Assert the instantiated rules, one per predicate it"
+                                  " ranges over, or stamp them from a generator whose"
+                                  " antecedent binds the predicate.")))
                       {:type :not-indexable :role role :literal lit
                        :literals (mapv second bad) :sentence sentence})))))

--- a/src/vaelii/impl/sentex.clj
+++ b/src/vaelii/impl/sentex.clj
@@ -1535,8 +1535,9 @@
     reads, so the literal matches nothing (`ist-read-problem`);
   * a nested `implies` anywhere but a rule's consequent — a rule is a sentence, not a
     literal, and consequent position is the one place it means something else: a
-    **generator**, whose firing stamps the inner rule out (docs/generators.md).  A
-    third level is refused, so a generator generates a rule and not another generator;
+    **generator**, whose firing stamps the inner rule out (docs/generators.md).  The
+    nesting is not capped there: a stamped rule may stamp one in turn, and each level
+    is checked in the ordinary rule roles;
   * a negated rule — `not` over an `implies`, bare or wrapped: negation lives on
     facts, and what a rule's negation would mean is said as an exception or a
     retraction instead (the record has no shape for it — a rule under `not` would
@@ -1591,26 +1592,20 @@
             (cond
               (not= 3 n)
               [(str "implies takes antecedents and one consequent, got arity " (dec n))]
-              (= :sentence role)
-              (into (vec (mapcat #(walk :antecedent %) (rule-antecedents form)))
-                    (walk :consequent (rule-consequent form)))
               ;; A rule **in consequent position** is a generator's head: the rule its
               ;; firing stamps out (docs/generators.md).  Its own parts are checked in
               ;; the ordinary rule roles, so every arm below — `ist`, a head
               ;; existential, a negated antecedent — holds of the stamped rule exactly
-              ;; as it holds of a written one.
+              ;; as it holds of a written one, at whatever depth it sits.
               ;;
-              ;; One level, and the third is refused here rather than by recursion:
-              ;; the scoping rule that makes a generator readable is that the stamped
-              ;; rule's free variables are its own, and a rule that stamps a generator
-              ;; would need two such splits in one sentence with nothing in the
-              ;; spelling to say which variable belongs to which.
-              (= :consequent role)
-              (let [c (rule-consequent form)]
-                (into (vec (mapcat #(walk :antecedent %) (rule-antecedents form)))
-                      (if (implies? (peek (peel-rule-wrapper c)))
-                        ["a generated rule cannot itself generate a rule; a rule generator nests one level"]
-                        (walk :consequent c))))
+              ;; The recursion is the whole of the nesting rule: a stamped rule that
+              ;; stamps a rule is read here exactly as the one above it was, and the
+              ;; scoping rule composes to match — a variable belongs to the outermost
+              ;; level whose antecedents mention it (`rules/nesting`), which is the
+              ;; level whose firing grounds it.
+              (contains? #{:sentence :consequent} role)
+              (into (vec (mapcat #(walk :antecedent %) (rule-antecedents form)))
+                    (walk :consequent (rule-consequent form)))
               :else
               [(str "a rule cannot stand as a " (clojure.core/name role) " literal")])
             (head-exists? form)

--- a/test/vaelii/generator_test.clj
+++ b/test/vaelii/generator_test.clj
@@ -29,9 +29,14 @@
   (filter :antecedent (v/sentexes-in-context kb ctx)))
 
 (defn- stamped
-  "The rules in `ctx` that a generator minted — every stored rule but the generators."
+  "The rules in `ctx` that conclude a fact — every stored rule but the generators."
   [kb ctx]
   (remove vr/generator-sentex? (rule-sentexes kb ctx)))
+
+(defn- generators
+  "The stored rules in `ctx` that conclude a rule, at any nesting depth."
+  [kb ctx]
+  (filter vr/generator-sentex? (rule-sentexes kb ctx)))
 
 ;; ---- the shape works ------------------------------------------------------
 
@@ -180,9 +185,14 @@
   (try (v/assert kb sentence 'CxUniverse) :accepted
        (catch clojure.lang.ExceptionInfo e (:type (ex-data e)))))
 
-(tu/deftest-kb a-generated-rule-cannot-itself-generate
+(tu/deftest-kb a-level-that-fills-nothing-new-is-refused
+  ;; The per-level form of `a-generator-sharing-no-variable-is-refused`, and under
+  ;; nesting it is a mistake the *outer* fill creates: `?x` is a hole of the first
+  ;; level, so it is already ground when the second level is stored, and that level
+  ;; stamps the same rule at every firing.  Saying so at the sentence is what keeps it
+  ;; out of the ledger, one mint at a time.
   (tu/with-terms [aa bb cc dd]
-    (is (= :not-well-formed
+    (is (= :not-range-restricted
            (refusal kb (list 'implies (list aa '?x)
                              (list 'implies (list bb '?x)
                                    (list 'implies (list cc '?x) (list dd '?x)))))))))
@@ -293,22 +303,213 @@
 (tu/deftest-kb check-predicts-assert-on-every-generator-refusal
   ;; the repo's contract, and it matters most at the one door that writes two records:
   ;; an editor validating a generator must be told what the firing would refuse
-  (tu/with-terms [marker dst aa bb cc dd]
+  (tu/with-terms [marker dst aa bb cc dd mid inner]
     (doseq [[label sentence]
-            [["depth 2"      (list 'implies (list aa '?x)
-                                   (list 'implies (list bb '?x)
-                                         (list 'implies (list cc '?x) (list dd '?x))))]
+            [["a level that fills nothing new"
+              (list 'implies (list aa '?x)
+                    (list 'implies (list bb '?x)
+                          (list 'implies (list cc '?x) (list dd '?x))))]
              ["backward"     (list 'set/backwardRule
                                    (list 'implies (list marker '?p)
                                          (list 'implies (list '?p '?x) (list dst '?x))))]
+             ["backward on a middle level"
+              (list 'implies (list marker '?p)
+                    (list 'set/backwardRule
+                          (list 'implies (list '?p '?q)
+                                (list 'implies (list '?q '?x) (list dst '?x)))))]
+             ["an exceptWhen an inner level carries"
+              (list 'implies (list marker '?p)
+                    (list 'implies (list '?p '?q)
+                          (list 'exceptWhen (list mid '?x)
+                                (list 'implies (list '?q '?x) (list dst '?x)))))]
+             ["a functor no level binds, three levels in"
+              (list 'implies (list marker '?p)
+                    (list 'implies (list '?p '?q)
+                          (list 'implies (list 'and (list '?q '?x) (list '?zz '?x))
+                                (list dst '?x))))]
              ["loose var"    (list 'implies (list marker '?p)
-                                   (list 'implies (list '?p '?x) (list dst '?x '?loose)))]]]
+                                   (list 'implies (list '?p '?x) (list dst '?x '?loose)))]
+             ["loose var, three levels in"
+              (list 'implies (list marker '?p)
+                    (list 'implies (list '?p '?q)
+                          (list 'implies (list '?q '?x) (list inner '?x '?loose))))]]]
       (testing label
         (let [predicted (v/check kb sentence 'CxUniverse)
               thrown    (refusal kb sentence)]
           (is (seq predicted) "check reports a problem")
           (is (= thrown (:type (first predicted)))
               "and it is the one assert throws"))))))
+
+;; ---- nesting: a stamped rule may stamp one in turn ------------------------
+;; The scoping rule composes, so nothing is capped: a variable belongs to the outermost
+;; level whose antecedents mention it, and that level's firing grounds it.  What the
+;; extra level buys is a functor: a predicate bound *further out* is concrete before the
+;; rule that uses it is stored, so a family of predicates can range over a family of
+;; types without the index ever seeing a variable in functor position.
+
+(tu/deftest-kb a-generator-may-stamp-a-generator
+  ;; the type-level/instance-level bridge, stated once instead of once per pair: the
+  ;; outer level fills the two predicates, the middle fills the type, and what is stored
+  ;; at the bottom is an ordinary rule over concrete functors
+  (tu/with-terms [typeVersion hasCap capType bird flying Tweety]
+    (v/assert kb (list 'implies (list typeVersion '?ipred '?tpred)
+                       (list 'implies (list '?tpred '?type '?cap)
+                             (list 'implies (list '?type '?instance)
+                                   (list '?ipred '?instance '?cap))))
+              'CxUniverse)
+    (testing "the pair fact stamps a generator, not a rule"
+      (v/assert kb (list typeVersion hasCap capType) 'CxUniverse)
+      (is (= 2 (count (generators kb 'CxUniverse))) "the written one and its mint")
+      (is (empty? (stamped kb 'CxUniverse)) "and nothing that concludes a fact yet"))
+    (testing "the type-level fact stamps the rule the mint was for"
+      (v/assert kb (list capType bird flying) 'CxUniverse)
+      (is (= 1 (count (stamped kb 'CxUniverse))))
+      (is (= bird (first (vr/antecedent-predicates
+                          (:sentence (first (stamped kb 'CxUniverse))))))
+          "keyed on the type, which was a variable two levels up"))
+    (testing "and the instance-level conclusion follows"
+      (v/assert kb (list bird Tweety) 'CxUniverse)
+      (is (= #{flying} (into #{} (map '?c) (v/ask kb (list hasCap Tweety '?c) 'CxUniverse)))))))
+
+(tu/deftest-kb an-outer-level-binds-the-functor-a-middle-one-cannot
+  ;; the distinction nesting exists for, in one pair of sentences.  Both write the same
+  ;; join; only the nested one stores rules the index can key.
+  (tu/with-terms [typeVersion hasCap capType]
+    (testing "same level: the type is bound by a literal of the rule being stored"
+      (is (= :not-indexable
+             (refusal kb (list 'implies (list typeVersion '?ipred '?tpred)
+                               (list 'implies (list 'and (list '?tpred '?type '?cap)
+                                                    (list '?type '?instance))
+                                     (list '?ipred '?instance '?cap)))))))
+    (testing "a level out: the type is a hole of the middle level, ground before it stores"
+      (is (= :accepted
+             (refusal kb (list 'implies (list typeVersion '?ipred '?tpred)
+                               (list 'implies (list '?tpred '?type '?cap)
+                                     (list 'implies (list '?type '?instance)
+                                           (list '?ipred '?instance '?cap))))))))))
+
+(tu/deftest-kb nesting-is-not-capped
+  ;; three levels, so the middle mint is itself a generator that stamps a generator.
+  ;; What bounds a generator is the cycle check, not the depth.
+  (tu/with-terms [aFor m1 m2 m3 endsAt Zed]
+    (v/assert kb (list 'implies (list aFor '?p)
+                       (list 'implies (list '?p '?q)
+                             (list 'implies (list '?q '?r)
+                                   (list 'implies (list '?r '?x) (list endsAt '?x)))))
+              'CxUniverse)
+    (v/assert kb (list aFor m1) 'CxUniverse)
+    (v/assert kb (list m1 m2) 'CxUniverse)
+    (v/assert kb (list m2 m3) 'CxUniverse)
+    (v/assert kb (list m3 Zed) 'CxUniverse)
+    (is (v/ask? kb (list endsAt Zed) 'CxUniverse))
+    (is (empty? (v/violations kb)) "every level's mint stood on its own")
+    (is (= 3 (count (generators kb 'CxUniverse))) "the written generator and two mints")
+    (is (= 1 (count (stamped kb 'CxUniverse))) "and one rule at the bottom")))
+
+(tu/deftest-kb retracting-an-outer-fill-unwinds-the-whole-chain
+  ;; a mint is derived content at every level, so one relabel takes the chain: the fill
+  ;; goes, the generator it stamped stops being believed, the rule *that* stamped goes
+  ;; with it, and so does the conclusion
+  (tu/with-terms [typeVersion hasCap capType bird flying Tweety]
+    (v/assert kb (list 'implies (list typeVersion '?ipred '?tpred)
+                       (list 'implies (list '?tpred '?type '?cap)
+                             (list 'implies (list '?type '?instance)
+                                   (list '?ipred '?instance '?cap))))
+              'CxUniverse)
+    (let [pair (v/assert kb (list typeVersion hasCap capType) 'CxUniverse)]
+      (v/assert kb (list capType bird flying) 'CxUniverse)
+      (v/assert kb (list bird Tweety) 'CxUniverse)
+      (is (seq (v/ask kb (list hasCap Tweety '?c) 'CxUniverse)))
+      (let [minted (mapv :id (remove #(vr/generator-sentex? %)
+                                     (rule-sentexes kb 'CxUniverse)))]
+        (v/retract! kb pair)
+        (testing "the conclusion goes"
+          (is (empty? (v/ask kb (list hasCap Tweety '?c) 'CxUniverse))))
+        (testing "and so does every rule the chain minted, at both levels"
+          (is (every? #(not (v/in? kb %)) minted))
+          (is (= 1 (count (filter #(v/in? kb (:id %)) (rule-sentexes kb 'CxUniverse))))
+              "only the generator the author wrote is left"))))))
+
+(tu/deftest-kb both-arrival-orders-agree-under-nesting
+  ;; order independence again, now over three levels: each level's mint is a datum that
+  ;; joins over what is already stored, so no arrival order needs a sweep of its own
+  (let [run (fn [reverse?]
+              (tu/with-terms [typeVersion hasCap capType bird flying Tweety]
+                (let [gen   #(v/assert kb (list 'implies (list typeVersion '?ipred '?tpred)
+                                                (list 'implies (list '?tpred '?type '?cap)
+                                                      (list 'implies (list '?type '?instance)
+                                                            (list '?ipred '?instance '?cap))))
+                                       'CxUniverse)
+                      facts #(do (v/assert kb (list bird Tweety) 'CxUniverse)
+                                 (v/assert kb (list capType bird flying) 'CxUniverse)
+                                 (v/assert kb (list typeVersion hasCap capType) 'CxUniverse))]
+                  (if reverse? (do (facts) (gen)) (do (gen) (facts)))
+                  {:derived (into #{} (map '?c) (v/ask kb (list hasCap Tweety '?c)
+                                                       'CxUniverse))
+                   :flying  flying})))
+        a   (run false)
+        b   (run true)]
+    (is (= #{(:flying a)} (:derived a)) "generator first derives the conclusion")
+    (is (= #{(:flying b)} (:derived b)) "facts first derives it too")))
+
+(tu/deftest-kb a-middle-level-owes-what-a-generator-owes
+  ;; every level reaches the store as a rule, and the mint reads the same check list the
+  ;; assert door does — so a wrapper or a guard the firing could not honour is refused
+  ;; at the sentence rather than one mint later
+  (tu/with-terms [marker dst blocked]
+    (testing "a backward wrapper on a middle level"
+      (is (= :not-indexable
+             (refusal kb (list 'implies (list marker '?p)
+                               (list 'set/backwardRule
+                                     (list 'implies (list '?p '?q)
+                                           (list 'implies (list '?q '?x) (list dst '?x)))))))))
+    (testing "an exceptWhen on an inner level, which no firing can split off"
+      (is (= :not-well-formed
+             (refusal kb (list 'implies (list marker '?p)
+                               (list 'implies (list '?p '?q)
+                                     (list 'exceptWhen (list blocked '?x)
+                                           (list 'implies (list '?q '?x)
+                                                 (list dst '?x)))))))))
+    (testing "and the innermost rule still owes its own range restriction"
+      (is (= :not-range-restricted
+             (refusal kb (list 'implies (list marker '?p)
+                               (list 'implies (list '?p '?q)
+                                     (list 'implies (list '?q '?x)
+                                           (list dst '?x '?loose))))))))))
+
+(tu/deftest-kb a-nested-mint-that-cannot-stand-is-dropped-and-recorded
+  ;; the mint door under nesting: a fill can make the *middle* rule junk, and the
+  ;; firing must record it rather than throw — the fixpoint is halfway through itself
+  (tu/with-terms [typeVersion capType]
+    (v/assert kb (list 'implies (list typeVersion '?ipred '?tpred)
+                       (list 'implies (list '?tpred '?type '?cap)
+                             (list 'implies (list '?type '?instance)
+                                   (list '?ipred '?instance '?cap))))
+              'CxUniverse)
+    (v/clear-violations! kb)
+    ;; a number in the instance-level predicate's place heads a literal no index can key
+    (v/assert kb (list typeVersion 7 capType) 'CxUniverse)
+    (is (empty? (stamped kb 'CxUniverse)) "nothing was stored for it")
+    (is (= 1 (count (generators kb 'CxUniverse))) "and no generator was minted either")
+    (is (seq (v/violations kb)) "the drop is readable")))
+
+(tu/deftest-kb a-cycle-through-a-nested-generator-is-refused
+  ;; the cycle check reads the *innermost* conclusion, because that is what reaches the
+  ;; fact store — the levels between conclude rules, under a key no fact carries
+  (tu/with-terms [mm nn kk pp]
+    (testing "a nested generator that feeds itself"
+      (is (= :not-stratified
+             (refusal kb (list 'implies (list mm '?p)
+                               (list 'implies (list '?p '?q)
+                                     (list 'implies (list '?q '?x) (list mm '?x))))))))
+    (testing "and one whose innermost conclusion another generator reads"
+      (is (= :accepted
+             (refusal kb (list 'implies (list nn '?p)
+                               (list 'implies (list '?p '?q)
+                                     (list 'implies (list '?q '?x) (list kk '?x)))))))
+      (is (= :not-stratified
+             (refusal kb (list 'implies (list 'and (list kk '?o) (list pp '?o))
+                               (list 'implies (list '?o '?a) (list pp '?a)))))))))
 
 ;; ---- the mint goes through the same door ---------------------------------
 


### PR DESCRIPTION
Refs #24 — this is option 2 from that issue, generalized: the nesting is not capped at two levels.

## What changes

A generator (a rule whose consequent is a rule) may stamp a generator, at any depth, and **a variable an enclosing level fills may head a literal**. The scoping rule needed nothing added to it: a variable belongs to the *outermost* level whose antecedents mention it, which is the level whose firing grounds it.

```clojure
;; accepted — ?type is a hole of the middle level, ground before the rule using it
;; as a functor is stored
(implies (typeVersion ?ipred ?tpred)
         (implies (?tpred ?type ?cap)
                  (implies (?type ?instance)
                           (?ipred ?instance ?cap))))
```

`(typeVersion hasCapability capabilityType)` stamps a generator; `(capabilityType bird flying)` stamps `(implies (bird ?x) (hasCapability ?x flying))`; `(bird Tweety)` concludes. Retracting the pair fact un-believes both mints and the conclusion through the ordinary relabel — every level is derived content.

## What stays refused

- **A variable functor in a top-level antecedent** — nothing encloses it, so nothing fills it (`:not-indexable`, unchanged).
- **The same join written flat** — `(implies (and (?tpred ?type ?cap) (?type ?instance)) …)` is still `:not-indexable`: `?type` is bound by a literal of the rule *being stored*, so the stored rule still has a variable in functor position.
- Per level, and now at **both** doors (`checks/check-rule!`, so a *minted* generator owes them too): `set/backwardRule` on a level that stamps → `:not-indexable`; an `exceptWhen` on any stamped level → `:not-well-formed`; a level filling no hole an enclosing one already filled → `:not-range-restricted`. The cycle check reads the innermost conclusion, the only level that concludes a fact.

`check` predicts every one of them.

## Tests and docs

- `test/vaelii/generator_test.clj` — 11 new cases: the bridge end to end, enclosing-vs-same-level, depth 3, the retraction cascade, both arrival orders, the per-level refusals, a nested mint dropped into the violation ledger, and a cycle through nesting.
- `docs/generators.md` — new **Nesting** section, updated refusal table and code map; `docs/indexing.md`, `docs/inference.md`, `docs/namespaces.md`, `docs/README.md`.
- `CHANGELOG.md` — one **Additive** entry under `0.7.1 — unreleased`.

## Verification

| run | result |
|---|---|
| `lein test` | 2987 tests, 138370 assertions, 0 failures |
| `lein test :all` | 3011 tests, 257492 assertions, 0 failures |
| `lein lint` | 9/9 clean |
| `lein perf` | 30/30 |
| sweep `hier-off` | 2987 tests, 138370 assertions, 0 failures |
| backend `disk-columnar` | 2987 tests, 138366 assertions, 0 failures (the documented `:fan` gap on a columnar arm) |
