### PR TITLE
fix(meta-constraints): interArgIsa trigger generalizes contravariantly

### DIFF
--- a/resources/kb/CxCore.txt
+++ b/resources/kb/CxCore.txt
@@ -57,11 +57,13 @@
 (argIsa argIsa 1 predicate)
 (argIsa argIsa 2 integer)
 (argGenl argIsa 3 thing)
-;; argIsa / argGenl / interArgIsa generalize up genl on the query surface the way check
-;; walks them internally — answered by provers/MetaConstraintProver, and deliberately
-;; NOT declared transitiveInArg: the meta-predicates are among the most-queried there are,
-;; and routing them through the general preservation prover taxes every genl lookup in
-;; the KB.  arity stays a plain fact (a sub-predicate may carry its own signature).
+;; argIsa / argGenl / interArgIsa generalize along genl on the query surface the way
+;; check walks them internally — a stored subtype constraint answers its supertypes, and
+;; interArgIsa's trigger (arg 3), being an antecedent, answers its subtypes instead.
+;; Answered by provers/MetaConstraintProver, and deliberately NOT declared
+;; transitiveInArg: the meta-predicates are among the most-queried there are, and routing
+;; them through the general preservation prover taxes every genl lookup in the KB.  arity
+;; stays a plain fact (a sub-predicate may carry its own signature).
 
 (comment interArgIsa
          "(interArgIsa ?predicate ?position1 ?type1 ?position2 ?type2) means that whenever argument ?position1 of ?predicate is a ?type1, argument ?position2 must be a ?type2. The conditional argument constraint, and it says what argIsa cannot: (interArgIsa eats 1 carnivore 2 meat) types the second argument only for the eaters that are carnivores, where (argIsa eats 2 meat) would demand meat of every eater. Open-world in both directions, and they point opposite ways — silence about the trigger argument's type leaves the constraint dormant rather than firing it, while silence about the target argument's is what convicts. Checked through genl transitivity from the writing context, like argIsa, and it entails the same way under assertive argument types.")

--- a/src/vaelii/impl/provers.clj
+++ b/src/vaelii/impl/provers.clj
@@ -1354,24 +1354,37 @@
 ;;
 ;; The predicate position reaches DOWN (a constraint on a super binds its
 ;; specializations — `constraining-predicates` is the super-predicate up-walk `check`
-;; uses), each type position reaches UP (a stored subtype constraint answers its
-;; supertypes — `genl?`).  On-demand and non-materializing, so it follows belief with no
-;; cache and `sentexes-matching` still shows only what was stored.  `arity` is NOT here:
-;; a sub-predicate may carry a signature of its own, and the answer would need the
-;; forward `arity`⇒type cycle a backward prover cannot fire; `check`'s `inherited-arity`
-;; still holds a silent sub-predicate to its supers.
+;; uses).  A type position's direction is its variance.  An *unconditional* type reaches
+;; UP (a stored subtype constraint answers its supertypes — `genl?`): `argIsa`/`argGenl`
+;; position 3 and `interArgIsa`'s target position 5.  `interArgIsa`'s *trigger* position
+;; 3 is the antecedent of a conditional, so it is contravariant and reaches DOWN: a
+;; stored `(interArgIsa P n animal m U)` already convicts every `mammal`-trigger fact (a
+;; mammal is an animal), so it answers the narrower `(interArgIsa P n mammal m U)` but
+;; never the wider `(… n thing m U)`, which would convict the non-animals `check` never
+;; touches.  Getting the trigger backwards is both unsound (the widening) and incomplete
+;; (the narrowing) against what `check` enforces — the same `assert`/`ask` agreement #20
+;; is about.  On-demand and non-materializing, so it follows belief with no cache and
+;; `sentexes-matching` still shows only what was stored.  `arity` is NOT here: a
+;; sub-predicate may carry a signature of its own, and the answer would need the forward
+;; `arity`⇒type cycle a backward prover cannot fire; `check`'s `inherited-arity` still
+;; holds a silent sub-predicate to its supers.
 (def ^:private meta-constraint-shape
   "By functor: the goal-list index of the predicate, the position-number indices that
-  must match a stored declaration exactly, and the type indices that reach up `genl`."
-  '{argIsa      {:pred 1 :fixed [2] :types [3]}
-    argGenl     {:pred 1 :fixed [2] :types [3]}
-    interArgIsa {:pred 1 :fixed [2 4] :types [3 5]}})
+  must match a stored declaration exactly, the type indices that reach UP `genl`
+  (covariant — a stored subtype answers its supertypes) and those that reach DOWN
+  (contravariant — a stored supertype answers its subtypes).  Only `interArgIsa`'s
+  trigger is contravariant; its target and the unconditional `argIsa`/`argGenl` type are
+  covariant."
+  '{argIsa      {:pred 1 :fixed [2] :types-up [3]}
+    argGenl     {:pred 1 :fixed [2] :types-up [3]}
+    interArgIsa {:pred 1 :fixed [2 4] :types-up [5] :types-down [3]}})
 
 (defn- meta-generalizes?
   "Does a stored declaration on `goal`'s predicate or a super-predicate answer `goal`
-  once its type positions are read up the `genl` closure?"
+  once each type position is read the way its variance allows — covariant positions up
+  the `genl` closure, the contravariant trigger down it?"
   [kb goal context]
-  (when-let [{:keys [pred fixed types]} (meta-constraint-shape (nm/functor goal))]
+  (when-let [{:keys [pred fixed types-up types-down]} (meta-constraint-shape (nm/functor goal))]
     (let [tax  (:taxonomy kb)
           k    (nm/functor goal)
           gvec (vec goal)
@@ -1385,7 +1398,10 @@
              (fn [[_h b]]
                (let [sval (fn [i] (if (= i pred) p' (get b (symbol (str "?g" i)))))]
                  (and (every? #(= (sval %) (nth gvec %)) fixed)
-                      (every? #(tax/genl? tax (sval %) (nth gvec %) context) types))))
+                      ;; covariant: the stored type sits at or below the queried one
+                      (every? #(tax/genl? tax (sval %) (nth gvec %) context) types-up)
+                      ;; contravariant: the queried type sits at or below the stored one
+                      (every? #(tax/genl? tax (nth gvec %) (sval %) context) types-down))))
              (res/matches-visible kb probe context))))
         (res/constraining-predicates kb k qp context))))))
 

--- a/test/vaelii/argpreserving_meta_test.clj
+++ b/test/vaelii/argpreserving_meta_test.clj
@@ -1,15 +1,22 @@
 ;; SPDX-License-Identifier: SSPL-1.0
 ;; Copyright © 2026 Vaelii LLC and the Vaelii contributors.
 (ns vaelii.argpreserving-meta-test
-  "The meta-predicates carry `transitiveInArg` / `transitiveInArgInverse` on their own
-  argument positions, so the query surface answers the same generalizations `check`
-  already walks internally.  Before this, a stored `(argIsa petMammal 1 mammal)` was
-  the only thing `(ask (argIsa petMammal 1 animal))` could return — nothing — even
-  though `(genl mammal animal)` holds and `check` would accept an animal there.  The
-  fix is data, not engine: declaring the meta-predicates preserved along `genl` on
-  themselves (position 3/5 up the type, position 1 down the predicate) closes #20.
+  "The argument-type meta-predicates answer along the `genl` closure on the query
+  surface, so `ask` agrees with the generalization `check` already walks internally.
+  Before this, a stored `(argIsa petMammal 1 mammal)` was the only thing
+  `(ask (argIsa petMammal 1 animal))` could return — nothing — even though
+  `(genl mammal animal)` holds and `check` would accept an animal there, closing #20.
 
-  The KB here is CxCore alone, so what these tests read is the *shipped* declaration
+  The engine answers it in `provers/MetaConstraintProver`, a bounded closure walk, and
+  NOT by declaring the meta-predicates `transitiveInArg` — that would tax every one of
+  the KB's very many `argIsa`/`argGenl` lookups (see `resources/kb/CxCore.txt`).  The
+  predicate position (1) reaches DOWN `genl` (a constraint on a super binds its
+  specializations); an unconditional type reaches UP (a stored subtype answers its
+  supertypes — `argIsa`/`argGenl` position 3, `interArgIsa`'s target position 5); and
+  `interArgIsa`'s trigger position 3, being an antecedent, is contravariant and reaches
+  DOWN.
+
+  The KB here is CxCore alone, so what these tests read is the *shipped* vocabulary
   and not one they stated."
   (:require [clojure.test :refer [is testing use-fixtures]]
             [vaelii.core :as v]
@@ -66,20 +73,32 @@
       (is (v/ask? kb (list 'argGenl typeRel 1 animal) C))
       (is (empty? (v/sentexes-matching kb (list 'argGenl typeRel 1 animal) '?ctx))))))
 
-(tu/deftest-kb interArgIsa-answers-up-both-type-positions
-  ;; positions 3 and 5 are the two types; each is transitiveInArgInverse along genl
-  (tu/with-terms [myRel carnivore predator meat food]
+(tu/deftest-kb interArgIsa-trigger-narrows-down-target-widens-up
+  ;; The conditional constraint's two types have OPPOSITE variance.  The trigger
+  ;; (position 3) is the antecedent: `(interArgIsa myRel 1 carnivore 2 meat)` convicts
+  ;; every carnivore, so it convicts every lion (a lion is a carnivore) and answers the
+  ;; *subtype* trigger — but it says nothing about predators at large, so it does not
+  ;; answer the *supertype* trigger.  The target (position 5) is the consequent, an
+  ;; ordinary unconditional type: `meat` answers up to `food`.  Widening the trigger up
+  ;; (the old, wrong direction) would convict the non-carnivore predators `check` never
+  ;; touches — unsound; not answering the narrower lion trigger — incomplete.
+  (tu/with-terms [myRel lion carnivore predator meat food]
     (v/assert kb (list 'genl predator 'thing) C)
     (v/assert kb (list 'genl carnivore predator) C)
+    (v/assert kb (list 'genl lion carnivore) C)
     (v/assert kb (list 'genl food 'thing) C)
     (v/assert kb (list 'genl meat food) C)
     (v/assert kb (list 'interArgIsa myRel 1 carnivore 2 meat) C)
-    (testing "position 3 generalizes up its type"
-      (is (v/ask? kb (list 'interArgIsa myRel 1 predator 2 meat) C)))
-    (testing "position 5 generalizes up its type"
+    (testing "the trigger narrows DOWN — a subtype trigger is answered"
+      (is (v/ask? kb (list 'interArgIsa myRel 1 lion 2 meat) C)))
+    (testing "the trigger does NOT widen up — a supertype trigger convicts non-carnivores"
+      (is (not (v/ask? kb (list 'interArgIsa myRel 1 predator 2 meat) C))))
+    (testing "the target widens UP its type"
       (is (v/ask? kb (list 'interArgIsa myRel 1 carnivore 2 food) C)))
-    (testing "neither is materialized"
-      (is (empty? (v/sentexes-matching kb (list 'interArgIsa myRel 1 predator 2 meat) '?ctx))))))
+    (testing "trigger narrowed and target widened together"
+      (is (v/ask? kb (list 'interArgIsa myRel 1 lion 2 food) C)))
+    (testing "nothing is materialized"
+      (is (empty? (v/sentexes-matching kb (list 'interArgIsa myRel 1 lion 2 meat) '?ctx))))))
 
 (tu/deftest-kb arity-does-not-generalize-down-the-predicate
   ;; arity is deliberately NOT among the generalized meta-predicates.  Unlike a type


### PR DESCRIPTION
## Summary

`MetaConstraintProver` answered `(interArgIsa P n T m U)` on the query surface by reading **both** type positions up the `genl` closure. That is right for the target (position 5, the consequent) but backwards for the trigger (position 3, the antecedent).

A stored `(interArgIsa P n animal m U)` already convicts every `mammal`-trigger fact — a mammal is an animal — so it entails the *narrower* `(… n mammal m U)` and never the *wider* `(… n thing m U)`, which would convict the non-animals `check` never touches. Reading the trigger up was therefore both:

- **unsound** — it answered the widening `(… n thing m U)` yes; and
- **incomplete** — it missed the sound narrowing `(… n mammal m U)`,

against what `check` (`inter-arg-problem`) enforces. That is an `assert`/`ask` disagreement of the same class #20 was about, left unfixed for this one position when #20 landed.

## Change

- Split `meta-constraint-shape`'s `:types` into covariant `:types-up` and contravariant `:types-down`. `interArgIsa`'s trigger (position 3) is the only `:types-down`; its target (5) and the unconditional `argIsa`/`argGenl` type (3) stay covariant.
- `meta-generalizes?` reads each set the matching way — up positions `genl? stored goal`, down positions `genl? goal stored`.
- Rewrite the test that pinned the wrong direction (`interArgIsa-answers-up-both-type-positions` → `interArgIsa-trigger-narrows-down-target-widens-up`) and refresh the stale namespace / `CxCore.txt` comments.

Query-only and non-materializing as before; no new declarations, so the performance gate #20's fix rests on is untouched.

## Relation to #23

Supersedes #23. #20 was already fixed on `develop` by `MetaConstraintProver` (v0.9.0); this corrects one direction it got wrong. #23's remaining substantive content — the `interArgIsa` trigger being contravariant — is exactly this, which #23 encodes as `(argPreserving interArgIsa 3 genl)` + `(argPreservingInverse … 5 genl)`. Here it lands in the prover instead of as `transitiveInArg`/`argPreserving` declarations, keeping the meta-predicates off the general preservation path for the performance reason `CxCore.txt` records.

## Validation

- `lein test vaelii.argpreserving-meta-test vaelii.constraint-vocabulary-test` — 28 tests, 172 assertions, green on the `develop` base
- full `:default` suite green with the same change on the maintainer tree — 3278 tests, 143651 assertions