### PR TITLE
refuse meta-exceptions as ill-formed

### DIFF
--- a/src/vaelii/core.clj
+++ b/src/vaelii/core.clj
@@ -1284,6 +1284,15 @@
                    (when-let [ps (seq (special/wff-problems (:taxonomy kb) sentence))]
                      (throw (ex-info (str "not well-formed: " (str/join "; " ps))
                                      {:type :not-well-formed :sentence sentence})))
+                   ;; a meta-exception — (except (sentexHandle H)) where H is itself
+                   ;; an (except …) — is ill-formed: excepting an except is inert (the
+                   ;; visibility roster does not cascade), so the sentence would silently
+                   ;; do nothing.  Refused here so the caller learns immediately.
+                   (when-let [target-h (kb/except-target sentence)]
+                     (when-let [target-sx (p/get-sentex (:records kb) target-h)]
+                       (when (kb/except-target (:sentence target-sx))
+                         (throw (ex-info "not well-formed: meta-exception (excepting an except) is ill-formed"
+                                         {:type :not-well-formed :sentence sentence})))))
                    ;; the rule-set half of well-formedness, for the *other* thing that can
                    ;; close a cycle through negation: a genl / genlCx edge arriving
                    ;; underneath rules already stored (docs/exceptions.md).  Before anything

--- a/src/vaelii/impl/kb.clj
+++ b/src/vaelii/impl/kb.clj
@@ -1506,7 +1506,13 @@
   "The handle a visibility `(except (sentexHandle H))` sentence hides, or nil for any
   other sentence — including `(not (except …))`, whose functor is `not`.  The one shape
   test the roster keys on, so a sentence that is not an `except` costs a `=` on its
-  functor at the store choke point and nothing else."
+  functor at the store choke point and nothing else.
+
+  A **meta-exception** — `(except (sentexHandle E))` where E is itself an `(except …)` —
+  is ill-formed and refused at assert time.  The visibility roster does not cascade:
+  excepting an except hides the except from queries but does not restore visibility of
+  the fact the except was hiding.  Since the sentence would silently do nothing useful,
+  it is refused rather than stored inertly."
   [sentence]
   (when (and (sequential? sentence)
              (= sx/except-functor (first sentence))

--- a/test/vaelii/meta_sentex_test.clj
+++ b/test/vaelii/meta_sentex_test.clj
@@ -415,3 +415,35 @@
         (is (roster-agrees? kb [gp pm 'CxWell]))
         (is (not (v/ask? kb (list shiny gold) pm)) "and the read still follows it")
         (is (v/ask? kb (list shiny gold) gp))))))
+
+;; ---- except strength converse: monotonic except defeats default not-except -
+
+(tu/deftest-kb a-monotonic-except-defeats-a-default-not-except
+  ;; The converse of `a-defeated-except-does-not-hide`: a default (not (except H))
+  ;; cannot override a monotonic (except H) — strength wins, so the target stays hidden.
+  (let [ctx (tu/tmp-ctx "Conv") shiny (tu/tmp-pred) gold (tu/tmp-ind)]
+    (v/assert kb (list 'genlCx ctx 'CxWell) 'CxUniverse {:strength :monotonic})
+    (let [h (v/assert kb (list shiny gold) ctx {:strength :monotonic})]
+      (v/assert kb (list 'except (sx/sentex-handle h)) ctx {:strength :monotonic})
+      (is (not (v/ask? kb (list shiny gold) ctx)) "the monotonic except hides it")
+      (v/assert kb (list 'not (list 'except (sx/sentex-handle h))) ctx {:strength :default})
+      (testing "the default negation cannot defeat the monotonic except; the target stays hidden"
+        (is (not (v/ask? kb (list shiny gold) ctx)))))))
+
+;; ---- meta-exception: excepting an except ----------------------------------
+
+(tu/deftest-kb meta-exception-is-ill-formed
+  ;; A meta-exception — (except (sentexHandle E)) where E is itself an (except …) —
+  ;; is ill-formed: the visibility roster does not cascade, so the sentence would
+  ;; silently do nothing.  The KB refuses it at assert time.
+  (let [ctx (tu/tmp-ctx "MetaEx") shiny (tu/tmp-pred) gold (tu/tmp-ind)]
+    (v/assert kb (list 'genlCx ctx 'CxWell) 'CxUniverse {:strength :monotonic})
+    (let [h (v/assert kb (list shiny gold) ctx {:strength :monotonic})]
+      (testing "P is true after assertion"
+        (is (v/ask? kb (list shiny gold) ctx)))
+      (let [e (v/assert kb (list 'except (sx/sentex-handle h)) ctx {:strength :monotonic})]
+        (testing "P is hidden after excepting"
+          (is (not (v/ask? kb (list shiny gold) ctx))))
+        (testing "excepting the except is refused as ill-formed"
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"meta-exception.*ill-formed"
+                (v/assert kb (list 'except (sx/sentex-handle e)) ctx {:strength :monotonic}))))))))


### PR DESCRIPTION
A meta-exception — `(except (sentexHandle E))` where E is itself an `(except …)` — is inert: the visibility roster does not cascade, so hiding an except does not restore visibility of the fact it hid.

Rather than storing a silently inert sentence, refuse it at assert time with `:not-well-formed`. The check lives in `assert-one` alongside the existing wff-problems gate.

- Adds test `meta-exception-is-ill-formed` to `meta_sentex_test`
- Updates `except-target` docstring to document the invariant
- All 18 meta-sentex tests pass (139 assertions)