### PR TITLE
fix: nestable, contextual, read-time exception semantics

### DIFF
--- a/src/vaelii/core.clj
+++ b/src/vaelii/core.clj
@@ -1287,15 +1287,6 @@
                    (when-let [ps (seq (special/wff-problems (:taxonomy kb) sentence))]
                      (throw (ex-info (str "not well-formed: " (str/join "; " ps))
                                      {:type :not-well-formed :sentence sentence})))
-                   ;; a meta-exception — (except (sentexHandle H)) where H is itself
-                   ;; an (except …) — is ill-formed: excepting an except is inert (the
-                   ;; visibility roster does not cascade), so the sentence would silently
-                   ;; do nothing.  Refused here so the caller learns immediately.
-                   (when-let [target-h (kb/except-target sentence)]
-                     (when-let [target-sx (p/get-sentex (:records kb) target-h)]
-                       (when (kb/except-target (:sentence target-sx))
-                         (throw (ex-info "not well-formed: meta-exception (excepting an except) is ill-formed"
-                                         {:type :not-well-formed :sentence sentence})))))
                    ;; the rule-set half of well-formedness, for the *other* thing that can
                    ;; close a cycle through negation: a genl / genlCx edge arriving
                    ;; underneath rules already stored (docs/exceptions.md).  Before anything

--- a/src/vaelii/core.clj
+++ b/src/vaelii/core.clj
@@ -1287,6 +1287,15 @@
                    (when-let [ps (seq (special/wff-problems (:taxonomy kb) sentence))]
                      (throw (ex-info (str "not well-formed: " (str/join "; " ps))
                                      {:type :not-well-formed :sentence sentence})))
+                   ;; a meta-exception — (except (sentexHandle H)) where H is itself
+                   ;; an (except …) — is ill-formed: excepting an except is inert (the
+                   ;; visibility roster does not cascade), so the sentence would silently
+                   ;; do nothing.  Refused here so the caller learns immediately.
+                   (when-let [target-h (kb/except-target sentence)]
+                     (when-let [target-sx (p/get-sentex (:records kb) target-h)]
+                       (when (kb/except-target (:sentence target-sx))
+                         (throw (ex-info "not well-formed: meta-exception (excepting an except) is ill-formed"
+                                         {:type :not-well-formed :sentence sentence})))))
                    ;; the rule-set half of well-formedness, for the *other* thing that can
                    ;; close a cycle through negation: a genl / genlCx edge arriving
                    ;; underneath rules already stored (docs/exceptions.md).  Before anything

--- a/src/vaelii/core.clj
+++ b/src/vaelii/core.clj
@@ -5590,6 +5590,10 @@
       ;; a fork would answer its base's excepts off a roster of its own that nothing filled.
       ;; Before the settle for the same reason too — `justification-excepted?` reads it.
       (kb/rebuild-excepted! kb)
+      ;; The first cache reconcile ran before the visibility roster existed, so it
+      ;; could narrow only against JTMS belief. Re-run through the common transition
+      ;; boundary now that recovery can also answer which declarations are excepted.
+      (special/reconcile-belief-change! kb)
       ;; ...and the settle that finishes the rebuild is told it *is* one, so the exposure
       ;; pass stays out of it: what it reports is what a change newly made jointly visible,
       ;; and a restore changes nothing (`settle/*rebuilding?*`).  On the certified fast path

--- a/src/vaelii/impl/chain.clj
+++ b/src/vaelii/impl/chain.clj
@@ -1172,6 +1172,25 @@
                 (distinct))
           ctxs)))
 
+(defn- exception-aware-placements
+  "Placement candidates for `handles` while one of them is hidden somewhere.
+
+  Assertion contexts alone are no longer sufficient in that case: an exception can
+  hide a supporter at its own context while a meta-exception restores it in only one
+  descendant cone.  Enumerate the contexts that structurally see every assertion,
+  retain the readers that see every exact supporter, then keep only their maximal
+  elements.  `excepted-anywhere?` is the coarse gate, so the ordinary placement path
+  still takes no cone walk when none of this firing's supporters is targeted."
+  [kb handles contexts]
+  (let [tax (:taxonomy kb)]
+    (if (some #(res/excepted-anywhere? kb %) handles)
+      (let [common  (tax/common-descendants tax contexts)
+            visible (filter (fn [ctx]
+                              (every? #(res/supporter-visible? kb % ctx) handles))
+                            common)]
+        (tax/maximal-contexts tax visible))
+      (tax/maximal-common-descendant-contexts tax contexts))))
+
 (defn- placement-ingredients
   "Where a firing's conclusion may live, and which taxonomy supporters it names getting
   there: `[placement-contexts {placement-context [edge-handle]}]`.  Both relations are
@@ -1206,7 +1225,7 @@
   firing whose candidates *some* of which see a path keeps only those, and does not also
   descend below the others.  Placing under both would need the union re-maximalized, and
   the case — incomparable candidates disagreeing about one edge — is exotic."
-  [kb rule raw-c ist? links fact-ctxs]
+  [kb rule raw-c ist? links fact-handles fact-ctxs]
   (let [tax (:taxonomy kb)]
     (if ist?
       (let [c  (when (nm/context? (second raw-c)) (second raw-c))
@@ -1215,7 +1234,8 @@
           [[c] {c (into (mapv first hs) (visibility-support tax c (keep second hs)))}]
           [nil nil]))
       (let [ingredients (cons (:context rule) fact-ctxs)
-            base        (tax/maximal-common-descendant-contexts tax ingredients)]
+            supporters  (cons (:rule-handle rule) fact-handles)
+            base        (exception-aware-placements kb supporters ingredients)]
         (if (empty? links)
           ;; no subsumption to witness, so the whole support map is the visibility one —
           ;; and it is empty for the firing whose rule and facts are where the conclusion
@@ -1369,7 +1389,7 @@
   (let [ist?        (and (sequential? raw-c) (= sx/ist-functor (first raw-c)))
         conseq      (if ist? (nth raw-c 2) raw-c)         ; (ist Ctx S) concludes S ...
         fact-ctxs   (map :context facts)
-        [placements support] (placement-ingredients kb rule raw-c ist? links fact-ctxs)]
+        [placements support] (placement-ingredients kb rule raw-c ist? links handles fact-ctxs)]
     (if (empty? placements)
       ;; The join completed — every antecedent matched — and then the conclusion
       ;; evaporated: no context sees everything the firing rests on (sibling

--- a/src/vaelii/impl/integrate.clj
+++ b/src/vaelii/impl/integrate.clj
@@ -92,29 +92,33 @@
   Records the sentex into `*removed-sink*` when one is bound, which is how a caller
   learns the region a teardown removed without every removal path having to report it."
   [kb sentex]
-  ;; the removal record, for a caller scoping its own follow-up work to what left
-  (when-let [sink *removed-sink*] (vswap! sink conj sentex))
-  (special/disintegrate-sentex! kb sentex)
-  (p/unindex-sentex! (:index kb) sentex (:id sentex))
-  (p/delete-sentex! (:records kb) (:id sentex))
-  ;; the remove-side seam for an incremental matcher's alpha memories, mirroring the
-  ;; add in `kb/create-sentex` — a no-op unless one is engaged
-  (observe/notify-remove kb sentex)
-  ;; and the change clock, mirroring the same line there
-  (observe/note-change)
-  ;; the handle cache holds "this sentence is stored at this handle", and this is the
-  ;; one event that falsifies it — so the invalidation belongs beside the removal
-  ;; itself, not in the caller that happens to have a cache bound
-  (observe/forget-handle! (:sentence sentex) (:context sentex))
-  ;; maintain the P/¬P coincidence set (this removal may have dissolved an opposing
-  ;; pair); read after `unindex-sentex!` so the departing fact is already gone
-  (kb/note-opposed! kb (:sentence sentex))
-  ;; ...and the visibility roster, the remove half of `kb/create-sentex`'s add.  Order
-  ;; does not matter to this one — it reads the departing sentex rather than the index
-  (kb/note-excepted! kb sentex false)
-  ;; An except's departure changes the effective belief of the declaration it hid.
-  ;; Run after the roster drop so the common reconcile reads the new visibility state;
-  ;; report the visibility move explicitly because the exception record is already gone.
-  (when-let [target (kb/except-target (:sentence sentex))]
-    (special/reconcile-belief-change! kb #{target} true))
-  (special/recheck-on-sentence kb (:sentence sentex)))
+  ;; Capture the except target *before* any mutation — the sentex record is about to be
+  ;; deleted, so extracting it afterward would depend on the local binding outliving
+  ;; storage.  Binding here makes the before/after contract structural.
+  (let [except-target (kb/except-target (:sentence sentex))]
+    ;; the removal record, for a caller scoping its own follow-up work to what left
+    (when-let [sink *removed-sink*] (vswap! sink conj sentex))
+    (special/disintegrate-sentex! kb sentex)
+    (p/unindex-sentex! (:index kb) sentex (:id sentex))
+    (p/delete-sentex! (:records kb) (:id sentex))
+    ;; the remove-side seam for an incremental matcher's alpha memories, mirroring the
+    ;; add in `kb/create-sentex` — a no-op unless one is engaged
+    (observe/notify-remove kb sentex)
+    ;; and the change clock, mirroring the same line there
+    (observe/note-change)
+    ;; the handle cache holds "this sentence is stored at this handle", and this is the
+    ;; one event that falsifies it — so the invalidation belongs beside the removal
+    ;; itself, not in the caller that happens to have a cache bound
+    (observe/forget-handle! (:sentence sentex) (:context sentex))
+    ;; maintain the P/¬P coincidence set (this removal may have dissolved an opposing
+    ;; pair); read after `unindex-sentex!` so the departing fact is already gone
+    (kb/note-opposed! kb (:sentence sentex))
+    ;; ...and the visibility roster, the remove half of `kb/create-sentex`'s add.  Order
+    ;; does not matter to this one — it reads the departing sentex rather than the index
+    (kb/note-excepted! kb sentex false)
+    ;; An except's departure changes the effective belief of the declaration it hid.
+    ;; Run after the roster drop so the common reconcile reads the new visibility state;
+    ;; report the visibility move explicitly because the exception record is already gone.
+    (when except-target
+      (special/reconcile-belief-change! kb #{except-target} true))
+    (special/recheck-on-sentence kb (:sentence sentex))))

--- a/src/vaelii/impl/integrate.clj
+++ b/src/vaelii/impl/integrate.clj
@@ -112,4 +112,9 @@
   ;; ...and the visibility roster, the remove half of `kb/create-sentex`'s add.  Order
   ;; does not matter to this one — it reads the departing sentex rather than the index
   (kb/note-excepted! kb sentex false)
+  ;; An except's departure changes the effective belief of the declaration it hid.
+  ;; Run after the roster drop so the common reconcile reads the new visibility state;
+  ;; report the visibility move explicitly because the exception record is already gone.
+  (when-let [target (kb/except-target (:sentence sentex))]
+    (special/reconcile-belief-change! kb #{target} true))
   (special/recheck-on-sentence kb (:sentence sentex)))

--- a/src/vaelii/impl/kb.clj
+++ b/src/vaelii/impl/kb.clj
@@ -1509,10 +1509,10 @@
   functor at the store choke point and nothing else.
 
   A **meta-exception** — `(except (sentexHandle E))` where E is itself an `(except …)` —
-  is ill-formed and refused at assert time.  The visibility roster does not cascade:
-  excepting an except hides the except from queries but does not restore visibility of
-  the fact the except was hiding.  Since the sentence would silently do nothing useful,
-  it is refused rather than stored inertly."
+  cascades: hiding an except suppresses its effect, restoring visibility of the target
+  the inner except was hiding.  The cascade is evaluated at read time by
+  `resolution/excepted-handles`, which checks whether each except-handle is itself
+  hidden before counting it as active."
   [sentence]
   (when (and (sequential? sentence)
              (= sx/except-functor (first sentence))

--- a/src/vaelii/impl/kb.clj
+++ b/src/vaelii/impl/kb.clj
@@ -825,6 +825,11 @@
                      ;; points as `:opposed`, and rebuilt by `recover` for the same
                      ;; reason: it is derived from storage and no store holds it
                      :excepted  (atom {})
+                     ;; How many stored excepts target another except's handle.  When
+                     ;; zero, `except-in-force?` is trivially true for every except
+                     ;; and `excepted-handles` can skip the cascade entirely.  Maintained
+                     ;; at the same choke points as `:excepted` and rebuilt by `recover`.
+                     :meta-except-count (atom 0)
                      ;; `{pred -> how many rules take it as an antecedent}` — the roster
                      ;; `special/visibility-seeds` enumerates instead of walking a context
                      ;; cone.  Kept O(1) at the rule index/unindex choke points, exactly
@@ -1566,7 +1571,13 @@
   (when-let [target (except-target (:sentence sentex))]
     (let [ctx (:context sentex)
           eh  (:id sentex)]
-      (swap! (:excepted kb) (if add? roster-add roster-drop) ctx target eh))))
+      (swap! (:excepted kb) (if add? roster-add roster-drop) ctx target eh)
+      ;; Maintain the meta-except counter: a meta-except is an except whose target
+      ;; is itself an except-handle.  Check by looking up the target in records —
+      ;; if it resolves to an `(except ...)` sentence, this is a meta-except.
+      (when-let [target-sentex (p/get-sentex (:records kb) target)]
+        (when (except-target (:sentence target-sentex))
+          (swap! (:meta-except-count kb) (if add? inc dec)))))))
 
 (defn rebuild-excepted!
   "Recompute `:excepted` from storage — the scan `recover` needs, since the roster is
@@ -1577,16 +1588,29 @@
   Enumerates the stored `except` facts through the functor root, which spans both
   polarities — a `(not (except H))` roots there too and `except-target` drops it."
   [kb]
-  (let [recs (:records kb)]
-    (reset! (:excepted kb)
-            (reduce (fn [m h]
-                      (if-let [s (p/get-sentex recs h)]
-                        (if-let [target (except-target (:sentence s))]
-                          (roster-add m (:context s) target h)
-                          m)
-                        m))
-                    {}
-                    (p/sentexes-with-functor (:index kb) sx/except-functor)))))
+  (let [recs (:records kb)
+        roster (reduce (fn [m h]
+                         (if-let [s (p/get-sentex recs h)]
+                           (if-let [target (except-target (:sentence s))]
+                             (roster-add m (:context s) target h)
+                             m)
+                           m))
+                       {}
+                       (p/sentexes-with-functor (:index kb) sx/except-functor))
+        ;; Count meta-exceptions: excepts whose target is itself an except
+        meta-count (reduce (fn [n h]
+                             (if-let [s (p/get-sentex recs h)]
+                               (if-let [target (except-target (:sentence s))]
+                                 (if-let [ts (p/get-sentex recs target)]
+                                   (if (except-target (:sentence ts))
+                                     (inc n) n)
+                                   n)
+                                 n)
+                               n))
+                           0
+                           (p/sentexes-with-functor (:index kb) sx/except-functor))]
+    (reset! (:excepted kb) roster)
+    (reset! (:meta-except-count kb) meta-count)))
 
 (defn create-sentex
   "Store `sentence` in `context` as a new sentex, index it, and return `[handle sentex]`.

--- a/src/vaelii/impl/kb.clj
+++ b/src/vaelii/impl/kb.clj
@@ -883,7 +883,7 @@
     (tax/install-supporter-visibility!
      (:taxonomy kb)
      #(seq @(:excepted kb))
-     (partial res/supporter-effective? kb))
+     (partial res/supporter-believed? kb))
     (when snapshot? (register-index-snapshot! (disk/disk-dir opts) istore rstore))
     ;; The durable index is gated on its key-layout sentinel before anything reads
     ;; it: a log written under another `kv/index-layout-version` replays cleanly and

--- a/src/vaelii/impl/kb.clj
+++ b/src/vaelii/impl/kb.clj
@@ -876,6 +876,14 @@
                      ;; index half by this open — see `write-hazards`
                      :unrecovered (atom {})})
         snapshot? (snapshot-mode? rkind ikind)]
+    ;; Taxonomy owns derived structures; the KB owns whether one recorded supporter
+    ;; is believed and visible from a reader after context-scoped exceptions.  Install
+    ;; the seam only after the mutually-referential KB exists, and before recovery can
+    ;; ask any scoped cache question.
+    (tax/install-supporter-visibility!
+     (:taxonomy kb)
+     #(seq @(:excepted kb))
+     (partial res/supporter-effective? kb))
     (when snapshot? (register-index-snapshot! (disk/disk-dir opts) istore rstore))
     ;; The durable index is gated on its key-layout sentinel before anything reads
     ;; it: a log written under another `kv/index-layout-version` replays cleanly and

--- a/src/vaelii/impl/kb.clj
+++ b/src/vaelii/impl/kb.clj
@@ -1506,7 +1506,13 @@
   "The handle a visibility `(except (sentexHandle H))` sentence hides, or nil for any
   other sentence — including `(not (except …))`, whose functor is `not`.  The one shape
   test the roster keys on, so a sentence that is not an `except` costs a `=` on its
-  functor at the store choke point and nothing else."
+  functor at the store choke point and nothing else.
+
+  A **meta-exception** — `(except (sentexHandle E))` where E is itself an `(except …)` —
+  is ill-formed and refused at assert time.  The visibility roster does not cascade:
+  excepting an except hides the except from queries but does not restore visibility of
+  the fact the except was hiding.  Since the sentence would silently do nothing useful,
+  it is refused rather than stored inertly."
   [sentence]
   (when (and (sequential? sentence)
              (= sx/except-functor (first sentence))

--- a/src/vaelii/impl/resolution.clj
+++ b/src/vaelii/impl/resolution.clj
@@ -441,7 +441,7 @@
     (or (not (jtms/known-datum? tms handle))
         (jtms/in? tms handle))))
 
-(defn supporter-effective?
+(defn supporter-believed?
   "Is stored supporter `handle` believed and not excepted from `context`?
 
   Assertion-context inheritance is deliberately not answered here: taxonomy's scoped
@@ -460,7 +460,7 @@
   "Is stored supporter `handle` believed, inherited, and not excepted from `context`?"
   [kb handle context]
   (boolean
-   (and (supporter-effective? kb handle context)
+   (and (supporter-believed? kb handle context)
         (when-let [sentex (p/get-sentex (:records kb) handle)]
           (tax/sees? (:taxonomy kb) context (:context sentex))))))
 
@@ -1061,7 +1061,7 @@
             v)
           out)))))
 
-(defn- effectively-active?
+(defn- except-in-force?
   "Is except-handle `eh` believed **and** not itself hidden by a cascading meta-except?
   Recursive with a `seen` set as cycle guard (unreachable with well-formed input, since
   stratification forbids the cycle, but defensive).
@@ -1076,7 +1076,7 @@
          (let [meta-ehs (get target->ehs eh)]
            (if meta-ehs
              ;; eh is itself a target; active only if none of its meta-excepts are active
-             (not (some #(effectively-active? tms target->ehs % (conj seen eh)) meta-ehs))
+             (not (some #(except-in-force? tms target->ehs % (conj seen eh)) meta-ehs))
              ;; eh is not a target; it is active
              true)))))
 
@@ -1099,7 +1099,7 @@
 
   **Meta-exception cascade.**  An except whose handle is itself hidden by another
   believed except does not suppress its target — the cascade is evaluated at read time by
-  `effectively-active?`, which walks the roster's own entries rather than the index.
+  `except-in-force?`, which walks the roster's own entries rather than the index.
   Most KBs store zero meta-exceptions, so the cascade adds no cost to the common path.
 
   **The O(1) gate is the empty roster**, which is where the functor-root count used to
@@ -1137,7 +1137,7 @@
                          {} by-ctx)]
         (persistent!
          (reduce-kv (fn [acc target ehs]
-                      (if (some #(effectively-active? tms target->ehs % #{}) ehs)
+                      (if (some #(except-in-force? tms target->ehs % #{}) ehs)
                         (conj! acc target)
                         acc))
                     (transient #{})
@@ -1185,7 +1185,7 @@
           (fn [handle]
             (boolean
              (when-let [ehs (get target->ehs handle)]
-               (some #(effectively-active? tms target->ehs % #{}) ehs)))))))))
+               (some #(except-in-force? tms target->ehs % #{}) ehs)))))))))
 
 (defn excepted?
   "Is the sentex at `handle` hidden from `view-context` by a believed `except`?  The

--- a/src/vaelii/impl/resolution.clj
+++ b/src/vaelii/impl/resolution.clj
@@ -1134,10 +1134,15 @@
                              (reduce-kv (fn [m2 target ehs]
                                           (update m2 target (fnil into #{}) ehs))
                                         m entries)))
-                         {} by-ctx)]
+                         {} by-ctx)
+            ;; Meta-except counter gate: when zero, no except targets another except,
+            ;; so every believed except is trivially in force — skip the cascade.
+            has-meta? (pos? @(:meta-except-count kb))]
         (persistent!
          (reduce-kv (fn [acc target ehs]
-                      (if (some #(except-in-force? tms target->ehs % #{}) ehs)
+                      (if (if has-meta?
+                            (some #(except-in-force? tms target->ehs % #{}) ehs)
+                            (some #(jtms/in? tms %) ehs))
                         (conj! acc target)
                         acc))
                     (transient #{})
@@ -1182,10 +1187,13 @@
                                              m entries))
                                 {} live)]
         (when (seq live)
-          (fn [handle]
-            (boolean
-             (when-let [ehs (get target->ehs handle)]
-               (some #(except-in-force? tms target->ehs % #{}) ehs)))))))))
+          (let [has-meta? (pos? @(:meta-except-count kb))]
+            (fn [handle]
+              (boolean
+               (when-let [ehs (get target->ehs handle)]
+                 (if has-meta?
+                   (some #(except-in-force? tms target->ehs % #{}) ehs)
+                   (some #(jtms/in? tms %) ehs)))))))))))
 
 (defn excepted?
   "Is the sentex at `handle` hidden from `view-context` by a believed `except`?  The

--- a/src/vaelii/impl/resolution.clj
+++ b/src/vaelii/impl/resolution.clj
@@ -25,7 +25,7 @@
 
 ;; unify and unify-var are mutually recursive (a bound variable is chased back
 ;; through unify), so one forward declaration is genuinely required here.
-(declare unify-var)
+(declare unify-var excepted? excepted-anywhere?)
 
 (defn- dot-tail
   "The remaining sequence a dotted rest-variable binds to, as a canonical list."
@@ -441,19 +441,40 @@
     (or (not (jtms/known-datum? tms handle))
         (jtms/in? tms handle))))
 
+(defn supporter-effective?
+  "Is stored supporter `handle` believed and not excepted from `context`?
+
+  Assertion-context inheritance is deliberately not answered here: taxonomy's scoped
+  edge/cache readers already apply it, and genlCx declarations are forced universal.
+  Keeping this callback about belief force alone also prevents context reachability
+  from recursively asking itself whether its own supporters are reachable."
+  [kb handle context]
+  (boolean
+   (and (jtms/in? (:tms kb) handle)
+        ;; The whole-KB roster is the cheap gate. Only a handle targeted somewhere
+        ;; pays the context-sensitive cascade walk.
+        (or (not (excepted-anywhere? kb handle))
+            (not (excepted? kb handle context))))))
+
+(defn supporter-visible?
+  "Is stored supporter `handle` believed, inherited, and not excepted from `context`?"
+  [kb handle context]
+  (boolean
+   (and (supporter-effective? kb handle context)
+        (when-let [sentex (p/get-sentex (:records kb) handle)]
+          (tax/sees? (:taxonomy kb) context (:context sentex))))))
+
 (defn visible-supporter-fn
-  "`handle -> boolean`, memoized: does `context` see the context the sentex `handle`
-  was asserted from?  nil when `context` is nil or a `?var` — the unscoped path, which
-  every caller reads as *no filter* rather than as *nothing visible*.
+  "`handle -> boolean`, memoized: is the sentex `handle` believed, inherited by
+  `context`, and not hidden there by a visibility exception? nil when `context` is nil
+  or a `?var` — the unscoped path, which every caller reads as *no filter* rather than
+  as *nothing visible*.
 
   The seam a **context-scoped equality** read hangs on: the equality partition records
   its supporters as handles, and only the record store knows where each was asserted."
   [kb context]
   (when (and (symbol? context) (not (sx/variable? context)))
-    (let [tax (:taxonomy kb) recs (:records kb)]
-      (memoize (fn [h]
-                 (boolean (when-let [sx (p/get-sentex recs h)]
-                            (tax/sees? tax context (:context sx)))))))))
+    (memoize #(supporter-visible? kb % context))))
 
 (defn representative-in
   "`term`'s equality-class representative as `visible?` sees the merges — the global
@@ -1103,7 +1124,7 @@
   (let [by-ctx @(:excepted kb)]
     (if (or (empty? by-ctx) (sx/variable? view-context))
       #{}
-      (let [up  (tax/context-up (:taxonomy kb) view-context)
+      (let [up  (tax/raw-context-up (:taxonomy kb) view-context)
             tms (:tms kb)
             ;; flatten the visible roster into a single target->ehs map for cascade
             target->ehs (reduce-kv
@@ -1149,7 +1170,7 @@
   [kb view-context]
   (let [by-ctx @(:excepted kb)]
     (when-not (or (empty? by-ctx) (sx/variable? view-context))
-      (let [up  (tax/context-up (:taxonomy kb) view-context)
+      (let [up  (tax/raw-context-up (:taxonomy kb) view-context)
             ;; only the contexts that both state an except and are visible from here —
             ;; computed once, so the predicate walks nothing it will always reject
             live (into [] (comp (filter #(contains? up (key %))) (map val)) by-ctx)
@@ -1171,6 +1192,17 @@
   one-shot form of `hidden-fn`, for a caller with a single handle to ask about."
   [kb handle view-context]
   (boolean (when-let [hidden? (hidden-fn kb view-context)] (hidden? handle))))
+
+(defn excepted-anywhere?
+  "Is `handle` hidden from at least one context by a believed visibility `except`?
+
+  This is the unscoped belief-transition question used by the derived-cache
+  reconcile. The roster is keyed by the contexts that state exceptions, and a
+  context always sees itself, so those keys are a complete set of witnesses.
+  `excepted?` still performs the meta-exception cascade, so an except suppressed in
+  its own context does not count here."
+  [kb handle]
+  (boolean (some #(excepted? kb handle %) (keys @(:excepted kb)))))
 
 (defn without-excepted
   "Drop the `[handle …]` matches whose handle is hidden from `view-context` by a

--- a/src/vaelii/impl/resolution.clj
+++ b/src/vaelii/impl/resolution.clj
@@ -1040,6 +1040,25 @@
             v)
           out)))))
 
+(defn- effectively-active?
+  "Is except-handle `eh` believed **and** not itself hidden by a cascading meta-except?
+  Recursive with a `seen` set as cycle guard (unreachable with well-formed input, since
+  stratification forbids the cycle, but defensive).
+
+  The cascade semantics: `(except H)` hides H.  `(except E)` where E is the except that
+  hides H suppresses E's effect, restoring H.  `(except M)` where M is the meta-except
+  suppresses M, restoring E's effect, re-hiding H — and so on, toggling at each depth."
+  [tms target->ehs eh seen]
+  (and (jtms/in? tms eh)
+       (if (contains? seen eh)
+         false
+         (let [meta-ehs (get target->ehs eh)]
+           (if meta-ehs
+             ;; eh is itself a target; active only if none of its meta-excepts are active
+             (not (some #(effectively-active? tms target->ehs % (conj seen eh)) meta-ehs))
+             ;; eh is not a target; it is active
+             true)))))
+
 (defn excepted-handles
   "The handles hidden from `view-context` by believed `(except (sentexHandle H))`
   facts: an `except` asserted in a context `view-context` sees (its genlCx
@@ -1056,6 +1075,11 @@
   and re-derive its target from its sentence — which on a chaining run is per placement
   and per candidate justification, and was 89% of the run's wall clock at 1,000 excepts
   (`lein bench-hotreads`).
+
+  **Meta-exception cascade.**  An except whose handle is itself hidden by another
+  believed except does not suppress its target — the cascade is evaluated at read time by
+  `effectively-active?`, which walks the roster's own entries rather than the index.
+  Most KBs store zero meta-exceptions, so the cascade adds no cost to the common path.
 
   **The O(1) gate is the empty roster**, which is where the functor-root count used to
   be and is both cheaper and tighter: a KB storing only `(not (except H))` roots under
@@ -1080,16 +1104,23 @@
     (if (or (empty? by-ctx) (sx/variable? view-context))
       #{}
       (let [up  (tax/context-up (:taxonomy kb) view-context)
-            tms (:tms kb)]
+            tms (:tms kb)
+            ;; flatten the visible roster into a single target->ehs map for cascade
+            target->ehs (reduce-kv
+                         (fn [m ctx entries]
+                           (if-not (contains? up ctx)
+                             m
+                             (reduce-kv (fn [m2 target ehs]
+                                          (update m2 target (fnil into #{}) ehs))
+                                        m entries)))
+                         {} by-ctx)]
         (persistent!
-         (reduce-kv (fn [acc ctx entries]
-                      (if-not (contains? up ctx)                 ; visible from view-context
-                        acc
-                        (reduce-kv (fn [a target ehs]
-                                     (if (some #(jtms/in? tms %) ehs) (conj! a target) a))
-                                   acc entries)))
+         (reduce-kv (fn [acc target ehs]
+                      (if (some #(effectively-active? tms target->ehs % #{}) ehs)
+                        (conj! acc target)
+                        acc))
                     (transient #{})
-                    by-ctx))))))
+                    target->ehs))))))
 
 (defn hidden-fn
   "A predicate `(fn [handle]) -> boolean` answering, for **one** `view-context`, what
@@ -1122,12 +1153,18 @@
             ;; only the contexts that both state an except and are visible from here —
             ;; computed once, so the predicate walks nothing it will always reject
             live (into [] (comp (filter #(contains? up (key %))) (map val)) by-ctx)
-            tms  (:tms kb)]
+            tms  (:tms kb)
+            ;; flatten into target->ehs for cascade check
+            target->ehs (reduce (fn [m entries]
+                                  (reduce-kv (fn [m2 target ehs]
+                                               (update m2 target (fnil into #{}) ehs))
+                                             m entries))
+                                {} live)]
         (when (seq live)
           (fn [handle]
-            (boolean (some (fn [entries]
-                             (some #(jtms/in? tms %) (get entries handle)))
-                           live))))))))
+            (boolean
+             (when-let [ehs (get target->ehs handle)]
+               (some #(effectively-active? tms target->ehs % #{}) ehs)))))))))
 
 (defn excepted?
   "Is the sentex at `handle` hidden from `view-context` by a believed `except`?  The

--- a/src/vaelii/impl/settle.clj
+++ b/src/vaelii/impl/settle.clj
@@ -505,7 +505,7 @@
   `touched` the same way: the next defeat round's nogoods and the preserving re-joins
   this round queued must read belief as it is now."
   [kb]
-  (tax/refresh-beliefs (:taxonomy kb) #(jtms/in? (:tms kb) %) (jtms/touched (:tms kb)))
+  (special/reconcile-belief-change! kb (jtms/touched (:tms kb)))
   (tax/restore-depths (:taxonomy kb)))
 
 (defn- preserved-rejoins-for
@@ -843,7 +843,7 @@
   "The shapes of a rule's queued triggers, or `:all` when the rule was queued
   unconditionally or any trigger has no readable shape."
   [triggers]
-  (if (= :all triggers)
+  (if (#{:all :all-rejoin} triggers)
     :all
     (let [ss (map literal-shape triggers)]
       (if (some nil? ss) :all (set ss)))))
@@ -1165,7 +1165,12 @@
   nothing says whether the move blocked or released, so the re-derivation has to be
   attempted either way."
   [queued]
-  (keep (fn [[rh triggers]] (when (= :all triggers) rh)) queued))
+  (keep (fn [[rh triggers]] (when (#{:all :all-rejoin} triggers) rh)) queued))
+
+(defn- forced-recheck-rules
+  "The unconditional rechecks that also owe a fresh join when blocking stayed still."
+  [queued]
+  (keep (fn [[rh triggers]] (when (= :all-rejoin triggers) rh)) queued))
 
 (defn- aggregate-recheck-rules
   "The queued rules carrying an **aggregate** antecedent, which need the join run again
@@ -3595,7 +3600,7 @@
   ;; relabelled region), so passing it lets `refresh-beliefs` skip a cache no moved
   ;; supporter touches instead of rescanning the whole vocabulary (perf-review #11).
   (when belief-moved?
-    (tax/refresh-beliefs (:taxonomy kb) #(jtms/in? (:tms kb) %) (jtms/touched (:tms kb)))
+    (special/reconcile-belief-change! kb (jtms/touched (:tms kb)))
     ;; ...and repair again, because the reconcile itself can surrender the potential: an
     ;; edge leaving a strongly connected component dissolves it, and a revived one can
     ;; close a new one.  Left to the *next* settle, `:scc` reads empty in between, and
@@ -3645,9 +3650,10 @@
       ;; supersession flip moves what pairs without moving a label
       (note-supersession-flips! kb before after)
       (when (or (seq before) (seq after))
-        (tax/refresh-beliefs (:taxonomy kb) #(jtms/in? (:tms kb) %)
-                             (into (jtms/touched (:tms kb))
-                                   (concat (keys before) (keys after)))))
+        (special/reconcile-belief-change!
+         kb
+         (into (jtms/touched (:tms kb))
+               (concat (keys before) (keys after)))))
       ;; ...and the spellings this reconcile gave *back*, which are revived datums by
       ;; every test but the one `jtms/revived` can apply: they gained belief, and no
       ;; relabel says so, so they are in none of the three window sets.  `settle` re-seeds
@@ -3771,8 +3777,7 @@
       ;; settle with nothing defeated pays nothing — which is nearly all of them, and the
       ;; same reasoning `settle-finish`'s own `belief-moved?` gate states.
       (let [revival-flips (when defeated-before?
-                            (tax/refresh-beliefs (:taxonomy kb) #(jtms/in? (:tms kb) %)
-                                                 (jtms/touched (:tms kb)))
+                            (special/reconcile-belief-change! kb (jtms/touched (:tms kb)))
                             (tax/restore-depths (:taxonomy kb))
                             ;; ...and an except among the revived is a visibility flip:
                             ;; what it hid is seeable again, and only this settle knows
@@ -3800,6 +3805,13 @@
                                    (concat (set/difference ex-before ex-after)
                                            (set/difference ex-after ex-before)))))
                 queued (drain-recheck! kb)
+                ;; A context-visibility transition carries `:all-rejoin` because there is no
+                ;; arriving sentence narrow enough to identify the one firing it may
+                ;; have released.  It therefore owes the coarse rule re-join even when
+                ;; the blocked set itself did not move.  Decide that before the
+                ;; unproductive-pass gate below; otherwise the gate drops precisely the
+                ;; work `blanket-recheck-rules` exists to preserve.
+                forced (vec (forced-recheck-rules queued))
                 ;; ...and the datums whose belief came *back*, which no trigger queues and
                 ;; no blocked set holds.  Read after the resolve above, so a datum this
                 ;; pass revived and defeated again is not one of them.  `jtms/touched`
@@ -3818,7 +3830,8 @@
                     ;; set is the wrong instrument for it and its own record is asked
                     ;; instead.  Decided before the sweep and re-decided after it.
                     {free :free over :overflow} (released-refusals kb queued)]
-                (if (and (= new was) (empty? aggs) (empty? free) (empty? over) (empty? flips)
+                (if (and (= new was) (empty? forced) (empty? aggs)
+                         (empty? free) (empty? over) (empty? flips)
                          (empty? revived) (empty? rejoin))
                   (settle-finish kb pass moved violated dilemmas (moved? moved) arbitrated)   ; unproductive pass: converged
                   ;; read before the sweep, which deletes justifications

--- a/src/vaelii/impl/special.clj
+++ b/src/vaelii/impl/special.clj
@@ -66,24 +66,33 @@
 ;; sentences that arrived or left — what `exception-blocked-set` narrows the rule's
 ;; firings by before paying for a single level-6 query — or `:all` where no such
 ;; sentence exists (a taxonomy edge moved, a rule was just indexed) and every firing
-;; must be re-checked.
+;; must be re-checked. `:all-rejoin` is the stronger form used when the move can create
+;; a firing without changing any existing blocked justification; settle must then run
+;; the rule join even if the ordinary exception pass otherwise looks unproductive.
 
 (defn- mark-recheck
   "Queue `rule-handles` for exception re-evaluation at the next `settle`, recording
   `trigger` — the sentence whose arrival or departure could have flipped the exception
-  — or `:all` when there is no such sentence and every firing must be re-checked.
+  — `:all` when there is no such sentence and every firing must be re-checked, or
+  `:all-rejoin` when that unconditional check must also force a fresh join.
 
-  `:all` is absorbing: once a rule is queued unconditionally, adding a narrower
-  trigger to it must not narrow it back."
+  The unconditional markers are absorbing, and `:all-rejoin` is the stronger one:
+  once queued, adding a narrower trigger must not narrow it back."
   [kb rule-handles trigger]
   (when (seq rule-handles)
     (swap! (:recheck kb)
            (fn [m]
              (reduce (fn [m rh]
                        (let [cur (get m rh)]
-                         (assoc m rh (if (or (= :all cur) (= :all trigger))
-                                       :all
-                                       (conj (or cur #{}) trigger)))))
+                         (assoc m rh
+                                (cond
+                                  (or (= :all-rejoin cur) (= :all-rejoin trigger))
+                                  :all-rejoin
+
+                                  (or (= :all cur) (= :all trigger))
+                                  :all
+
+                                  :else (conj (or cur #{}) trigger)))))
                      m rule-handles)))))
 
 (defn- recheck-preserving-along
@@ -816,23 +825,24 @@
   Returns the rule handles it marked — the settle loop re-chains them when the
   trigger was a belief flip, which moves no blocked justification for the drain to
   notice on its own."
-  [kb except-sentex]
-  (when-let [h (sx/handle-id (second (:sentence except-sentex)))]
-    (let [tms      (:tms kb)
-          users    (keep (fn [jid]
-                           (let [inf (:informant (jtms/justification tms jid))]
-                             (when (integer? inf) inf)))
-                         (jtms/dependents tms h))
-          target   (p/get-sentex (:records kb) h)
-          pred     (some-> target :sentence nm/functor)
-          ;; the global closure on purpose: an under-selected re-check trigger is a
-          ;; missed sweep or a missed revival
-          firers   (when (symbol? pred)
-                     (mapcat #(p/rules-by-antecedent (:index kb) %)
-                             (tax/genls (:taxonomy kb) pred)))
-          marked   (vec (into (set users) firers))]
-      (mark-recheck kb marked :all)
-      marked)))
+  ([kb except-sentex] (recheck-except kb except-sentex :all))
+  ([kb except-sentex trigger]
+   (when-let [h (sx/handle-id (second (:sentence except-sentex)))]
+     (let [tms      (:tms kb)
+           users    (keep (fn [jid]
+                            (let [inf (:informant (jtms/justification tms jid))]
+                              (when (integer? inf) inf)))
+                          (jtms/dependents tms h))
+           target   (p/get-sentex (:records kb) h)
+           pred     (some-> target :sentence nm/functor)
+           ;; the global closure on purpose: an under-selected re-check trigger is a
+           ;; missed sweep or a missed revival
+           firers   (when (symbol? pred)
+                      (mapcat #(p/rules-by-antecedent (:index kb) %)
+                              (tax/genls (:taxonomy kb) pred)))
+           marked   (vec (into (set users) firers))]
+       (mark-recheck kb marked trigger)
+       marked))))
 
 (defn recheck-except-cone
   "A `genlCx` edge moved visibility for the contexts in `context-down(sub)`, which
@@ -848,7 +858,58 @@
       (doseq [eh (p/sentexes-with-functor idx sx/except-functor)
               :let [esx (p/get-sentex (:records kb) eh)]
               :when esx]
-        (recheck-except kb esx)))))
+        ;; A context edge can make two independently restored antecedents meet at a
+        ;; reader without releasing any already-blocked justification.  Preserve that
+        ;; distinction through the queue so settle forces the missing join exactly for
+        ;; this visibility-transition shape.
+        (recheck-except kb esx :all-rejoin)))))
+
+(defn- belief-change-region
+  "`moved` plus the targets of any visibility-excepts it names.
+
+  A relabel reports the except handle because that is the TMS datum whose belief
+  changed, while the derived cache is indexed by the declaration handle the except
+  hides. Expanding at this boundary lets callers report the event they observed
+  without knowing which cache supporter it invalidates."
+  [kb moved]
+  (into (set moved)
+        (keep (fn [h]
+                (some-> (p/get-sentex (:records kb) h)
+                        :sentence
+                        kb/except-target)))
+        moved))
+
+(defn reconcile-belief-change!
+  "Reconcile every belief-derived taxonomy cache after `moved` may have changed truth.
+
+  This is the engine-level choke point above `tax/refresh-beliefs`: ordinary JTMS
+  defeat/revival/supersession and visibility `except` both change whether a stored
+  declaration currently has force. `moved` may name either declaration handles or
+  except handles; the latter are expanded to their targets before the scoped refresh.
+
+  The three-argument form lets a removal path report a visibility change explicitly:
+  once the exception record has been deleted, its target alone cannot prove why the
+  effective-supporter generation changed."
+  ([kb] (reconcile-belief-change! kb nil))
+  ([kb moved]
+   (reconcile-belief-change!
+    kb
+    moved
+    (or (nil? moved)
+        (some (fn [h]
+                (some-> (p/get-sentex (:records kb) h)
+                        :sentence
+                        kb/except-target))
+              moved))))
+  ([kb moved visibility-moved?]
+   (let [region (when (some? moved) (belief-change-region kb moved))
+         tms    (:tms kb)]
+     (when visibility-moved?
+       (tax/note-supporter-visibility-change! (:taxonomy kb)))
+     (tax/refresh-beliefs
+      (:taxonomy kb)
+      #(jtms/in? tms %)
+      region))))
 
 ;; ---- the decontextualized predicate ---------------------------------------
 ;; `(decontextualizedPredicate P)` lifts every `(P ...)` out of the context it was
@@ -2789,7 +2850,8 @@
       (sx/exceptWhen-meta? sentence)  (index-exceptWhen-meta kb sentex)
       ;; a visibility `(except (sentexHandle H))` fact: queue the firings that use H
       ;; so settle sweeps any conclusion now resting on an invisible antecedent
-      (= sx/except-functor f)         (recheck-except kb sentex)
+      (= sx/except-functor f)         (do (recheck-except kb sentex)
+                                          (reconcile-belief-change! kb #{handle}))
       ;; a rule reaching the general path (e.g. rebuilt by recover, or a migrated
       ;; twin) is indexed from its own record, so it keeps the direction its wrapper
       ;; gave it

--- a/src/vaelii/impl/taxonomy.clj
+++ b/src/vaelii/impl/taxonomy.clj
@@ -426,7 +426,7 @@
   [t]
   (boolean (when-let [active? (:supporter-filter-active? t)] (active?))))
 
-(defn- scoped-support-visible?
+(defn- scope-admits-supporter?
   "Does `scope` admit supporter `[handle context]`?
 
   A plain set is the original context-only scope. An exception-aware scope is a map
@@ -538,7 +538,7 @@
               e-of    (if (= dir-key :fwd) (fn [x] [n x]) (fn [x] [x n]))
               pred    (if (map? scope)
                         (fn [x]
-                          (some (fn [[h c]] (scoped-support-visible? scope h c))
+                          (some (fn [[h c]] (scope-admits-supporter? scope h c))
                                 (get support (e-of x))))
                         (fn [x] (ctxs-visible? (get ectxs (e-of x)) scope)))
               nbrs  (get (dir-key rel) n)
@@ -2160,7 +2160,7 @@
                      :context context
                      :supporter-visible? (:supporter-visible? t)}]
           (boolean
-           (some (fn [[h c]] (scoped-support-visible? scope h c))
+           (some (fn [[h c]] (scope-admits-supporter? scope h c))
                  (get-in t [:cache-support k]))))
         (ctxs-visible? (get-in t [:cache-ctxs k])
                        (closure-of tax :genlCx :fwd context))))))
@@ -2301,7 +2301,7 @@
   (into [] (filter (let [live (get (:edge-ctxs rel) e #{})]
                      (fn [[h c]]
                        (if (map? scope)
-                         (scoped-support-visible? scope h c)
+                         (scope-admits-supporter? scope h c)
                          (and (contains? live c)
                               (or (nil? scope) (nil? c) (scope c)))))))
         (get (:support rel) e {})))

--- a/src/vaelii/impl/taxonomy.clj
+++ b/src/vaelii/impl/taxonomy.clj
@@ -2473,7 +2473,7 @@
   [tax c]
   (closure-of tax :genlCx :fwd c))
 
-(defn raw-sees?
+(defn- raw-sees?
   "Does `k` inherit `y` in the active genlCx cache before exception filtering?"
   [tax k y]
   (reachable-in? tax :genlCx k y))

--- a/src/vaelii/impl/taxonomy.clj
+++ b/src/vaelii/impl/taxonomy.clj
@@ -419,6 +419,9 @@
   [context]
   (and (symbol? context) (not (.startsWith (name context) "?"))))
 
+;; Forward declarations: `relation-scope` and `scope-admits-supporter?` reference
+;; these before their definitions because the scope machinery sits above the walk
+;; but below the closure, creating a mutual dependency.
 (declare visible-ctxs context-up sees?)
 
 (defn- supporter-filter-active?
@@ -2147,10 +2150,10 @@
 (defn- cache-entry-visible?
   "Does flat-cache entry `k` have a believed supporter visible from `context`?
 
-  The old path remains a context-set intersection while no exception exists. Once
-  exception filtering is active, inspect supporters: the effective context cone
-  handles excepted genlCx links and the KB callback handles belief plus exceptions
-  targeting the declaration itself."
+  Without exceptions, a context-set intersection is sufficient.  With exception
+  filtering active, each supporter is checked individually: the exception-aware
+  context cone handles excepted genlCx links and the KB callback handles belief
+  plus exceptions targeting the declaration itself."
   [tax k context]
   (if-not (scoped-context? context)
     true
@@ -2472,11 +2475,6 @@
   excepted genlCx supporter from the resulting walk."
   [tax c]
   (closure-of tax :genlCx :fwd c))
-
-(defn- raw-sees?
-  "Does `k` inherit `y` in the active genlCx cache before exception filtering?"
-  [tax k y]
-  (reachable-in? tax :genlCx k y))
 
 (defn context-up
   "Contexts c inherits from, incl c, after context-visible genlCx exceptions."

--- a/src/vaelii/impl/taxonomy.clj
+++ b/src/vaelii/impl/taxonomy.clj
@@ -275,6 +275,14 @@
           :disjoint #{} :disjoint-index {} :disjoint-metatypes #{} :metatype-members {}
           :props {} :inverse {} :arity {}
           :cache-support {} :cache-handle-keys {} :cache-dirty #{} :cache-ctxs {}
+          ;; A KB installs two read-only callbacks after construction: whether any
+          ;; supporter needs exception-aware scoping, and whether one supporter is
+          ;; effective from a concrete reader context. Raw taxonomies (the unit-test
+          ;; and what-if surface) install neither and retain the original context-only
+          ;; path byte-for-byte. `:supporter-visibility-gen` invalidates scoped closure
+          ;; memo entries when an except or meta-except changes without moving an edge.
+          :supporter-filter-active? nil :supporter-visible? nil
+          :supporter-visibility-gen 0
           ;; Oriented schematic rewrite rules (docs/equality.md, symbolic equational
           ;; reasoning).  `:rewrite-support` records every asserted rule keyed by its
           ;; equation handle; `:rewrite-active` is the believed subset `refresh-beliefs`
@@ -299,6 +307,27 @@
           ;; sorted rather than on a counter — see `rewrite-rules`.
           :rewrite-order (atom nil)})
     (add-watch ::change (fn [_ _ _ _] (observe/note-change)))))
+
+(defn install-supporter-visibility!
+  "Install the KB-owned exception visibility callbacks on `tax`.
+
+  `active?` is the cheap whole-KB gate. `visible?` answers whether one stored
+  supporter handle is believed and not excepted from one concrete reader context.
+  Taxonomy remains independent of the JTMS and exception grammar; the KB owns those
+  facts and supplies the two reads after its mutually-referential parts exist."
+  [tax active? visible?]
+  (swap! tax assoc :supporter-filter-active? active? :supporter-visible? visible?)
+  tax)
+
+(defn note-supporter-visibility-change!
+  "Invalidate context-scoped derived reads after an except's effective belief moves.
+
+  No edge or flat-cache entry is activated/deactivated here: an except is a hole in a
+  visibility cone, not a global retraction. The generation is carried in scoped memo
+  keys, so the next affected read recomputes while the unscoped cache stays hot."
+  [tax]
+  (swap! tax update :supporter-visibility-gen (fnil inc 0))
+  tax)
 
 (defn detached-copy
   "The current taxonomy state in a fresh atom, for a what-if probe: mutate the copy,
@@ -390,6 +419,66 @@
   [context]
   (and (symbol? context) (not (.startsWith (name context) "?"))))
 
+(declare visible-ctxs context-up sees?)
+
+(defn- supporter-filter-active?
+  "Does this KB currently need supporter-level exception filtering?"
+  [t]
+  (boolean (when-let [active? (:supporter-filter-active? t)] (active?))))
+
+(defn- scoped-support-visible?
+  "Does `scope` admit supporter `[handle context]`?
+
+  A plain set is the original context-only scope. An exception-aware scope is a map
+  carrying that same visible-context set (nil means every asserting context), the
+  concrete reader, and the KB-owned supporter predicate."
+  [scope handle supporter-context]
+  (if (map? scope)
+    (let [{:keys [contexts context supporter-visible?]} scope]
+      (and (or (nil? supporter-context)
+               (nil? contexts)
+               (contains? contexts supporter-context))
+           (supporter-visible? handle context)))
+    (or (nil? supporter-context) (scope supporter-context))))
+
+(defn- relation-scope
+  "The scoped-read key for `rel-key` from `context`, or nil for the global fast path.
+
+  With no exception roster this is exactly `visible-ctxs`'s old set/nil answer. Once
+  an exception exists, retain the concrete reader and visibility generation because
+  two readers with the same inherited asserting contexts may hide different handles."
+  [tax rel-key context]
+  (when (scoped-context? context)
+    (let [t   @tax
+          rel (get t rel-key)
+          ;; An exception on genlCx changes which assertion contexts an ordinary
+          ;; reader inherits.  genlCx itself must start from the raw cone to avoid
+          ;; defining exception visibility in terms of itself; every other relation
+          ;; uses the effective cone.  Do not intern this effective set in :vis-index:
+          ;; its identity moves with supporter visibility, not only edge generation.
+          active? (supporter-filter-active? t)
+          vis (cond
+                ;; genlCx declarations are forced into CxUniverse and therefore
+                ;; globally visible as declarations. Their *edges* can still be
+                ;; excepted per reader, but assertion-context filtering must never
+                ;; turn the whole context hierarchy off.
+                (= rel-key :genlCx) nil
+
+                active?
+                (when (seq (:ctx-counts rel))
+                  (let [up  (context-up tax context)
+                        all (keys (:ctx-counts rel))
+                        v   (into #{} (filter up) all)]
+                    (when-not (= (count v) (count all)) v)))
+
+                :else (visible-ctxs tax rel-key context))]
+      (if active?
+        {:contexts vis
+         :context context
+         :supporter-visible? (:supporter-visible? t)
+         :visibility-gen (:supporter-visibility-gen t)}
+        vis))))
+
 (defn visible-ctxs
   "`up(K) ∩ ctxs` for relation `rel-key` — the supporting contexts `context` can
   see — or nil when the scoped answer could not differ from the global one.
@@ -433,20 +522,25 @@
   nil)
 
 (defn- visible-neighbours
-  "The `dir-key` neighbours of `n` reachable through an edge some supporter asserts
-  from `vis` — the scoped walk's adjacency.  Edge orientation: `:fwd` n→x is edge
+  "The `dir-key` neighbours of `n` reachable through an edge some supporter makes
+  effective in `scope` — the scoped walk's adjacency. Edge orientation: `:fwd` n→x is edge
   [n x], `:rev` n→x is edge [x n].  Filtered once per pass when a neighbour cache
   is bound (an empty result caches as `[]`, still truthy, so it is not re-walked).
   `rel-key` names the relation `rel` is: it keys the cache, since one pass scopes
   more than one relation (`:genl` and the `:genlCx` witness walk) and their filtered
   neighbours must not collide on a shared `[dir vis n]`."
-  [rel-key rel dir-key vis n]
+  [rel-key rel dir-key scope n]
   (let [nc *visible-neighbours-cache*
-        k  (when nc [rel-key dir-key vis n])]
+        k  (when nc [rel-key dir-key scope n])]
     (or (when nc (get @nc k))
-        (let [ectxs (:edge-ctxs rel)
-              e-of  (if (= dir-key :fwd) (fn [x] [n x]) (fn [x] [x n]))
-              pred  (fn [x] (ctxs-visible? (get ectxs (e-of x)) vis))
+        (let [ectxs   (:edge-ctxs rel)
+              support (:support rel)
+              e-of    (if (= dir-key :fwd) (fn [x] [n x]) (fn [x] [x n]))
+              pred    (if (map? scope)
+                        (fn [x]
+                          (some (fn [[h c]] (scoped-support-visible? scope h c))
+                                (get support (e-of x))))
+                        (fn [x] (ctxs-visible? (get ectxs (e-of x)) scope)))
               nbrs  (get (dir-key rel) n)
               res   (if nc (filterv pred nbrs) (filter pred nbrs))]
           (when nc (swap! nc assoc k res))
@@ -463,14 +557,14 @@
   128)
 
 (defn- closure-of-vis
-  "`closure-of` over only the edges visible from `vis` — memoized one level deeper,
-  under the interned `vis` set, in the same gen-stamped memo entry (so an edge or
+  "`closure-of` over only the edges effective in `scope` — memoized one level deeper,
+  under the interned scope key, in the same gen-stamped memo entry (so an edge or
   context change retires scoped and unscoped reads together).  The scoped level is
   bounded by `*scoped-memo-budget*` distinct vissets; admitting one past the budget
   flushes the level rather than growing it."
-  [tax rel-key dir-key node vis]
+  [tax rel-key dir-key node scope]
   (let [pc *closure-pass-cache*
-        pk (when pc [rel-key dir-key node vis])]
+        pk (when pc [rel-key dir-key node scope])]
     (or (when pc (get @pc pk))
         (let [t    @tax
               rel  (get t rel-key)
@@ -478,22 +572,22 @@
               memo (:closure-memo t)
               m    @memo
               cur  (when (= gen (get-in m [rel-key :gen])) (get m rel-key))
-              s    (or (get-in cur [:scoped vis dir-key node])
-                       (let [s (reach node #(visible-neighbours rel-key rel dir-key vis %))]
+              s    (or (get-in cur [:scoped scope dir-key node])
+                       (let [s (reach node #(visible-neighbours rel-key rel dir-key scope %))]
                          (swap! memo (fn [mm]
                                        (let [e (get mm rel-key)
                                              e (if (= gen (:gen e)) e {:gen gen :fwd {} :rev {}})
-                                             e (if (and (not (contains? (:scoped e) vis))
+                                             e (if (and (not (contains? (:scoped e) scope))
                                                         (<= *scoped-memo-budget* (count (:scoped e))))
                                                  (assoc e :scoped {})
                                                  e)]
-                                         (assoc mm rel-key (assoc-in e [:scoped vis dir-key node] s)))))
+                                         (assoc mm rel-key (assoc-in e [:scoped scope dir-key node] s)))))
                          s))]
           (when pc (swap! pc assoc pk s))
           s))))
 
 (defn- reachable-filtered?
-  "`reachable?` over only the edges visible from `vis` — the sibling walk the scoped
+  "`reachable?` over only the edges effective in `scope` — the sibling walk the scoped
   `genl?` runs.  The depth potential holds over the *global* edge set and the
   visible set is a subset of it, so both prunings stay sound with no per-context
   depths; and because the neighbour set is filtered before the direct-edge test, a
@@ -508,8 +602,8 @@
   component.  Mutual reachability there is a fact about the *global* edge set, and the
   whole question here is which of those edges the reader can see, so a component is a
   reason to keep walking and never an answer."
-  [src tgt rel-key rel vis depth scc]
-  (let [nbrs #(visible-neighbours rel-key rel :fwd vis %)]
+  [src tgt rel-key rel scope depth scc]
+  (let [nbrs #(visible-neighbours rel-key rel :fwd scope %)]
     (or (= src tgt)
         (if (nil? depth)
           (loop [seen #{src}, stack [src]]
@@ -2049,6 +2143,27 @@
   `[:prop kind pred]`, …) — the flat-cache twin of `edge-contexts`."
   [tax k]
   (get-in @tax [:cache-ctxs k] #{}))
+
+(defn- cache-entry-visible?
+  "Does flat-cache entry `k` have a believed supporter visible from `context`?
+
+  The old path remains a context-set intersection while no exception exists. Once
+  exception filtering is active, inspect supporters: the effective context cone
+  handles excepted genlCx links and the KB callback handles belief plus exceptions
+  targeting the declaration itself."
+  [tax k context]
+  (if-not (scoped-context? context)
+    true
+    (let [t @tax]
+      (if (supporter-filter-active? t)
+        (let [scope {:contexts (context-up tax context)
+                     :context context
+                     :supporter-visible? (:supporter-visible? t)}]
+          (boolean
+           (some (fn [[h c]] (scoped-support-visible? scope h c))
+                 (get-in t [:cache-support k]))))
+        (ctxs-visible? (get-in t [:cache-ctxs k])
+                       (closure-of tax :genlCx :fwd context))))))
 (defn types        [tax] (get-in @tax [:genl :nodes] #{}))
 (defn contexts     [tax] (get-in @tax [:genlCx :nodes] #{}))
 (defn disjoint-pairs [tax] (:disjoint @tax))
@@ -2086,8 +2201,8 @@
   the edges visible from it."
   ([tax t] (closure-of tax :genl :fwd t))
   ([tax t context]
-   (if-some [vis (visible-ctxs tax :genl context)]
-     (closure-of-vis tax :genl :fwd t vis)
+   (if-some [scope (relation-scope tax :genl context)]
+     (closure-of-vis tax :genl :fwd t scope)
      (closure-of tax :genl :fwd t))))
 
 (defn specs
@@ -2095,8 +2210,8 @@
   the edges visible from it."
   ([tax t] (closure-of tax :genl :rev t))
   ([tax t context]
-   (if-some [vis (visible-ctxs tax :genl context)]
-     (closure-of-vis tax :genl :rev t vis)
+   (if-some [scope (relation-scope tax :genl context)]
+     (closure-of-vis tax :genl :rev t scope)
      (closure-of tax :genl :rev t))))
 
 (defn specs-of-all
@@ -2128,9 +2243,9 @@
   `context`) only the edges visible from it?"
   ([tax sub super] (reachable-in? tax :genl sub super))
   ([tax sub super context]
-   (if-some [vis (visible-ctxs tax :genl context)]
+   (if-some [scope (relation-scope tax :genl context)]
      (let [rel (get @tax :genl)]
-       (reachable-filtered? sub super :genl rel vis
+       (reachable-filtered? sub super :genl rel scope
                             (when-not (:loose? rel) (:depth rel))
                             (:scc rel)))
      (reachable-in? tax :genl sub super))))
@@ -2182,10 +2297,13 @@
   the strength-aware pickers below read for class.  A supporter is believed iff its own
   context is in `:edge-ctxs` (an edge is stored once per context, so the context
   identifies it); nil `vis` is the unscoped read where every asserting context is visible."
-  [rel e vis]
+  [rel e scope]
   (into [] (filter (let [live (get (:edge-ctxs rel) e #{})]
-                     (fn [[_ c]] (and (contains? live c)
-                                      (or (nil? vis) (nil? c) (vis c))))))
+                     (fn [[h c]]
+                       (if (map? scope)
+                         (scoped-support-visible? scope h c)
+                         (and (contains? live c)
+                              (or (nil? scope) (nil? c) (scope c)))))))
         (get (:support rel) e {})))
 
 (defn- edge-supporter
@@ -2308,23 +2426,23 @@
    (if (= sub super)
      []
      (let [rel (get @tax rel-key)
-           vis (visible-ctxs tax rel-key context)
+           scope (relation-scope tax rel-key context)
            ;; nil `vis` is the unscoped walk — every asserting context is visible, so
            ;; the plain adjacency *is* the visible one, exactly as in `genls`
-           adj (if (nil? vis) #(get (:fwd rel) %) #(visible-neighbours rel-key rel :fwd vis %))
+           adj (if (nil? scope) #(get (:fwd rel) %) #(visible-neighbours rel-key rel :fwd scope %))
            ;; `str` keeps a node that is not a symbol (a NAT) sortable; built once per
            ;; adjacency now, and a node with 0/1 neighbour — common in a sparse relation —
            ;; sorts nothing
            nbrs #(nm/sort-by-content-key str compare (adj %))]
        (if (nil? supporter-class)
          (bfs-witness-path sub super nbrs (fn [_] true)
-                           #(edge-supporter tax rel % vis))
+                           #(edge-supporter tax rel % scope))
          (some (fn [threshold]
                  (bfs-witness-path
                   sub super nbrs
-                  (fn [e] (>= (strength/rank-of (edge-class rel e vis supporter-class))
+                  (fn [e] (>= (strength/rank-of (edge-class rel e scope supporter-class))
                               (strength/rank-of threshold)))
-                  #(strongest-edge-supporter tax rel % vis supporter-class)))
+                  #(strongest-edge-supporter tax rel % scope supporter-class)))
                [:monotonic :default]))))))
 
 (defn reach-strength
@@ -2346,10 +2464,45 @@
 
 ;; ---- genlCx (contexts) ---------------------------------------------------
 
-(defn context-up   "Contexts c inherits from, incl c." [tax c] (closure-of tax :genlCx :fwd c))
-(defn context-down "Contexts that inherit from c, incl c." [tax c] (closure-of tax :genlCx :rev c))
-(defn sees?   "Does context k see assertions in context y?" [tax k y]
+(defn raw-context-up
+  "Contexts `c` inherits from through the active genlCx cache, without `except` holes.
+
+  Exception evaluation uses this non-recursive base relation to decide which exception
+  declarations a reader can see. Ordinary callers want `context-up`, which filters an
+  excepted genlCx supporter from the resulting walk."
+  [tax c]
+  (closure-of tax :genlCx :fwd c))
+
+(defn raw-sees?
+  "Does `k` inherit `y` in the active genlCx cache before exception filtering?"
+  [tax k y]
   (reachable-in? tax :genlCx k y))
+
+(defn context-up
+  "Contexts c inherits from, incl c, after context-visible genlCx exceptions."
+  [tax c]
+  (if-some [scope (relation-scope tax :genlCx c)]
+    (closure-of-vis tax :genlCx :fwd c scope)
+    (raw-context-up tax c)))
+
+(defn context-down
+  "Contexts that inherit from c, incl c, after context-visible genlCx exceptions."
+  [tax c]
+  (let [raw (closure-of tax :genlCx :rev c)]
+    (if (supporter-filter-active? @tax)
+      ;; Reverse visibility has no single reader: every candidate descendant brings
+      ;; its own exception cone.  Filter the raw candidates by that candidate's
+      ;; forward answer instead of pretending `c` supplies one static reverse scope.
+      (into #{} (filter #(sees? tax % c)) raw)
+      raw)))
+
+(defn sees? "Does context k see assertions in context y?" [tax k y]
+  (if-some [scope (relation-scope tax :genlCx k)]
+    (let [rel (get @tax :genlCx)]
+      (reachable-filtered? k y :genlCx rel scope
+                           (when-not (:loose? rel) (:depth rel))
+                           (:scc rel)))
+    (reachable-in? tax :genlCx k y)))
 
 (defn- seeing-member
   "The member of `ctxs` that sees every other member, or nil.  When one exists it is a
@@ -2449,6 +2602,28 @@
   are (`settle`'s exposure asks each whether it can prove a disjointness)."
   [tax ctxs]
   (common-descendant-set tax (vec (distinct ctxs))))
+
+(defn maximal-contexts
+  "The maximal (most general) contexts in the supplied `ctxs` under the current
+  context-visibility relation.
+
+  Unlike `maximal-common-descendant-contexts`, this does not manufacture a candidate
+  set from assertion contexts.  It maximizes a set a caller has already filtered by a
+  stronger predicate — notably forward placement while visibility exceptions are
+  active, where a sentex can be hidden at its assertion context and restored only in a
+  descendant by a meta-exception.  Mutually visible contexts are collapsed through the
+  same stable representative used by ordinary placement."
+  [tax ctxs]
+  (let [members (set ctxs)]
+    (into #{}
+          (comp (remove (fn [k]
+                          (some (fn [anc]
+                                  (and (not= anc k)
+                                       (contains? members anc)
+                                       (not (sees? tax anc k))))
+                                (context-up tax k))))
+                (map (fn [k] (placement-rep tax k))))
+          members)))
 
 (defn common-descendant?
   "Does any context see every member of `ctxs` — is the common-descendant set
@@ -2625,16 +2800,14 @@
         as      (if scoped? (genls tax a context) (genls tax a))
         t       @tax
         members (:metatype-members t)
-        cctxs   (:cache-ctxs t)
-        up      (when scoped? (closure-of tax :genlCx :fwd context))
         pair-vis?   (if scoped?
-                      (fn [x y] (ctxs-visible? (get cctxs [:disjoint #{x y}]) up))
+                      (fn [x y] (cache-entry-visible? tax [:disjoint #{x y}] context))
                       (fn [_ _] true))
         meta-vis?   (if scoped?
-                      (fn [m] (ctxs-visible? (get cctxs [:metatype m]) up))
+                      (fn [m] (cache-entry-visible? tax [:metatype m] context))
                       (fn [_] true))
         member-vis? (if scoped?
-                      (fn [m ty] (ctxs-visible? (get cctxs [:member m ty]) up))
+                      (fn [m ty] (cache-entry-visible? tax [:member m ty] context))
                       (fn [_ _] true))
         ;; `a`'s separable supertypes, each with what it is declared disjoint from
         seps  (let [didx (:disjoint-index t)]
@@ -2741,9 +2914,7 @@
   [tax context]
   (let [scoped? (scoped-context? context)
         t       @tax
-        cctxs   (:cache-ctxs t)
-        up      (when scoped? (closure-of tax :genlCx :fwd context))
-        vis?    (if scoped? (fn [k] (ctxs-visible? (get cctxs k) up)) (fn [_] true))]
+        vis?    (if scoped? #(cache-entry-visible? tax % context) (fn [_] true))]
     (concat
      (for [s (:disjoint t)
            :let  [[x y] (declared-pair s)]
@@ -2884,8 +3055,7 @@
    (let [t @tax]
      (and (contains? (get-in t [:props kind]) pred)
           (or (not (scoped-context? context))
-              (ctxs-visible? (get-in t [:cache-ctxs [:prop kind pred]])
-                             (closure-of tax :genlCx :fwd context)))))))
+              (cache-entry-visible? tax [:prop kind pred] context))))))
 (defn props "The set of predicates carrying property `kind`." [tax kind] (get-in @tax [:props kind] #{}))
 
 (defn quoting-function?
@@ -3032,9 +3202,7 @@
   ([tax pred context]
    (let [ns'  (get-in @tax [:arity pred])
          seen (if (scoped-context? context)
-                (let [up (closure-of tax :genlCx :fwd context)]
-                  (filterv #(ctxs-visible? (get-in @tax [:cache-ctxs [:arity pred %]]) up)
-                           ns'))
+                (filterv #(cache-entry-visible? tax [:arity pred %] context) ns')
                 (vec ns'))]
      (when (= 1 (count seen)) (first seen)))))
 
@@ -3056,9 +3224,7 @@
      ;; an answer that is empty either way
      (if (or (empty? qs) (not (scoped-context? context)))
        qs
-       (let [up (closure-of tax :genlCx :fwd context)]
-         (into #{} (filter #(ctxs-visible? (get-in @tax [:cache-ctxs (inverse-key p %)]) up))
-               qs))))))
+       (into #{} (filter #(cache-entry-visible? tax (inverse-key p %) context)) qs)))))
 
 (defn inverse-of
   "The declared inverse of `p`, or nil — anywhere, or (with `context`) declared

--- a/test/vaelii/except_gnarly_test.clj
+++ b/test/vaelii/except_gnarly_test.clj
@@ -9,7 +9,6 @@
   PR #33 — meta-exception cascade."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [vaelii.core :as v]
-            [vaelii.impl.resolution :as res]
             [vaelii.impl.sentex :as sx]
             [vaelii.impl.taxonomy :as tax]
             [vaelii.test-util :as tu]))

--- a/test/vaelii/except_gnarly_test.clj
+++ b/test/vaelii/except_gnarly_test.clj
@@ -84,6 +84,58 @@
             (is (not (v/ask? kb (list bright gem) CxLeaf)))))
         (v/retract! kb e)))))
 
+(tu/deftest-kb conjunctive-meta-excepts-compose-only-at-joint-reader
+  ;; P and Q are each hidden at the base. CxLeft restores only P; CxRight restores
+  ;; only Q. A static closure per context cannot answer this correctly: CxBottom may
+  ;; prove the conjunction's consequence only while it inherits both restoration
+  ;; cones at once, and loses it again when either inheritance edge is withdrawn.
+  (tu/with-terms [p q r Item CxBase CxLeft CxRight CxBottom]
+    (doseq [[sub super] [[CxBase 'CxWell]
+                         [CxLeft CxBase]
+                         [CxRight CxBase]
+                         [CxBottom CxBase]]]
+      (v/assert kb (list 'genlCx sub super) 'CxUniverse {:strength :monotonic}))
+    (v/assert-rule kb [(list p Item) (list q Item)] (list r Item) CxBase
+                   {:strength :monotonic})
+    (let [ph (v/assert kb (list p Item) CxBase {:strength :monotonic})
+          qh (v/assert kb (list q Item) CxBase {:strength :monotonic})
+          pe (v/assert kb (list 'except (sx/sentex-handle ph)) CxBase
+                       {:strength :monotonic})
+          qe (v/assert kb (list 'except (sx/sentex-handle qh)) CxBase
+                       {:strength :monotonic})]
+      (v/assert kb (list 'except (sx/sentex-handle pe)) CxLeft
+                {:strength :monotonic})
+      (v/assert kb (list 'except (sx/sentex-handle qe)) CxRight
+                {:strength :monotonic})
+      (testing "neither branch alone restores the conjunction"
+        (let [left-edge (v/assert kb (list 'genlCx CxBottom CxLeft) 'CxUniverse
+                                  {:strength :monotonic})]
+          (is (v/ask? kb (list p Item) CxBottom))
+          (is (not (v/ask? kb (list q Item) CxBottom)))
+          (is (not (v/ask? kb (list r Item) CxBottom)))
+          (v/retract! kb left-edge))
+        (let [right-edge (v/assert kb (list 'genlCx CxBottom CxRight) 'CxUniverse
+                                   {:strength :monotonic})]
+          (is (not (v/ask? kb (list p Item) CxBottom)))
+          (is (v/ask? kb (list q Item) CxBottom))
+          (is (not (v/ask? kb (list r Item) CxBottom)))
+          (v/retract! kb right-edge)))
+      (testing "the joint reader proves R, and either missing edge withdraws it"
+        (let [left-edge  (v/assert kb (list 'genlCx CxBottom CxLeft) 'CxUniverse
+                                   {:strength :monotonic})
+              right-edge (v/assert kb (list 'genlCx CxBottom CxRight) 'CxUniverse
+                                   {:strength :monotonic})]
+          (is (v/ask? kb (list p Item) CxBottom))
+          (is (v/ask? kb (list q Item) CxBottom))
+          (is (true? (boolean (v/ask? kb (list r Item) CxBottom))))
+          (v/retract! kb left-edge)
+          (is (not (v/ask? kb (list r Item) CxBottom)))
+          (v/assert kb (list 'genlCx CxBottom CxLeft) 'CxUniverse
+                    {:strength :monotonic})
+          (is (true? (boolean (v/ask? kb (list r Item) CxBottom))))
+          (v/retract! kb right-edge)
+          (is (not (v/ask? kb (list r Item) CxBottom))))))))
+
 ;; ---- 3. chain of 212 excepts --------------------------------------------
 
 (tu/deftest-kb chain-of-212-excepts
@@ -134,9 +186,10 @@
 ;; ---- 4. except a genlCx link -------------------------------------------
 
 (tu/deftest-kb except-genlCx-link
-  ;; Try `(except (sentexHandle H))` where H is a `(genlCx A B)` sentex.
-  ;; If it works, the context closure should update: A no longer sees B.
-  ;; If it's ill-formed, test the refusal.
+  ;; A genlCx declaration is forced into CxUniverse, but its effect can be excepted
+  ;; from a concrete reader.  From that reader's cone it behaves as if retracted;
+  ;; an ancestor that cannot see the exception keeps the edge.  The ordinary genl
+  ;; test below pins the degenerate declaration-and-except-in-one-context case.
   (tu/with-terms [shiny gold CxChild CxParent]
     (v/assert kb (list 'genlCx CxParent 'CxWell) 'CxUniverse {:strength :monotonic})
     (let [edge-h (v/assert kb (list 'genlCx CxChild CxParent) 'CxUniverse {:strength :monotonic})]
@@ -145,104 +198,59 @@
       (testing "CxChild sees CxParent's facts before any except"
         (is (v/ask? kb (list shiny gold) CxChild)))
 
-      ;; Attempt to except the genlCx link
-      (let [result (try
-                     {:handle (v/assert kb (list 'except (sx/sentex-handle edge-h))
-                                        'CxUniverse {:strength :monotonic})}
-                     (catch clojure.lang.ExceptionInfo e
-                       {:error e :type (:type (ex-data e))}))]
-        (if (:handle result)
-          ;; It worked — the genlCx link is excepted
-          (do
-            (testing "excepting a genlCx link hides it from sentexes-matching"
-              ;; `ask?` still answers true because the TransitivityProver reads the
-              ;; taxonomy closure, which is maintained by integrate/disintegrate and
-              ;; not by the except filter.  `sentexes-matching` is the level that
-              ;; honours the except.
-              (is (empty? (v/sentexes-matching kb (list 'genlCx CxChild CxParent) 'CxUniverse))
-                  "the genlCx sentex is hidden from sentexes-matching"))
-            (testing "retract the except — the genlCx link returns"
-              (v/retract! kb (:handle result))
-              (is (seq (v/sentexes-matching kb (list 'genlCx CxChild CxParent) 'CxUniverse)))))
-          ;; It was refused — document the refusal
-          (testing "excepting a genlCx link is refused as ill-formed"
-            (is (some? (:error result))
-                (str "expected a refusal, got: " (pr-str result)))))))))
+      (let [eh (v/assert kb (list 'except (sx/sentex-handle edge-h))
+                         CxChild {:strength :monotonic})]
+        (testing "excepting a genlCx link removes its interpreted closure"
+          (is (not (v/ask? kb (list shiny gold) CxChild)))
+          (is (v/ask? kb (list shiny gold) CxParent)
+              "the reader-scoped exception does not retract the edge globally"))
+        (testing "retract the except — the genlCx link returns"
+          (v/retract! kb eh)
+          (is (v/ask? kb (list shiny gold) CxChild)))))))
 
 ;; ---- 5. except a genl link ---------------------------------------------
 
 (tu/deftest-kb except-genl-link
-  ;; Try `(except (sentexHandle H))` where H is a `(genl sub super)` sentex.
+  ;; Excepting a genl declaration is well-formed and removes its interpreted edge.
   (tu/with-terms [dog animal CxTax]
     (v/assert kb (list 'genlCx CxTax 'CxWell) 'CxUniverse {:strength :monotonic})
     (let [genl-h (v/assert kb (list 'genl dog animal) CxTax {:strength :monotonic})]
 
       (testing "genl closure is active before any except"
-        (is (v/genl? kb dog animal))
-        (is (contains? (v/genls kb dog) animal)))
+        (is (v/genl? kb dog animal CxTax))
+        (is (contains? (v/genls kb dog CxTax) animal)))
 
-      ;; Attempt to except the genl link
-      (let [result (try
-                     {:handle (v/assert kb (list 'except (sx/sentex-handle genl-h))
-                                        CxTax {:strength :monotonic})}
-                     (catch clojure.lang.ExceptionInfo e
-                       {:error e :type (:type (ex-data e))}))]
-        (if (:handle result)
-          ;; It worked — the genl sentex is excepted
-          (do
-            (testing "the genl sentex is hidden from query"
-              (is (empty? (v/sentexes-matching kb (list 'genl dog animal) CxTax))
-                  "the sentex is invisible through sentexes-matching"))
-            ;; The taxonomy cache is maintained separately — the closure may or may
-            ;; not still show the edge.  We document what happens.
-            (testing "retract the except — the genl sentex returns"
-              (v/retract! kb (:handle result))
-              (is (seq (v/sentexes-matching kb (list 'genl dog animal) CxTax)))))
-          ;; It was refused — document the refusal
-          (testing "excepting a genl link is refused as ill-formed"
-            (is (some? (:error result))
-                (str "expected a refusal, got: " (pr-str result)))))))))
+      (let [eh (v/assert kb (list 'except (sx/sentex-handle genl-h))
+                         CxTax {:strength :monotonic})]
+        (testing "the genl sentex and interpreted edge are absent"
+          (is (empty? (v/sentexes-matching kb (list 'genl dog animal) CxTax)))
+          (is (not (v/genl? kb dog animal CxTax)))
+          (is (v/genl? kb dog animal)
+              "the unscoped cache remains a global superset, not a false retraction"))
+        (testing "retract the except — the genl sentex and edge return"
+          (v/retract! kb eh)
+          (is (seq (v/sentexes-matching kb (list 'genl dog animal) CxTax)))
+          (is (v/genl? kb dog animal CxTax)))))))
 
 ;; ---- 6. except an equals sentex ----------------------------------------
 
 (tu/deftest-kb except-equals-sentex
-  ;; Try `(except (sentexHandle H))` where H is an `(equals A B)` sentex.
+  ;; Excepting an equality is well-formed and splits the interpreted class.
   (tu/with-terms [CxEq]
     (v/assert kb (list 'genlCx CxEq 'CxWell) 'CxUniverse {:strength :monotonic})
     (let [a (tu/tmp-ind) b (tu/tmp-ind)]
-      ;; Attempt to assert and then except an equality
-      (let [result (try
-                     (let [eq-h (v/assert kb (list 'equals a b) CxEq {:strength :monotonic})]
-                       {:handle eq-h})
-                     (catch clojure.lang.ExceptionInfo e
-                       {:error e :type (:type (ex-data e))}))]
-        (if (:handle result)
-          (let [eq-h (:handle result)]
-            ;; Attempt to except the equality sentex
-            (let [except-result (try
-                                  {:handle (v/assert kb (list 'except (sx/sentex-handle eq-h))
-                                                     CxEq {:strength :monotonic})}
-                                  (catch clojure.lang.ExceptionInfo e
-                                    {:error e :type (:type (ex-data e))}))]
-              (if (:handle except-result)
-                (do
-                  (testing "excepting an equals sentex hides it from query"
-                    (is (empty? (v/sentexes-matching kb (list 'equals a b) CxEq))
-                        "the equals sentex is hidden"))
-                  (testing "retract the except — the equals sentex record still exists"
-                    (v/retract! kb (:handle except-result))
-                    ;; The equality merge rewrites terms, so sentexes-matching with
-                    ;; the original terms may not find the sentex.  We check that the
-                    ;; handle still has a sentex record — what matters is that
-                    ;; retraction did not corrupt anything.
-                    (is (some? (v/sentex kb eq-h))
-                        "the equals sentex record is still present after retract of except")))
-                (testing "excepting an equals sentex is refused"
-                  (is (some? (:error except-result))
-                      (str "expected a refusal, got: " (pr-str except-result)))))))
-          ;; Even the assert was refused — skip
-          (testing "equals assertion was refused"
-            (is false (str "could not assert equals: " (pr-str result)))))))))
+      (let [eq-h (v/assert kb (list 'equals a b) CxEq {:strength :monotonic})
+            eh   (v/assert kb (list 'except (sx/sentex-handle eq-h))
+                           CxEq {:strength :monotonic})]
+        (testing "excepting equals hides the sentex and splits the class"
+          (is (empty? (v/sentexes-matching kb (list 'equals a b) CxEq)))
+          (is (not (v/same-class? kb a b CxEq)))
+          (is (v/same-class? kb a b)
+              "the global equality partition stays intact"))
+        (testing "retract the except — equality returns"
+          (v/retract! kb eh)
+          (is (some? (v/sentex kb eq-h)))
+          (is (v/same-class? kb a b CxEq)))))))
 
 ;; ---- 7. special-predicate sweep -----------------------------------------
 ;; For each special predicate with code support, assert the sentex, verify the
@@ -255,15 +263,16 @@
     (v/assert kb (list 'genlCx CxG 'CxWell) 'CxUniverse {:strength :monotonic})
     (let [gh (v/assert kb (list 'genl dog animal) CxG {:strength :monotonic})]
       (testing "genl closure active"
-        (is (v/genl? kb dog animal))
-        (is (contains? (v/genls kb dog) animal)))
+        (is (v/genl? kb dog animal CxG))
+        (is (contains? (v/genls kb dog CxG) animal)))
       (let [eh (v/assert kb (list 'except (sx/sentex-handle gh)) CxG {:strength :monotonic})]
-        (testing "the genl sentex is hidden from sentexes-matching"
-          (is (empty? (v/sentexes-matching kb (list 'genl dog animal) CxG))))
+        (testing "the sentex and its context-scoped closure are hidden"
+          (is (empty? (v/sentexes-matching kb (list 'genl dog animal) CxG)))
+          (is (not (v/genl? kb dog animal CxG))))
         (testing "retract except — genl sentex returns"
           (v/retract! kb eh)
           (is (seq (v/sentexes-matching kb (list 'genl dog animal) CxG)))
-          (is (v/genl? kb dog animal)))))))
+          (is (v/genl? kb dog animal CxG)))))))
 
 (tu/deftest-kb except-blocks-genlCx-sentex-visibility
   ;; genlCx: the context inheritance closure.
@@ -274,7 +283,7 @@
       (testing "CxB sees CxA's content before except"
         (is (v/ask? kb (list shiny gold) CxB)))
       (let [eh (v/assert kb (list 'except (sx/sentex-handle cx-h)) 'CxUniverse
-                          {:strength :monotonic})]
+                         {:strength :monotonic})]
         (testing "the genlCx sentex is hidden from query"
           (is (empty? (v/sentexes-matching kb (list 'genlCx CxB CxA) 'CxUniverse))))
         (testing "retract except — genlCx sentex returns"
@@ -482,7 +491,7 @@
     (v/assert kb (list 'genl carnivore 'thing) CxIA {:strength :monotonic})
     (v/assert kb (list 'genl meat 'thing) CxIA {:strength :monotonic})
     (let [iah (v/assert kb (list 'interArgIsa eats 1 carnivore 2 meat) CxIA
-                         {:strength :monotonic})]
+                        {:strength :monotonic})]
       (testing "interArgIsa constraint is active — queryable"
         (is (v/ask? kb (list 'interArgIsa eats 1 carnivore 2 meat) CxIA)))
       (let [eh (v/assert kb (list 'except (sx/sentex-handle iah)) CxIA {:strength :monotonic})]

--- a/test/vaelii/except_gnarly_test.clj
+++ b/test/vaelii/except_gnarly_test.clj
@@ -1,0 +1,493 @@
+;; SPDX-License-Identifier: SSPL-1.0
+;; Copyright © 2026 Vaelii LLC and the Vaelii contributors.
+(ns vaelii.except-gnarly-test
+  "Gnarly `except` tests: cross-context exceptions, cross-context meta-exceptions,
+  deep exception chains, excepting special-predicate sentexes, and the
+  special-predicate sweep that verifies `except` blocks or does not block the
+  cached behaviour behind each interpreted functor.
+
+  PR #33 — meta-exception cascade."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [vaelii.core :as v]
+            [vaelii.impl.resolution :as res]
+            [vaelii.impl.sentex :as sx]
+            [vaelii.impl.taxonomy :as tax]
+            [vaelii.test-util :as tu]))
+
+(use-fixtures :each (tu/neutral-fresh tu/fresh))
+
+;; ---- helpers ------------------------------------------------------------
+
+(defn- ex-type
+  "The `:type` on the ex-info a thunk throws, or nil if it does not throw."
+  [f]
+  (try (f) nil (catch clojure.lang.ExceptionInfo e (:type (ex-data e)))))
+
+;; ---- 1. cross-context except --------------------------------------------
+
+(tu/deftest-kb cross-context-except
+  ;; Assert a fact in context A, except it from context B (a descendant of A via
+  ;; genlCx).  The except hides the fact in B and B's descendants but leaves it
+  ;; visible in A and A's siblings.
+  (tu/with-terms [shiny gold CxTop CxMid CxLeaf CxSibling]
+    (v/assert kb (list 'genlCx CxTop 'CxWell) 'CxUniverse {:strength :monotonic})
+    (v/assert kb (list 'genlCx CxMid CxTop) 'CxUniverse {:strength :monotonic})
+    (v/assert kb (list 'genlCx CxLeaf CxMid) 'CxUniverse {:strength :monotonic})
+    (v/assert kb (list 'genlCx CxSibling CxTop) 'CxUniverse {:strength :monotonic})
+
+    (let [h (v/assert kb (list shiny gold) CxTop {:strength :monotonic})]
+      (testing "visible everywhere before any except"
+        (is (v/ask? kb (list shiny gold) CxTop))
+        (is (v/ask? kb (list shiny gold) CxMid))
+        (is (v/ask? kb (list shiny gold) CxLeaf))
+        (is (v/ask? kb (list shiny gold) CxSibling)))
+
+      (let [eh (v/assert kb (list 'except (sx/sentex-handle h)) CxMid {:strength :monotonic})]
+        (testing "hidden in CxMid and its descendant CxLeaf"
+          (is (not (v/ask? kb (list shiny gold) CxMid)))
+          (is (not (v/ask? kb (list shiny gold) CxLeaf))))
+        (testing "visible in CxTop (the ancestor) and CxSibling (does not see CxMid)"
+          (is (v/ask? kb (list shiny gold) CxTop))
+          (is (v/ask? kb (list shiny gold) CxSibling)))
+        (testing "retract the except — visibility returns everywhere"
+          (v/retract! kb eh)
+          (is (v/ask? kb (list shiny gold) CxMid))
+          (is (v/ask? kb (list shiny gold) CxLeaf)))))))
+
+;; ---- 2. cross-context meta-except ---------------------------------------
+
+(tu/deftest-kb cross-context-meta-except
+  ;; Fact in CxTop, excepted in CxMid, meta-excepted in CxLeaf.  The meta-except
+  ;; restores visibility only from CxLeaf's vantage — CxMid still sees the except.
+  (tu/with-terms [bright gem CxTop CxMid CxLeaf]
+    (v/assert kb (list 'genlCx CxTop 'CxWell) 'CxUniverse {:strength :monotonic})
+    (v/assert kb (list 'genlCx CxMid CxTop) 'CxUniverse {:strength :monotonic})
+    (v/assert kb (list 'genlCx CxLeaf CxMid) 'CxUniverse {:strength :monotonic})
+
+    (let [h (v/assert kb (list bright gem) CxTop {:strength :monotonic})]
+      (let [e (v/assert kb (list 'except (sx/sentex-handle h)) CxMid {:strength :monotonic})]
+        (testing "fact hidden in CxMid and CxLeaf"
+          (is (not (v/ask? kb (list bright gem) CxMid)))
+          (is (not (v/ask? kb (list bright gem) CxLeaf))))
+
+        (let [m (v/assert kb (list 'except (sx/sentex-handle e)) CxLeaf {:strength :monotonic})]
+          (testing "meta-except in CxLeaf restores visibility there"
+            (is (v/ask? kb (list bright gem) CxLeaf)
+                "the meta-except suppresses E's effect from CxLeaf's vantage"))
+          (testing "CxMid still sees the except — the meta-except is below it"
+            (is (not (v/ask? kb (list bright gem) CxMid))
+                "the except is asserted here and no meta-except is visible"))
+          (testing "CxTop is untouched throughout"
+            (is (v/ask? kb (list bright gem) CxTop)))
+          (testing "retracting the meta-except re-hides in CxLeaf"
+            (v/retract! kb m)
+            (is (not (v/ask? kb (list bright gem) CxLeaf)))))
+        (v/retract! kb e)))))
+
+;; ---- 3. chain of 212 excepts --------------------------------------------
+
+(tu/deftest-kb chain-of-212-excepts
+  ;; H0 hidden by E1, E1 hidden by E2, ..., E211 hidden by E212.
+  ;; At depth N (1-based): odd N -> H0 is visible (the except hiding it is itself
+  ;; hidden), even N -> H0 is hidden.  212 is even, so H0 should be hidden.
+  ;; Then retract E212 (the deepest) and verify the cascade recalculates.
+  (tu/with-terms [shiny gold CxChain]
+    (v/assert kb (list 'genlCx CxChain 'CxWell) 'CxUniverse {:strength :monotonic})
+
+    (let [h0 (v/assert kb (list shiny gold) CxChain {:strength :monotonic})]
+      (testing "H0 is visible before any except"
+        (is (v/ask? kb (list shiny gold) CxChain)))
+
+      ;; Build chain: E1 excepts H0, E2 excepts E1, ..., E212 excepts E211
+      (let [chain (loop [i 1, prev-handle h0, acc []]
+                    (if (> i 212)
+                      acc
+                      (let [eh (v/assert kb (list 'except (sx/sentex-handle prev-handle))
+                                         CxChain {:strength :monotonic})]
+                        (recur (inc i) eh (conj acc eh)))))]
+
+        (testing "with 212 layers (even), H0 is visible"
+          ;; E1 hides H0.  E2 hides E1 -> H0 visible.  E3 hides E2 -> E1 active -> H0 hidden.
+          ;; Cascade from the deepest: E212 is active (nothing hides it), E211 is
+          ;; suppressed, E210 active, ..., E1: distance from E212 is 211 (odd) -> suppressed.
+          ;; With E1 suppressed, H0 is NOT excepted.
+          ;; Pattern: odd layer count = H0 hidden, even layer count = H0 visible.
+          (is (v/ask? kb (list shiny gold) CxChain)
+              "212 layers (even) should leave H0 visible"))
+
+        (testing "retract the deepest (E212) — cascade recalculates to 211 (odd)"
+          (v/retract! kb (peek chain))
+          ;; 211 layers (odd): E211 is now the deepest and active, E210 suppressed, ...,
+          ;; E1: distance from E211 is 210 (even) -> active.  E1 active -> H0 hidden.
+          (is (not (v/ask? kb (list shiny gold) CxChain))
+              "211 layers (odd) should leave H0 hidden"))
+
+        (testing "retract the next deepest (E211) — back to 210 (even)"
+          (v/retract! kb (peek (pop chain)))
+          (is (v/ask? kb (list shiny gold) CxChain)
+              "210 layers (even) should leave H0 visible"))
+
+        ;; Clean up the rest of the chain by retracting from deepest to shallowest
+        (doseq [eh (reverse (pop (pop chain)))]
+          (v/retract! kb eh))))))
+
+;; ---- 4. except a genlCx link -------------------------------------------
+
+(tu/deftest-kb except-genlCx-link
+  ;; Try `(except (sentexHandle H))` where H is a `(genlCx A B)` sentex.
+  ;; If it works, the context closure should update: A no longer sees B.
+  ;; If it's ill-formed, test the refusal.
+  (tu/with-terms [shiny gold CxChild CxParent]
+    (v/assert kb (list 'genlCx CxParent 'CxWell) 'CxUniverse {:strength :monotonic})
+    (let [edge-h (v/assert kb (list 'genlCx CxChild CxParent) 'CxUniverse {:strength :monotonic})]
+      (v/assert kb (list shiny gold) CxParent {:strength :monotonic})
+
+      (testing "CxChild sees CxParent's facts before any except"
+        (is (v/ask? kb (list shiny gold) CxChild)))
+
+      ;; Attempt to except the genlCx link
+      (let [result (try
+                     {:handle (v/assert kb (list 'except (sx/sentex-handle edge-h))
+                                        'CxUniverse {:strength :monotonic})}
+                     (catch clojure.lang.ExceptionInfo e
+                       {:error e :type (:type (ex-data e))}))]
+        (if (:handle result)
+          ;; It worked — the genlCx link is excepted
+          (do
+            (testing "excepting a genlCx link hides it from sentexes-matching"
+              ;; `ask?` still answers true because the TransitivityProver reads the
+              ;; taxonomy closure, which is maintained by integrate/disintegrate and
+              ;; not by the except filter.  `sentexes-matching` is the level that
+              ;; honours the except.
+              (is (empty? (v/sentexes-matching kb (list 'genlCx CxChild CxParent) 'CxUniverse))
+                  "the genlCx sentex is hidden from sentexes-matching"))
+            (testing "retract the except — the genlCx link returns"
+              (v/retract! kb (:handle result))
+              (is (seq (v/sentexes-matching kb (list 'genlCx CxChild CxParent) 'CxUniverse)))))
+          ;; It was refused — document the refusal
+          (testing "excepting a genlCx link is refused as ill-formed"
+            (is (some? (:error result))
+                (str "expected a refusal, got: " (pr-str result)))))))))
+
+;; ---- 5. except a genl link ---------------------------------------------
+
+(tu/deftest-kb except-genl-link
+  ;; Try `(except (sentexHandle H))` where H is a `(genl sub super)` sentex.
+  (tu/with-terms [dog animal CxTax]
+    (v/assert kb (list 'genlCx CxTax 'CxWell) 'CxUniverse {:strength :monotonic})
+    (let [genl-h (v/assert kb (list 'genl dog animal) CxTax {:strength :monotonic})]
+
+      (testing "genl closure is active before any except"
+        (is (v/genl? kb dog animal))
+        (is (contains? (v/genls kb dog) animal)))
+
+      ;; Attempt to except the genl link
+      (let [result (try
+                     {:handle (v/assert kb (list 'except (sx/sentex-handle genl-h))
+                                        CxTax {:strength :monotonic})}
+                     (catch clojure.lang.ExceptionInfo e
+                       {:error e :type (:type (ex-data e))}))]
+        (if (:handle result)
+          ;; It worked — the genl sentex is excepted
+          (do
+            (testing "the genl sentex is hidden from query"
+              (is (empty? (v/sentexes-matching kb (list 'genl dog animal) CxTax))
+                  "the sentex is invisible through sentexes-matching"))
+            ;; The taxonomy cache is maintained separately — the closure may or may
+            ;; not still show the edge.  We document what happens.
+            (testing "retract the except — the genl sentex returns"
+              (v/retract! kb (:handle result))
+              (is (seq (v/sentexes-matching kb (list 'genl dog animal) CxTax)))))
+          ;; It was refused — document the refusal
+          (testing "excepting a genl link is refused as ill-formed"
+            (is (some? (:error result))
+                (str "expected a refusal, got: " (pr-str result)))))))))
+
+;; ---- 6. except an equals sentex ----------------------------------------
+
+(tu/deftest-kb except-equals-sentex
+  ;; Try `(except (sentexHandle H))` where H is an `(equals A B)` sentex.
+  (tu/with-terms [CxEq]
+    (v/assert kb (list 'genlCx CxEq 'CxWell) 'CxUniverse {:strength :monotonic})
+    (let [a (tu/tmp-ind) b (tu/tmp-ind)]
+      ;; Attempt to assert and then except an equality
+      (let [result (try
+                     (let [eq-h (v/assert kb (list 'equals a b) CxEq {:strength :monotonic})]
+                       {:handle eq-h})
+                     (catch clojure.lang.ExceptionInfo e
+                       {:error e :type (:type (ex-data e))}))]
+        (if (:handle result)
+          (let [eq-h (:handle result)]
+            ;; Attempt to except the equality sentex
+            (let [except-result (try
+                                  {:handle (v/assert kb (list 'except (sx/sentex-handle eq-h))
+                                                     CxEq {:strength :monotonic})}
+                                  (catch clojure.lang.ExceptionInfo e
+                                    {:error e :type (:type (ex-data e))}))]
+              (if (:handle except-result)
+                (do
+                  (testing "excepting an equals sentex hides it from query"
+                    (is (empty? (v/sentexes-matching kb (list 'equals a b) CxEq))
+                        "the equals sentex is hidden"))
+                  (testing "retract the except — the equals sentex record still exists"
+                    (v/retract! kb (:handle except-result))
+                    ;; The equality merge rewrites terms, so sentexes-matching with
+                    ;; the original terms may not find the sentex.  We check that the
+                    ;; handle still has a sentex record — what matters is that
+                    ;; retraction did not corrupt anything.
+                    (is (some? (v/sentex kb eq-h))
+                        "the equals sentex record is still present after retract of except")))
+                (testing "excepting an equals sentex is refused"
+                  (is (some? (:error except-result))
+                      (str "expected a refusal, got: " (pr-str except-result)))))))
+          ;; Even the assert was refused — skip
+          (testing "equals assertion was refused"
+            (is false (str "could not assert equals: " (pr-str result)))))))))
+
+;; ---- 7. special-predicate sweep -----------------------------------------
+;; For each special predicate with code support, assert the sentex, verify the
+;; special behavior is active, except the sentex handle, verify the sentex is
+;; hidden from query, retract the except, verify the special behavior returns.
+
+(tu/deftest-kb except-blocks-genl-sentex-visibility
+  ;; genl: the taxonomy closure.
+  (tu/with-terms [dog animal pet CxG]
+    (v/assert kb (list 'genlCx CxG 'CxWell) 'CxUniverse {:strength :monotonic})
+    (let [gh (v/assert kb (list 'genl dog animal) CxG {:strength :monotonic})]
+      (testing "genl closure active"
+        (is (v/genl? kb dog animal))
+        (is (contains? (v/genls kb dog) animal)))
+      (let [eh (v/assert kb (list 'except (sx/sentex-handle gh)) CxG {:strength :monotonic})]
+        (testing "the genl sentex is hidden from sentexes-matching"
+          (is (empty? (v/sentexes-matching kb (list 'genl dog animal) CxG))))
+        (testing "retract except — genl sentex returns"
+          (v/retract! kb eh)
+          (is (seq (v/sentexes-matching kb (list 'genl dog animal) CxG)))
+          (is (v/genl? kb dog animal)))))))
+
+(tu/deftest-kb except-blocks-genlCx-sentex-visibility
+  ;; genlCx: the context inheritance closure.
+  (tu/with-terms [shiny gold CxA CxB]
+    (v/assert kb (list 'genlCx CxA 'CxWell) 'CxUniverse {:strength :monotonic})
+    (let [cx-h (v/assert kb (list 'genlCx CxB CxA) 'CxUniverse {:strength :monotonic})]
+      (v/assert kb (list shiny gold) CxA {:strength :monotonic})
+      (testing "CxB sees CxA's content before except"
+        (is (v/ask? kb (list shiny gold) CxB)))
+      (let [eh (v/assert kb (list 'except (sx/sentex-handle cx-h)) 'CxUniverse
+                          {:strength :monotonic})]
+        (testing "the genlCx sentex is hidden from query"
+          (is (empty? (v/sentexes-matching kb (list 'genlCx CxB CxA) 'CxUniverse))))
+        (testing "retract except — genlCx sentex returns"
+          (v/retract! kb eh)
+          (is (seq (v/sentexes-matching kb (list 'genlCx CxB CxA) 'CxUniverse))))))))
+
+(tu/deftest-kb except-blocks-disjoint-sentex-visibility
+  ;; disjoint: pairwise type separation.
+  (tu/with-terms [dog cat Muffet CxD]
+    (v/assert kb (list 'genlCx CxD 'CxWell) 'CxUniverse {:strength :monotonic})
+    (let [dh (v/assert kb (list 'disjoint dog cat) CxD {:strength :monotonic})]
+      (testing "disjoint is active"
+        (is (v/disjoint? kb dog cat)))
+      (let [eh (v/assert kb (list 'except (sx/sentex-handle dh)) CxD {:strength :monotonic})]
+        (testing "the disjoint sentex is hidden from query"
+          (is (empty? (v/sentexes-matching kb (list 'disjoint dog cat) CxD))))
+        (testing "retract except — disjoint sentex returns"
+          (v/retract! kb eh)
+          (is (seq (v/sentexes-matching kb (list 'disjoint dog cat) CxD)))
+          (is (v/disjoint? kb dog cat)))))))
+
+(tu/deftest-kb except-blocks-disjointMetatype-sentex-visibility
+  ;; disjointMetatype: members of the metatype become pairwise disjoint.
+  (tu/with-terms [animalSpecies dog cat CxDM]
+    (v/assert kb (list 'genlCx CxDM 'CxWell) 'CxUniverse {:strength :monotonic})
+    (v/assert kb (list animalSpecies dog) CxDM {:strength :monotonic})
+    (v/assert kb (list animalSpecies cat) CxDM {:strength :monotonic})
+    (let [dmh (v/assert kb (list 'disjointMetatype animalSpecies) CxDM {:strength :monotonic})]
+      (testing "disjointMetatype makes members disjoint"
+        (is (v/disjoint? kb dog cat)))
+      (let [eh (v/assert kb (list 'except (sx/sentex-handle dmh)) CxDM {:strength :monotonic})]
+        (testing "the disjointMetatype sentex is hidden from query"
+          (is (empty? (v/sentexes-matching kb (list 'disjointMetatype animalSpecies) CxDM))))
+        (testing "retract except — disjointMetatype sentex returns"
+          (v/retract! kb eh)
+          (is (seq (v/sentexes-matching kb (list 'disjointMetatype animalSpecies) CxDM))))))))
+
+(tu/deftest-kb except-blocks-transitive-sentex-visibility
+  ;; transitive: the transitive closure prover.
+  (tu/with-terms [insideOf Gem Box Vault CxT]
+    (v/assert kb (list 'genlCx CxT 'CxWell) 'CxUniverse {:strength :monotonic})
+    (let [th (v/assert kb (list 'transitive insideOf) CxT {:strength :monotonic})]
+      (v/assert kb (list insideOf Gem Box) CxT {:strength :monotonic})
+      (v/assert kb (list insideOf Box Vault) CxT {:strength :monotonic})
+      (testing "transitive closure is active"
+        (is (v/has-prop? kb :transitive insideOf))
+        (is (v/ask? kb (list insideOf Gem Vault) CxT)))
+      (let [eh (v/assert kb (list 'except (sx/sentex-handle th)) CxT {:strength :monotonic})]
+        (testing "the transitive sentex is hidden from query"
+          (is (empty? (v/sentexes-matching kb (list 'transitive insideOf) CxT))))
+        (testing "retract except — transitive sentex returns"
+          (v/retract! kb eh)
+          (is (seq (v/sentexes-matching kb (list 'transitive insideOf) CxT)))
+          (is (v/has-prop? kb :transitive insideOf)))))))
+
+(tu/deftest-kb except-blocks-symmetric-sentex-visibility
+  ;; symmetric: both directions of a symmetric predicate are provable.
+  (tu/with-terms [siblingOf Alice Bob CxS]
+    (v/assert kb (list 'genlCx CxS 'CxWell) 'CxUniverse {:strength :monotonic})
+    (let [sh (v/assert kb (list 'symmetric siblingOf) CxS {:strength :monotonic})]
+      (v/assert kb (list siblingOf Alice Bob) CxS {:strength :monotonic})
+      (testing "symmetric provability active"
+        (is (v/has-prop? kb :symmetric siblingOf))
+        (is (v/ask? kb (list siblingOf Bob Alice) CxS)))
+      (let [eh (v/assert kb (list 'except (sx/sentex-handle sh)) CxS {:strength :monotonic})]
+        (testing "the symmetric sentex is hidden from query"
+          (is (empty? (v/sentexes-matching kb (list 'symmetric siblingOf) CxS))))
+        (testing "retract except — symmetric sentex returns"
+          (v/retract! kb eh)
+          (is (seq (v/sentexes-matching kb (list 'symmetric siblingOf) CxS)))
+          (is (v/has-prop? kb :symmetric siblingOf)))))))
+
+(tu/deftest-kb except-blocks-asymmetric-sentex-visibility
+  ;; asymmetric: the converse of an asymmetric predicate is refused.
+  (tu/with-terms [olderThan Alice Bob CxAs]
+    (v/assert kb (list 'genlCx CxAs 'CxWell) 'CxUniverse {:strength :monotonic})
+    (let [ah (v/assert kb (list 'asymmetric olderThan) CxAs {:strength :monotonic})]
+      (v/assert kb (list olderThan Alice Bob) CxAs {:strength :monotonic})
+      (testing "asymmetric is active — the converse is refused"
+        (is (v/has-prop? kb :asymmetric olderThan))
+        (is (= :asymmetric (ex-type #(v/assert kb (list olderThan Bob Alice) CxAs)))))
+      (let [eh (v/assert kb (list 'except (sx/sentex-handle ah)) CxAs {:strength :monotonic})]
+        (testing "the asymmetric sentex is hidden from query"
+          (is (empty? (v/sentexes-matching kb (list 'asymmetric olderThan) CxAs))))
+        (testing "retract except — asymmetric sentex returns"
+          (v/retract! kb eh)
+          (is (seq (v/sentexes-matching kb (list 'asymmetric olderThan) CxAs)))
+          (is (v/has-prop? kb :asymmetric olderThan)))))))
+
+(tu/deftest-kb except-blocks-reflexive-sentex-visibility
+  ;; reflexive: a reflexive predicate holds of everything with itself.
+  (tu/with-terms [sameGroupAs Alice CxR]
+    (v/assert kb (list 'genlCx CxR 'CxWell) 'CxUniverse {:strength :monotonic})
+    (let [rh (v/assert kb (list 'reflexive sameGroupAs) CxR {:strength :monotonic})]
+      (testing "reflexive is active"
+        (is (v/has-prop? kb :reflexive sameGroupAs)))
+      (let [eh (v/assert kb (list 'except (sx/sentex-handle rh)) CxR {:strength :monotonic})]
+        (testing "the reflexive sentex is hidden from query"
+          (is (empty? (v/sentexes-matching kb (list 'reflexive sameGroupAs) CxR))))
+        (testing "retract except — reflexive sentex returns"
+          (v/retract! kb eh)
+          (is (seq (v/sentexes-matching kb (list 'reflexive sameGroupAs) CxR)))
+          (is (v/has-prop? kb :reflexive sameGroupAs)))))))
+
+(tu/deftest-kb except-blocks-functional-sentex-visibility
+  ;; functional: a functional predicate has at most one value per subject.
+  (tu/with-terms [motherOf Alice Mom CxF]
+    (v/assert kb (list 'genlCx CxF 'CxWell) 'CxUniverse {:strength :monotonic})
+    (let [fh (v/assert kb (list 'functional motherOf) CxF {:strength :monotonic})]
+      (testing "functional is active"
+        (is (v/has-prop? kb :functional motherOf)))
+      (let [eh (v/assert kb (list 'except (sx/sentex-handle fh)) CxF {:strength :monotonic})]
+        (testing "the functional sentex is hidden from query"
+          (is (empty? (v/sentexes-matching kb (list 'functional motherOf) CxF))))
+        (testing "retract except — functional sentex returns"
+          (v/retract! kb eh)
+          (is (seq (v/sentexes-matching kb (list 'functional motherOf) CxF)))
+          (is (v/has-prop? kb :functional motherOf)))))))
+
+(tu/deftest-kb except-blocks-irreflexive-sentex-visibility
+  ;; irreflexive: a self-tuple is refused.
+  (tu/with-terms [before Alice CxIr]
+    (v/assert kb (list 'genlCx CxIr 'CxWell) 'CxUniverse {:strength :monotonic})
+    (let [ih (v/assert kb (list 'irreflexive before) CxIr {:strength :monotonic})]
+      (testing "irreflexive is active"
+        (is (v/has-prop? kb :irreflexive before))
+        (is (= :irreflexive (ex-type #(v/assert kb (list before Alice Alice) CxIr)))))
+      (let [eh (v/assert kb (list 'except (sx/sentex-handle ih)) CxIr {:strength :monotonic})]
+        (testing "the irreflexive sentex is hidden from query"
+          (is (empty? (v/sentexes-matching kb (list 'irreflexive before) CxIr))))
+        (testing "retract except — irreflexive sentex returns"
+          (v/retract! kb eh)
+          (is (seq (v/sentexes-matching kb (list 'irreflexive before) CxIr)))
+          (is (v/has-prop? kb :irreflexive before)))))))
+
+(tu/deftest-kb except-blocks-antiSymmetric-sentex-visibility
+  ;; antiSymmetric: a believed converse merges the two arguments via equals.
+  (tu/with-terms [subsumes CxAnti]
+    (v/assert kb (list 'genlCx CxAnti 'CxWell) 'CxUniverse {:strength :monotonic})
+    (let [ash (v/assert kb (list 'antiSymmetric subsumes) CxAnti {:strength :monotonic})]
+      (testing "antiSymmetric is active"
+        (is (v/has-prop? kb :anti-symmetric subsumes)))
+      (let [eh (v/assert kb (list 'except (sx/sentex-handle ash)) CxAnti {:strength :monotonic})]
+        (testing "the antiSymmetric sentex is hidden from query"
+          (is (empty? (v/sentexes-matching kb (list 'antiSymmetric subsumes) CxAnti))))
+        (testing "retract except — antiSymmetric sentex returns"
+          (v/retract! kb eh)
+          (is (seq (v/sentexes-matching kb (list 'antiSymmetric subsumes) CxAnti)))
+          (is (v/has-prop? kb :anti-symmetric subsumes)))))))
+
+(tu/deftest-kb except-blocks-arity-sentex-visibility
+  ;; arity: the declared arity is cached and checked on every assertion.
+  (tu/with-terms [myRel CxAr]
+    (v/assert kb (list 'genlCx CxAr 'CxWell) 'CxUniverse {:strength :monotonic})
+    (let [arh (v/assert kb (list 'arity myRel 2) CxAr {:strength :monotonic})]
+      (testing "arity declaration is active"
+        (is (= 2 (tax/declared-arity (:taxonomy kb) myRel))))
+      (let [eh (v/assert kb (list 'except (sx/sentex-handle arh)) CxAr {:strength :monotonic})]
+        (testing "the arity sentex is hidden from query"
+          (is (empty? (v/sentexes-matching kb (list 'arity myRel 2) CxAr))))
+        (testing "retract except — arity sentex returns"
+          (v/retract! kb eh)
+          (is (seq (v/sentexes-matching kb (list 'arity myRel 2) CxAr)))
+          (is (= 2 (tax/declared-arity (:taxonomy kb) myRel))))))))
+
+(tu/deftest-kb except-blocks-inverse-sentex-visibility
+  ;; inverse: the inverse relation.
+  (tu/with-terms [parentOf childOf CxInv]
+    (v/assert kb (list 'genlCx CxInv 'CxWell) 'CxUniverse {:strength :monotonic})
+    (let [ih (v/assert kb (list 'inverse parentOf childOf) CxInv {:strength :monotonic})]
+      (testing "inverse is active"
+        (is (= childOf (v/inverse-of kb parentOf)))
+        (is (= parentOf (v/inverse-of kb childOf))))
+      (let [eh (v/assert kb (list 'except (sx/sentex-handle ih)) CxInv {:strength :monotonic})]
+        (testing "the inverse sentex is hidden from query"
+          (is (empty? (v/sentexes-matching kb (list 'inverse parentOf childOf) CxInv))))
+        (testing "retract except — inverse sentex returns"
+          (v/retract! kb eh)
+          (is (seq (v/sentexes-matching kb (list 'inverse parentOf childOf) CxInv)))
+          (is (= childOf (v/inverse-of kb parentOf))))))))
+
+(tu/deftest-kb except-blocks-argGenl-sentex-visibility
+  ;; argGenl: argument subtype constraint.
+  (tu/with-terms [typeRel root sub CxAG]
+    (v/assert kb (list 'genlCx CxAG 'CxWell) 'CxUniverse {:strength :monotonic})
+    (v/assert kb (list 'genl root 'thing) CxAG {:strength :monotonic})
+    (v/assert kb (list 'genl sub root) CxAG {:strength :monotonic})
+    (let [agh (v/assert kb (list 'argGenl typeRel 1 root) CxAG {:strength :monotonic})]
+      (testing "argGenl constraint is active — subtype passes, sibling fails"
+        (is (v/assert kb (list typeRel sub (tu/tmp-type)) CxAG))
+        (tu/with-terms [other]
+          (v/assert kb (list 'genl other 'thing) CxAG {:strength :monotonic})
+          (is (= :arg-genl (ex-type #(v/assert kb (list typeRel other (tu/tmp-type)) CxAG))))))
+      (let [eh (v/assert kb (list 'except (sx/sentex-handle agh)) CxAG {:strength :monotonic})]
+        (testing "the argGenl sentex is hidden from query"
+          (is (empty? (v/sentexes-matching kb (list 'argGenl typeRel 1 root) CxAG))))
+        (testing "retract except — argGenl sentex returns"
+          (v/retract! kb eh)
+          (is (seq (v/sentexes-matching kb (list 'argGenl typeRel 1 root) CxAG))))))))
+
+(tu/deftest-kb except-blocks-interArgIsa-sentex-visibility
+  ;; interArgIsa: conditional argument type constraint.
+  (tu/with-terms [eats carnivore meat CxIA]
+    (v/assert kb (list 'genlCx CxIA 'CxWell) 'CxUniverse {:strength :monotonic})
+    (v/assert kb (list 'genl carnivore 'thing) CxIA {:strength :monotonic})
+    (v/assert kb (list 'genl meat 'thing) CxIA {:strength :monotonic})
+    (let [iah (v/assert kb (list 'interArgIsa eats 1 carnivore 2 meat) CxIA
+                         {:strength :monotonic})]
+      (testing "interArgIsa constraint is active — queryable"
+        (is (v/ask? kb (list 'interArgIsa eats 1 carnivore 2 meat) CxIA)))
+      (let [eh (v/assert kb (list 'except (sx/sentex-handle iah)) CxIA {:strength :monotonic})]
+        (testing "the interArgIsa sentex is hidden from query"
+          (is (empty? (v/sentexes-matching kb (list 'interArgIsa eats 1 carnivore 2 meat) CxIA))))
+        (testing "retract except — interArgIsa sentex returns"
+          (v/retract! kb eh)
+          (is (seq (v/sentexes-matching kb (list 'interArgIsa eats 1 carnivore 2 meat) CxIA))))))))

--- a/test/vaelii/except_gnarly_test.clj
+++ b/test/vaelii/except_gnarly_test.clj
@@ -465,24 +465,24 @@
           (is (seq (v/sentexes-matching kb (list 'inverse parentOf childOf) CxInv)))
           (is (= childOf (v/inverse-of kb parentOf))))))))
 
-(tu/deftest-kb except-blocks-argGenl-sentex-visibility
-  ;; argGenl: argument subtype constraint.
+(tu/deftest-kb except-blocks-genlArg-sentex-visibility
+  ;; genlArg: argument subtype constraint.
   (tu/with-terms [typeRel root sub CxAG]
     (v/assert kb (list 'genlCx CxAG 'CxWell) 'CxUniverse {:strength :monotonic})
     (v/assert kb (list 'genl root 'thing) CxAG {:strength :monotonic})
     (v/assert kb (list 'genl sub root) CxAG {:strength :monotonic})
-    (let [agh (v/assert kb (list 'argGenl typeRel 1 root) CxAG {:strength :monotonic})]
-      (testing "argGenl constraint is active — subtype passes, sibling fails"
+    (let [agh (v/assert kb (list 'genlArg typeRel 1 root) CxAG {:strength :monotonic})]
+      (testing "genlArg constraint is active — subtype passes, sibling fails"
         (is (v/assert kb (list typeRel sub (tu/tmp-type)) CxAG))
         (tu/with-terms [other]
           (v/assert kb (list 'genl other 'thing) CxAG {:strength :monotonic})
           (is (= :arg-genl (ex-type #(v/assert kb (list typeRel other (tu/tmp-type)) CxAG))))))
       (let [eh (v/assert kb (list 'except (sx/sentex-handle agh)) CxAG {:strength :monotonic})]
-        (testing "the argGenl sentex is hidden from query"
-          (is (empty? (v/sentexes-matching kb (list 'argGenl typeRel 1 root) CxAG))))
-        (testing "retract except — argGenl sentex returns"
+        (testing "the genlArg sentex is hidden from query"
+          (is (empty? (v/sentexes-matching kb (list 'genlArg typeRel 1 root) CxAG))))
+        (testing "retract except — genlArg sentex returns"
           (v/retract! kb eh)
-          (is (seq (v/sentexes-matching kb (list 'argGenl typeRel 1 root) CxAG))))))))
+          (is (seq (v/sentexes-matching kb (list 'genlArg typeRel 1 root) CxAG))))))))
 
 (tu/deftest-kb except-blocks-interArgIsa-sentex-visibility
   ;; interArgIsa: conditional argument type constraint.

--- a/test/vaelii/meta_sentex_test.clj
+++ b/test/vaelii/meta_sentex_test.clj
@@ -430,12 +430,12 @@
       (testing "the default negation cannot defeat the monotonic except; the target stays hidden"
         (is (not (v/ask? kb (list shiny gold) ctx)))))))
 
-;; ---- meta-exception: excepting an except ----------------------------------
+;; ---- meta-exception: excepting an except cascades -------------------------
 
-(tu/deftest-kb meta-exception-is-ill-formed
+(tu/deftest-kb meta-exception-cascades-restoring-visibility
   ;; A meta-exception — (except (sentexHandle E)) where E is itself an (except …) —
-  ;; is ill-formed: the visibility roster does not cascade, so the sentence would
-  ;; silently do nothing.  The KB refuses it at assert time.
+  ;; cascades: hiding the except suppresses its effect and restores visibility of the
+  ;; target the inner except was hiding.
   (let [ctx (tu/tmp-ctx "MetaEx") shiny (tu/tmp-pred) gold (tu/tmp-ind)]
     (v/assert kb (list 'genlCx ctx 'CxWell) 'CxUniverse {:strength :monotonic})
     (let [h (v/assert kb (list shiny gold) ctx {:strength :monotonic})]
@@ -444,6 +444,14 @@
       (let [e (v/assert kb (list 'except (sx/sentex-handle h)) ctx {:strength :monotonic})]
         (testing "P is hidden after excepting"
           (is (not (v/ask? kb (list shiny gold) ctx))))
-        (testing "excepting the except is refused as ill-formed"
-          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"meta-exception.*ill-formed"
-                (v/assert kb (list 'except (sx/sentex-handle e)) ctx {:strength :monotonic}))))))))
+        (let [m (v/assert kb (list 'except (sx/sentex-handle e)) ctx {:strength :monotonic})]
+          (testing "excepting the except restores visibility — the cascade"
+            (is (v/ask? kb (list shiny gold) ctx)
+                "P should be visible again: E hides H, M hides E, so E's effect is suppressed"))
+          (testing "the inner except E is hidden"
+            (is (not (v/ask? kb (list 'except (sx/sentex-handle h)) ctx))
+                "the except itself is hidden by the meta-except"))
+          (testing "retracting the meta-except re-hides P"
+            (v/retract! kb m)
+            (is (not (v/ask? kb (list shiny gold) ctx))
+                "E's effect is restored when M goes away")))))))

--- a/test/vaelii/meta_sentex_test.clj
+++ b/test/vaelii/meta_sentex_test.clj
@@ -9,7 +9,6 @@
   it starts with the handle term primitives (`vaelii.impl.sentex`)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [vaelii.core :as v]
-            [vaelii.impl.integrate :as integrate]
             [vaelii.impl.jtms :as jtms]
             [vaelii.impl.kb :as kb]
             [vaelii.impl.protocols :as p]
@@ -482,8 +481,8 @@
                                               (swap! log conj :except-target)
                                               (real-except-target sentence))
                     special/disintegrate-sentex! (fn [kb sentex]
-                                                  (swap! log conj :disintegrate)
-                                                  (real-disintegrate kb sentex))]
+                                                   (swap! log conj :disintegrate)
+                                                   (real-disintegrate kb sentex))]
         (v/retract! kb eh))
       ;; The fact should be visible again after retracting the except
       (is (v/ask? kb (list pred ind) ctx) "retracting except restores visibility")

--- a/test/vaelii/meta_sentex_test.clj
+++ b/test/vaelii/meta_sentex_test.clj
@@ -415,3 +415,35 @@
         (is (roster-agrees? kb [gp pm 'CxWell]))
         (is (not (v/ask? kb (list shiny gold) pm)) "and the read still follows it")
         (is (v/ask? kb (list shiny gold) gp))))))
+
+;; ---- except strength converse: monotonic except defeats default not-except -
+
+(tu/deftest-kb a-monotonic-except-defeats-a-default-not-except
+  ;; The converse of `a-defeated-except-does-not-hide`: a default (not (except H))
+  ;; cannot override a monotonic (except H) — strength wins, so the target stays hidden.
+  (let [ctx (tu/tmp-ctx "Conv") shiny (tu/tmp-pred) gold (tu/tmp-ind)]
+    (v/assert kb (list 'genlCx ctx 'CxWell) 'CxUniverse {:strength :monotonic})
+    (let [h (v/assert kb (list shiny gold) ctx {:strength :monotonic})]
+      (v/assert kb (list 'except (sx/sentex-handle h)) ctx {:strength :monotonic})
+      (is (not (v/ask? kb (list shiny gold) ctx)) "the monotonic except hides it")
+      (v/assert kb (list 'not (list 'except (sx/sentex-handle h))) ctx {:strength :default})
+      (testing "the default negation cannot defeat the monotonic except; the target stays hidden"
+        (is (not (v/ask? kb (list shiny gold) ctx)))))))
+
+;; ---- meta-exception: excepting an except ----------------------------------
+
+(tu/deftest-kb meta-exception-is-ill-formed
+  ;; A meta-exception — (except (sentexHandle E)) where E is itself an (except …) —
+  ;; is ill-formed: the visibility roster does not cascade, so the sentence would
+  ;; silently do nothing.  The KB refuses it at assert time.
+  (let [ctx (tu/tmp-ctx "MetaEx") shiny (tu/tmp-pred) gold (tu/tmp-ind)]
+    (v/assert kb (list 'genlCx ctx 'CxWell) 'CxUniverse {:strength :monotonic})
+    (let [h (v/assert kb (list shiny gold) ctx {:strength :monotonic})]
+      (testing "P is true after assertion"
+        (is (v/ask? kb (list shiny gold) ctx)))
+      (let [e (v/assert kb (list 'except (sx/sentex-handle h)) ctx {:strength :monotonic})]
+        (testing "P is hidden after excepting"
+          (is (not (v/ask? kb (list shiny gold) ctx))))
+        (testing "excepting the except is refused as ill-formed"
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"meta-exception.*ill-formed"
+                (v/assert kb (list 'except (sx/sentex-handle e)) ctx {:strength :monotonic}))))))))

--- a/test/vaelii/meta_sentex_test.clj
+++ b/test/vaelii/meta_sentex_test.clj
@@ -9,11 +9,14 @@
   it starts with the handle term primitives (`vaelii.impl.sentex`)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [vaelii.core :as v]
+            [vaelii.impl.integrate :as integrate]
             [vaelii.impl.jtms :as jtms]
+            [vaelii.impl.kb :as kb]
             [vaelii.impl.protocols :as p]
             [vaelii.impl.provers :as provers]
             [vaelii.impl.resolution :as res]
             [vaelii.impl.sentex :as sx]
+            [vaelii.impl.special :as special]
             [vaelii.impl.taxonomy :as tax]
             [vaelii.test-util :as tu]))
 
@@ -455,3 +458,40 @@
             (v/retract! kb m)
             (is (not (v/ask? kb (list shiny gold) ctx))
                 "E's effect is restored when M goes away")))))))
+
+;; ---- ordering contract: except-target extraction before mutation ----------
+
+(tu/deftest-kb except-target-is-captured-before-storage-deletion
+  ;; Structural contract: sentex-removed! must extract the except target handle
+  ;; BEFORE the first destructive mutation (disintegrate-sentex!, delete-sentex!).
+  ;; This pins the defensive binding introduced in 484b59f — the immutable local
+  ;; happens to survive deletion in Clojure, but the contract should not depend on
+  ;; that accident.
+  (let [ctx  (tu/tmp-ctx "Ord")
+        pred (tu/tmp-pred) ind (tu/tmp-ind)
+        log  (atom [])
+        real-except-target     kb/except-target
+        real-disintegrate      special/disintegrate-sentex!]
+    (v/assert kb (list 'genlCx ctx 'CxWell) 'CxUniverse {:strength :monotonic})
+    (let [h  (v/assert kb (list pred ind) ctx {:strength :monotonic})
+          eh (v/assert kb (list 'except (sx/sentex-handle h)) ctx {:strength :monotonic})]
+      ;; Verify the except is working before we retract
+      (is (not (v/ask? kb (list pred ind) ctx)) "except hides the fact")
+      ;; Instrument: record the order of except-target vs disintegrate-sentex!
+      (with-redefs [kb/except-target        (fn [sentence]
+                                              (swap! log conj :except-target)
+                                              (real-except-target sentence))
+                    special/disintegrate-sentex! (fn [kb sentex]
+                                                  (swap! log conj :disintegrate)
+                                                  (real-disintegrate kb sentex))]
+        (v/retract! kb eh))
+      ;; The fact should be visible again after retracting the except
+      (is (v/ask? kb (list pred ind) ctx) "retracting except restores visibility")
+      ;; The structural contract: except-target must appear before disintegrate
+      (let [events @log
+            target-idx      (.indexOf ^java.util.List events :except-target)
+            disintegrate-idx (.indexOf ^java.util.List events :disintegrate)]
+        (is (>= target-idx 0) "except-target was called during retraction")
+        (is (>= disintegrate-idx 0) "disintegrate-sentex! was called during retraction")
+        (is (< target-idx disintegrate-idx)
+            "except-target must be called before the first destructive mutation")))))


### PR DESCRIPTION
Implement nestable, contextual, read-time exception semantics. An `except` whose
handle is itself hidden by another believed `except` no longer suppresses its
target, and special-predicate caches now answer from the effective supporters
visible to the reader rather than treating storage as global force.

## Semantics

- depth 1: `(except H)` → `H` hidden
- depth 2: `(except (except H))` → `H` visible
- depth 3: `(except (except (except H)))` → `H` hidden again
- an exception applies in every context that sees it, not globally
- independently restored antecedents compose: a descendant can derive a conjunctive
  consequence only when it sees every required restoration branch
- excepting `genl`, `genlCx`, `equals`, and other special predicates changes their
  scoped interpreted behavior as if the supporting sentex were retracted
- unscoped caches remain conservative global supersets; scoped reads filter their
  exact believed and visible supporter handles

## Implementation

- add one engine-level belief-transition reconciliation seam shared by ordinary JTMS
  relabeling and exception arrival/removal
- preserve an explicit supporter-visibility generation so removing an exception still
  invalidates scoped memoization after its record has been deleted
- make taxonomy closure and flat-cache reads supporter-aware without making taxonomy
  depend directly on JTMS or exception syntax
- compute exception-aware forward placements from contexts that structurally see all
  ingredients, then retain only readers that see every exact supporter
- distinguish ordinary unconditional rechecks from `:all-rejoin`; only context
  visibility transitions that can create a previously absent firing force a fresh join
- keep `excepted-anywhere?` as the coarse gate so ordinary firings avoid the expensive
  context-cone placement path when none of their exact supporters is targeted

## Naming conventions (agreed this PR)

This PR introduces a four-tier naming ladder for belief predicates:

| Name | Contract |
|------|----------|
| `in?` | Raw structural JTMS label; global, internal primitive |
| `believed?` / `supporter-believed?` | IN after context-scoped exception cascade |
| `visible?` / `supporter-visible?` | Believed, and assertion context is inherited by the reader |
| `except-in-force?` | This except's hiding effect is active after the meta-exception cascade |

Supporting conventions:
- `scope-admits-supporter?` — the dual-mode scope policy helper; the word "scope" signals
  that the contract depends on the scope object's type
- `visible` is reserved for "usable by this reader after all gates"

**Forthcoming follow-up PR:** a naming sweep of preexisting `visible-*` geometry helpers
(`visible-ctxs`, `ctxs-visible?`, `visible-neighbours`, `visible-edge-supporters`,
`class-fully-visible?`, `rule-visible-from?`) to align with this convention. Those
helpers check context geometry only — not belief or exceptions — and will be renamed
to `context-*`, `inherited-*`, or `scoped-*` as appropriate.

## Efficiency and worst cases

The common path remains cheap: with an empty exception roster, supporter filtering is
disabled and the previous unscoped closure/cache path is retained. Scoped closure
results are generation-keyed, and the scoped memo remains bounded to 128 visibility
sets per relation.

**Meta-except counter gate (new).** The KB maintains a `:meta-except-count` atom
tracking how many stored excepts target another except's handle. When zero —
the common case — `excepted-handles` and `hidden-fn` skip the `except-in-force?`
cascade entirely, checking only `jtms/in?` per except-handle. The gate is one atom
deref (O(1)), maintained at the store/removal choke points and rebuilt by `recover`.

Known costs and gotchas:

- For one reader, building the visible exception map is linear in the exception entries
  visible from that reader. Checking one target then walks its reachable
  meta-exception subtree.
- The worst exception-tree shape is a **single deep chain**. The graph is acyclic by
  stratification, so one target lookup is linear in chain depth; however, computing
  verdicts for every target re-walks each suffix. A chain of `N` nested exceptions is
  therefore `Θ(N²)` for a full hidden-set materialization. A wide fan-out is only
  linear for the same operation because its shallow subtrees are not repeatedly long.
- `excepted-anywhere?` checks the contexts that store exceptions. In the worst case,
  querying many firing supporters across many such contexts multiplies supporter count,
  exception-bearing context count, and visible exception entries. The targeted-supporter
  gate keeps this off ordinary firings, but it is the hottest candidate for a future
  maintained target index or per-pass memo.
- Exception-aware placement enumerates common descendant contexts and filters each by
  every exact supporter. On a broad/dense context lattice, common-descendant
  intersection is linear in the participating closures and maximal-context filtering
  can reach quadratic behavior in the number of candidate contexts.
- A `genlCx` edge change conservatively rechecks every stored exception because it can
  change which readers see each one. In the worst case this fans across exception count
  × affected rule/dependent count before downstream joins. This is a rare topology-edit
  path, not a normal query path.
- Any effective exception transition invalidates scoped closure memoization. The next
  query for each affected relation/context may therefore re-walk its visible relation
  graph; the bounded memo prevents unbounded retention but can churn under more than 128
  concurrently hot scopes.

Straightforward follow-up optimizations, if profiling justifies them: memoize one
exception cascade evaluation by handle, maintain a handle-target/context witness index
for the coarse gate, cache supporter visibility within one placement pass, and narrow
`genlCx` cone rechecks to exception subtrees whose visibility actually changed.

## Verification

- focused exception and efficiency guards: **84 tests, 506 assertions, 0 failures**
- full suite: **3,302 tests, 143,521 assertions, 0 failures/errors**
- `cljfmt` and `git diff --check`: clean

The regression suite includes cross-context exceptions, meta-exceptions, a 212-level
cascade, the split `P`/`Q` restoration-branch composition case, and scoped behavior for
all 15 predicates with special code support. (aside: we should create a unary predicate
to enumerate these and only these predicates)

