### PR TITLE
feat: add belief status diagnostics

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -267,8 +267,16 @@ default-chain-opts                              ; the bounds a chain run takes w
 (provenance kb handle)                          ; the per-handle bookkeeping map, or nil
 (add-provenance kb handle m)                     ; merge application fields into it
 (retract! kb handle)                            ; teardown -> {:removed-sentexes n :removed-justifications n}
-(in? kb handle)
-(believed kb handles)                           ; in? in batch -> the set of handles that are IN
+(in? kb handle)                                 ; raw structural JTMS IN, before contextual exceptions
+(believed? kb handle context)                   ; IN after exceptions visible from context, before
+                                                ; assertion-context inheritance
+(belief-status kb handle context)               ; deterministic diagnostic map:
+                                                ; {:handle :view-context :stored? :in?
+                                                ;  :assertion-context :exceptions :excepted?
+                                                ;  :inherited-path :believed? :visible?}
+                                                ; :exceptions is context/content ordered; every node
+                                                ; is {:handle :in? :in-force? :excepted-by}
+(believed kb handles)                           ; in? in batch -> the set of raw-IN handles
 (why kb handle opts?)                           ; proof tree: support -> rule + recursive antecedents,
                                                 ; terminating at premises, cycle-guarded, originalized
                                                 ; opts {:max-depth n} (default 256); a branch at the

--- a/src/vaelii/client.clj
+++ b/src/vaelii/client.clj
@@ -102,9 +102,21 @@
   ([conn goal context] (c/provable? conn goal context)))
 
 (defn in?
-  "Whether the sentex `handle` names is currently believed."
+  "Whether the sentex `handle` names is raw JTMS IN."
   [conn handle]
   (c/in? conn handle))
+
+(defn believed?
+  "Whether `handle` is JTMS IN after exceptions visible from `context`, before
+  assertion-context inheritance."
+  [conn handle context]
+  (c/believed? conn handle context))
+
+(defn belief-status
+  "Storage, raw IN, exception forest, inheritance path, belief, and visibility for
+  `handle` as viewed from `context`."
+  [conn handle context]
+  (c/belief-status conn handle context))
 
 (defn why
   "Why the sentex `handle` names is believed — its supporting justifications, as data."

--- a/src/vaelii/core.clj
+++ b/src/vaelii/core.clj
@@ -4323,7 +4323,10 @@
             {:added added :removed (dissoc removed :seeds)}))))))
 
 (defn in?
-  "Is the sentex handle raw structural JTMS IN, before contextual exceptions?"
+  "Is the sentex handle raw structural JTMS IN, before contextual exceptions?
+
+  When this answers true but a contextual read cannot see the sentex, call
+  `belief-status` to inspect the exception and assertion-context inheritance gates."
   [kb handle]
   (jtms/in? (:tms kb) (the-handle handle "in?")))
 

--- a/src/vaelii/core.clj
+++ b/src/vaelii/core.clj
@@ -4323,13 +4323,58 @@
             {:added added :removed (dissoc removed :seeds)}))))))
 
 (defn in?
-  "Is the sentex handle currently believed (JTMS IN)?"
+  "Is the sentex handle raw structural JTMS IN, before contextual exceptions?"
   [kb handle]
   (jtms/in? (:tms kb) (the-handle handle "in?")))
 
+(defn believed?
+  "Is `handle` JTMS IN after the `(except ...)` cascade visible from `context`?
+
+  This is contextual belief force only.  It deliberately does not require `context`
+  to inherit the sentex's assertion context; `belief-status` reports that final
+  visibility gate separately.  nil and unknown handles answer false; a non-handle is
+  refused with `:bad-handle`, exactly as `in?`."
+  [kb handle context]
+  (let [h (the-handle handle "believed?")]
+    (boolean (and (jtms/in? (:tms kb) h)
+                  (not (res/excepted? kb h context))))))
+
+(defn belief-status
+  "Explain `handle`'s belief and visibility from `context` as a deterministic map.
+
+  Separates storage, raw JTMS IN, context-visible exception force, assertion-context
+  inheritance, and the two terminal answers `:believed?` / `:visible?`.  `:exceptions`
+  is ordered by assertion context and content; nested meta-exceptions are under
+  `:excepted-by`.
+  nil and unknown handles report absent storage and raw belief; a dangling exception
+  may still appear in `:exceptions` / `:excepted?`. Malformed handles are refused with
+  `:bad-handle`."
+  [kb handle context]
+  (let [h       (the-handle handle "belief-status")
+        stored  (when-some [h h] (p/get-sentex (:records kb) h))
+        raw-in? (boolean (jtms/in? (:tms kb) h))
+        {:keys [exceptions excepted?]} (res/exception-status kb h context)
+        believed? (boolean (and raw-in? (not excepted?)))
+        assertion-context (:context stored)
+        path (when stored
+               (some->> (tax/reach-support (:taxonomy kb) :genlCx
+                                           context assertion-context context)
+                        (mapv (fn [[supporter-h supporter-context]]
+                                {:handle supporter-h :context supporter-context}))))]
+    {:handle h
+     :view-context context
+     :stored? (boolean stored)
+     :in? raw-in?
+     :assertion-context assertion-context
+     :exceptions exceptions
+     :excepted? excepted?
+     :inherited-path path
+     :believed? believed?
+     :visible? (boolean (and believed? (some? path)))}))
+
 (defn believed
-  "The subset of `handles` currently believed, as a set — `in?` asked of many handles
-  at once.  Belief is a label already computed on the JTMS node, so this is one map
+  "The subset of `handles` raw structural JTMS IN, as a set — `in?` asked of many
+  handles at once.  IN is a label already computed on the JTMS node, so this is one map
   read per handle either way; what the batch form saves is the **call**, which for a
   remote client (`vaelii.impl.serve`) is a whole round-trip.  A page listing n rows
   asks once instead of n times.

--- a/src/vaelii/impl/access.clj
+++ b/src/vaelii/impl/access.clj
@@ -84,7 +84,8 @@
        (def read-ops ~(mapv keyword names))))
 
 (defreads
-  query query? sentexes-matching ask ask? prove provable? sentex handle-of find-sentexes in? believed why-not
+  query query? sentexes-matching ask ask? prove provable? sentex handle-of find-sentexes
+  in? believed? belief-status believed why-not
   why isa? types-of disjoint? genls specs types contexts premise? defeat-class justification
   supporting-justifications dependent-justifications lookup escalate explain-levels count-in-context
   sentexes-in-context sentexes-with-arg sentexes-with-functor count-with-arg

--- a/src/vaelii/impl/client.clj
+++ b/src/vaelii/impl/client.clj
@@ -168,6 +168,8 @@
   ([conn goal context] (call conn :provable? [goal context])))
 
 (defn in? [conn handle] (call conn :in? [handle]))
+(defn believed? [conn handle context] (call conn :believed? [handle context]))
+(defn belief-status [conn handle context] (call conn :belief-status [handle context]))
 (defn why [conn handle] (call conn :why [handle]))
 
 (defn why-not

--- a/src/vaelii/impl/resolution.clj
+++ b/src/vaelii/impl/resolution.clj
@@ -11,6 +11,7 @@
   (:require [clojure.walk :as walk]
             [vaelii.impl.jtms :as jtms]
             [vaelii.impl.literal-cache :as lc]
+            [vaelii.impl.naming :as nm]
             [vaelii.impl.observe :as observe]
             [vaelii.impl.plan :as plan]
             [vaelii.impl.profile :as prof]
@@ -1080,6 +1081,90 @@
              ;; eh is not a target; it is active
              true)))))
 
+(defn- visible-exception-index
+  "The exception roster visible from `view-context`, flattened to
+  `{target-handle -> #{except-handle ...}}`, or nil when the ordinary no-exception
+  fast path applies.  Both the hot boolean reads and diagnostic exception forest use
+  this one index so they cannot disagree about scope."
+  [kb view-context]
+  (let [by-ctx @(:excepted kb)]
+    (when-not (or (empty? by-ctx) (sx/variable? view-context))
+      (let [up (tax/raw-context-up (:taxonomy kb) view-context)]
+        (not-empty
+         (reduce-kv
+          (fn [m ctx entries]
+            (if-not (contains? up ctx)
+              m
+              (reduce-kv (fn [m2 target ehs]
+                           (update m2 target (fnil into #{}) ehs))
+                         m entries)))
+          {} by-ctx))))))
+
+(defn- exception-states
+  "Evaluate the cascade once for every exception reachable from `roots`.
+
+  Returns `{handle {:in? bool :in-force? bool}}`.  Memoization keeps a linear chain
+  linear instead of re-walking every suffix while rendering the diagnostic forest.
+  `seen` retains the defensive cycle answer; valid graphs are stratified."
+  [tms target->ehs roots]
+  (let [states (atom {})]
+    (letfn [(active? [eh seen]
+              (if (contains? seen eh)
+                false
+                (if-some [state (get @states eh)]
+                  (:in-force? state)
+                  (let [in? (boolean (jtms/in? tms eh))
+                        ;; Eagerly evaluate every child: `not-any?` directly over the
+                        ;; recursive calls would short-circuit after one active child,
+                        ;; leaving its siblings absent from the diagnostic state map.
+                        child-active (mapv #(active? % (conj seen eh))
+                                           (get target->ehs eh))
+                        active (boolean (and in? (not-any? true? child-active)))]
+                    (swap! states assoc eh {:in? in? :in-force? active})
+                    active))))]
+      (doseq [eh roots] (active? eh #{}))
+      @states)))
+
+(defn- exception-node
+  "One deterministic diagnostic node in the exception forest.  `seen` is only the
+  defensive cycle witness; valid exception graphs are stratified and never take it."
+  [records states target->ehs eh seen]
+  (if (contains? seen eh)
+    {:handle eh :in? (get-in states [eh :in?] false) :in-force? false
+     :cycle? true :excepted-by []}
+    (let [seen' (conj seen eh)
+          {:keys [in? in-force?]} (get states eh)]
+      {:handle eh
+       :in? in?
+       :in-force? in-force?
+       :excepted-by (mapv #(exception-node records states target->ehs % seen')
+                          (nm/sort-by-content-key
+                           (fn [h]
+                             (let [s (p/get-sentex records h)]
+                               [(:context s) (:sentence s)]))
+                           (get target->ehs eh)))})))
+
+(defn exception-status
+  "Diagnostic exception forest for `handle` from `view-context`.
+
+  Returns `{:exceptions [...] :excepted? bool}`.  Roots are every visible exception
+  directly targeting `handle`, ordered by assertion context and content; nested
+  meta-exceptions live under `:excepted-by`."
+  [kb handle view-context]
+  (if-let [target->ehs (visible-exception-index kb view-context)]
+    (let [records (:records kb)
+          tms (:tms kb)
+          ordered-roots (nm/sort-by-content-key
+                         (fn [h]
+                           (let [s (p/get-sentex records h)]
+                             [(:context s) (:sentence s)]))
+                         (get target->ehs handle))
+          states (exception-states tms target->ehs ordered-roots)
+          roots (mapv #(exception-node records states target->ehs % #{}) ordered-roots)]
+      {:exceptions roots
+       :excepted? (boolean (some :in-force? roots))})
+    {:exceptions [] :excepted? false}))
+
 (defn excepted-handles
   "The handles hidden from `view-context` by believed `(except (sentexHandle H))`
   facts: an `except` asserted in a context `view-context` sees (its genlCx
@@ -1121,32 +1206,19 @@
   **A caller asking about particular handles wants `excepted?`**, which answers the same
   question without materializing this set."
   [kb view-context]
-  (let [by-ctx @(:excepted kb)]
-    (if (or (empty? by-ctx) (sx/variable? view-context))
-      #{}
-      (let [up  (tax/raw-context-up (:taxonomy kb) view-context)
-            tms (:tms kb)
-            ;; flatten the visible roster into a single target->ehs map for cascade
-            target->ehs (reduce-kv
-                         (fn [m ctx entries]
-                           (if-not (contains? up ctx)
-                             m
-                             (reduce-kv (fn [m2 target ehs]
-                                          (update m2 target (fnil into #{}) ehs))
-                                        m entries)))
-                         {} by-ctx)
-            ;; Meta-except counter gate: when zero, no except targets another except,
-            ;; so every believed except is trivially in force — skip the cascade.
-            has-meta? (pos? @(:meta-except-count kb))]
-        (persistent!
-         (reduce-kv (fn [acc target ehs]
-                      (if (if has-meta?
-                            (some #(except-in-force? tms target->ehs % #{}) ehs)
-                            (some #(jtms/in? tms %) ehs))
-                        (conj! acc target)
-                        acc))
-                    (transient #{})
-                    target->ehs))))))
+  (if-let [target->ehs (visible-exception-index kb view-context)]
+    (let [tms (:tms kb)
+          has-meta? (pos? @(:meta-except-count kb))]
+      (persistent!
+       (reduce-kv (fn [acc target ehs]
+                    (if (if has-meta?
+                          (some #(except-in-force? tms target->ehs % #{}) ehs)
+                          (some #(jtms/in? tms %) ehs))
+                      (conj! acc target)
+                      acc))
+                  (transient #{})
+                  target->ehs)))
+    #{}))
 
 (defn hidden-fn
   "A predicate `(fn [handle]) -> boolean` answering, for **one** `view-context`, what
@@ -1175,25 +1247,29 @@
   [kb view-context]
   (let [by-ctx @(:excepted kb)]
     (when-not (or (empty? by-ctx) (sx/variable? view-context))
-      (let [up  (tax/raw-context-up (:taxonomy kb) view-context)
-            ;; only the contexts that both state an except and are visible from here —
-            ;; computed once, so the predicate walks nothing it will always reject
+      (let [up (tax/raw-context-up (:taxonomy kb) view-context)
             live (into [] (comp (filter #(contains? up (key %))) (map val)) by-ctx)
-            tms  (:tms kb)
-            ;; flatten into target->ehs for cascade check
-            target->ehs (reduce (fn [m entries]
-                                  (reduce-kv (fn [m2 target ehs]
-                                               (update m2 target (fnil into #{}) ehs))
-                                             m entries))
-                                {} live)]
+            tms (:tms kb)]
         (when (seq live)
-          (let [has-meta? (pos? @(:meta-except-count kb))]
+          (if (pos? @(:meta-except-count kb))
+            (let [target->ehs (delay
+                                (reduce (fn [m entries]
+                                          (reduce-kv (fn [m2 target ehs]
+                                                       (update m2 target (fnil into #{}) ehs))
+                                                     m entries))
+                                        {} live))]
+              (fn [handle]
+                (let [roots (reduce (fn [ehs entries]
+                                      (into ehs (get entries handle)))
+                                    #{} live)]
+                  (boolean
+                   (when (seq roots)
+                     (some #(except-in-force? tms @target->ehs % #{}) roots))))))
             (fn [handle]
               (boolean
-               (when-let [ehs (get target->ehs handle)]
-                 (if has-meta?
-                   (some #(except-in-force? tms target->ehs % #{}) ehs)
-                   (some #(jtms/in? tms %) ehs)))))))))))
+               (some (fn [entries]
+                       (some #(jtms/in? tms %) (get entries handle)))
+                     live)))))))))
 
 (defn excepted?
   "Is the sentex at `handle` hidden from `view-context` by a believed `except`?  The

--- a/src/vaelii/impl/serve.clj
+++ b/src/vaelii/impl/serve.clj
@@ -108,6 +108,8 @@
    :prove        (op v/prove)
    :provable?    (op v/provable?)
    :in?          (op v/in?)
+   :believed?    (op v/believed?)
+   :belief-status (op v/belief-status)
    :believed     (op v/believed)
    :why          (op v/why)
    :why-not      (op v/why-not)

--- a/src/vaelii/impl/spec.clj
+++ b/src/vaelii/impl/spec.clj
@@ -210,6 +210,14 @@
 (s/fdef vaelii.core/contexts-of
   :args (s/cat :kb ::kb :sentence ::sentence))
 
+(s/fdef vaelii.core/believed?
+  :args (s/cat :kb ::kb :handle ::handle-arg :context ::context)
+  :ret boolean?)
+
+(s/fdef vaelii.core/belief-status
+  :args (s/cat :kb ::kb :handle ::handle-arg :context ::context)
+  :ret map?)
+
 ;; ---- reads: the lookup-to-query stack -----------------------------------
 
 (s/fdef vaelii.core/lookup
@@ -421,6 +429,8 @@
     vaelii.core/sentexes-with-arg
     vaelii.core/count-with-arg
     vaelii.core/in?
+    vaelii.core/believed?
+    vaelii.core/belief-status
     vaelii.core/sentex
     vaelii.core/justification
     vaelii.core/premise?

--- a/test/golden/api-surface.edn
+++ b/test/golden/api-surface.edn
@@ -14,6 +14,8 @@
   "[[conn sentences context] [conn sentences context opts]]",
   assert-rule
   "[[conn antecedents consequent context] [conn antecedents consequent context opts]]",
+  belief-status "[[conn handle context]]",
+  believed? "[[conn handle context]]",
   call "[[conn op args] [conn op args opts]]",
   client "[[host port] [host port opts]]",
   conflicts "[[conn]]",
@@ -65,7 +67,9 @@
   assert-opt-keys :var,
   assert-rule
   "[[kb antecedents consequent] [kb antecedents consequent context] [kb antecedents consequent context opts]]",
+  belief-status "[[kb handle context]]",
   believed "[[kb handles]]",
+  believed? "[[kb handle context]]",
   bulk-assert-facts! "[[kb facts context] [kb facts context opts]]",
   caches "[[kb]]",
   calculi "[[]]",

--- a/test/vaelii/access_test.clj
+++ b/test/vaelii/access_test.clj
@@ -83,6 +83,18 @@
     (is (seq? (:sentence (access/sentex *remote*
                                         (access/handle-of *remote* '(dog Muffet) 'CxNaturalWorld)))))))
 
+(deftest contextual-belief-introspection-has-local-remote-parity
+  (let [h (v/handle-of tu/*kb* '(dog Muffet) 'CxNaturalWorld)
+        expected (v/belief-status tu/*kb* h 'CxNaturalWorld)]
+    (is (= (v/believed? tu/*kb* h 'CxNaturalWorld)
+           (access/believed? tu/*kb* h 'CxNaturalWorld)
+           (access/believed? (access/local tu/*kb*) h 'CxNaturalWorld)
+           (access/believed? *remote* h 'CxNaturalWorld)))
+    (is (= expected
+           (access/belief-status tu/*kb* h 'CxNaturalWorld)
+           (access/belief-status (access/local tu/*kb*) h 'CxNaturalWorld)
+           (access/belief-status *remote* h 'CxNaturalWorld)))))
+
 (deftest the-vocabulary-reads-the-same-over-the-wire
   ;; a remote client has no records to scan, so term enumeration has to be an op of its
   ;; own — and its ORDER has to survive EDN, which is why `terms` answers a vector

--- a/test/vaelii/belief_status_test.clj
+++ b/test/vaelii/belief_status_test.clj
@@ -3,7 +3,7 @@
 (ns vaelii.belief-status-test
   "Contextual belief introspection: raw IN, exception force, and inheritance stay
   distinct while the status report agrees with the boolean and matching surfaces."
-  (:require [clojure.test :refer [is testing use-fixtures]]
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [vaelii.core :as v]
             [vaelii.impl.jtms :as jtms]
             [vaelii.impl.resolution :as res]
@@ -11,6 +11,10 @@
             [vaelii.test-util :as tu]))
 
 (use-fixtures :each (tu/neutral-fresh tu/fresh))
+
+(deftest raw-in-doc-points-to-contextual-diagnostics
+  (is (re-find #"belief-status" (:doc (meta #'v/in?)))
+      "the raw-IN read points a caller at the diagnostic for contextual disagreement"))
 
 (tu/deftest-kb contextual-belief-status-separates-every-gate
   (tu/with-terms [bright gem CxTop CxSibling CxLeaf]

--- a/test/vaelii/belief_status_test.clj
+++ b/test/vaelii/belief_status_test.clj
@@ -1,0 +1,158 @@
+;; SPDX-License-Identifier: SSPL-1.0
+;; Copyright © 2026 Vaelii LLC and the Vaelii contributors.
+(ns vaelii.belief-status-test
+  "Contextual belief introspection: raw IN, exception force, and inheritance stay
+  distinct while the status report agrees with the boolean and matching surfaces."
+  (:require [clojure.test :refer [is testing use-fixtures]]
+            [vaelii.core :as v]
+            [vaelii.impl.jtms :as jtms]
+            [vaelii.impl.resolution :as res]
+            [vaelii.impl.sentex :as sx]
+            [vaelii.test-util :as tu]))
+
+(use-fixtures :each (tu/neutral-fresh tu/fresh))
+
+(tu/deftest-kb contextual-belief-status-separates-every-gate
+  (tu/with-terms [bright gem CxTop CxSibling CxLeaf]
+    (v/assert kb (list 'genlCx CxTop 'CxWell) 'CxUniverse {:strength :monotonic})
+    (v/assert kb (list 'genlCx CxSibling 'CxWell) 'CxUniverse {:strength :monotonic})
+    (let [inherit-h (v/assert kb (list 'genlCx CxLeaf CxTop) 'CxUniverse
+                              {:strength :monotonic})
+          h (v/assert kb (list bright gem) CxTop {:strength :monotonic})]
+      (testing "belief does not imply assertion-context inheritance"
+        (let [status (v/belief-status kb h CxSibling)]
+          (is (v/believed? kb h CxSibling))
+          (is (= true (:believed? status)))
+          (is (false? (:visible? status)))
+          (is (nil? (:inherited-path status)))
+          (is (empty? (v/sentexes-matching kb (list bright gem) CxSibling)))))
+      (testing "a visible inherited fact carries the exact genlCx support path"
+        (let [status (v/belief-status kb h CxLeaf)]
+          (is (= [{:handle inherit-h :context 'CxUniverse}]
+                 (:inherited-path status)))
+          (is (:visible? status))
+          (is (= (:visible? status)
+                 (v/ask? kb (list bright gem) CxLeaf)))))
+      (testing "same-context inheritance is the empty path"
+        (is (= [] (:inherited-path (v/belief-status kb h CxTop)))))
+      (let [e2 (v/assert kb (list 'except (sx/sentex-handle h)) 'CxWell
+                         {:strength :monotonic})
+            e1 (v/assert kb (list 'except (sx/sentex-handle h)) CxTop
+                         {:strength :monotonic})]
+        (testing "raw IN remains true while a contextual exception removes belief"
+          (let [status (v/belief-status kb h CxLeaf)]
+            (is (v/in? kb h))
+            (is (not (v/believed? kb h CxLeaf)))
+            (is (= false (:believed? status) (:visible? status)))
+            (is (:excepted? status))
+            (is (= (sort-by str [CxTop 'CxWell])
+                   (mapv #(-> (v/sentex kb (:handle %)) :context)
+                         (:exceptions status))))
+            (is (= status (v/belief-status kb h CxLeaf))
+                "the branching forest is deterministic")))
+        (testing "the cheap boolean makes one contextual exception query, not a global scan"
+          (let [calls (atom 0)
+                excepted? res/excepted?]
+            (with-redefs [res/excepted-anywhere?
+                          (fn [& _]
+                            (throw (ex-info "believed? scanned every exception context" {})))
+                          res/excepted?
+                          (fn [& args]
+                            (swap! calls inc)
+                            (apply excepted? args))]
+              (is (false? (v/believed? kb h CxLeaf)))
+              (is (= 1 @calls)))))
+        (let [m (v/assert kb (list 'except (sx/sentex-handle e1)) CxLeaf
+                          {:strength :monotonic})]
+          (testing "a meta-except restores one branch but another live branch still hides"
+            (let [status (v/belief-status kb h CxLeaf)
+                  roots  (into {} (map (juxt :handle identity)) (:exceptions status))]
+              (is (= [{:handle m :in? true :in-force? true :excepted-by []}]
+                     (:excepted-by (get roots e1))))
+              (is (false? (:in-force? (get roots e1))))
+              (is (:in-force? (get roots e2)))
+              (is (:excepted? status))))
+          (v/retract! kb e2)
+          (testing "with the other branch gone, the meta-except restores belief"
+            (let [status (v/belief-status kb h CxLeaf)]
+              (is (v/believed? kb h CxLeaf))
+              (is (= true (:believed? status) (:visible? status)))
+              (is (false? (:excepted? status))))))))))
+
+(tu/deftest-kb status-covers-out-absent-and-malformed-handles
+  (tu/with-terms [flies Tweety CxStatus]
+    (v/assert kb (list 'genlCx CxStatus 'CxWell) 'CxUniverse {:strength :monotonic})
+    (let [h (v/assert kb (list flies Tweety) CxStatus {:strength :default})]
+      (v/assert kb (list 'not (list flies Tweety)) CxStatus {:strength :monotonic})
+      (testing "a defeated sentex is stored but OUT"
+        (let [status (v/belief-status kb h CxStatus)]
+          (is (:stored? status))
+          (is (false? (:in? status)))
+          (is (false? (:believed? status)))
+          (is (false? (:visible? status)))))
+      (testing "nil and an unknown integer without dangling exceptions are all false"
+        (doseq [handle [nil 999999999]]
+          (let [status (v/belief-status kb handle CxStatus)]
+            (is (= handle (:handle status)))
+            (is (false? (:stored? status)))
+            (is (false? (:in? status)))
+            (is (nil? (:assertion-context status)))
+            (is (= [] (:exceptions status)))
+            (is (false? (:excepted? status)))
+            (is (nil? (:inherited-path status)))
+            (is (false? (:believed? status)))
+            (is (false? (:visible? status)))
+            (is (false? (v/believed? kb handle CxStatus))))))
+      (testing "a dangling exception remains diagnosable without making its target stored"
+        (let [missing 999999999
+              eh (v/assert kb (list 'except (sx/sentex-handle missing)) CxStatus
+                           {:strength :monotonic})
+              status (v/belief-status kb missing CxStatus)]
+          (is (false? (:stored? status)))
+          (is (false? (:in? status)))
+          (is (= [eh] (mapv :handle (:exceptions status))))
+          (is (:excepted? status))
+          (is (false? (:believed? status)))
+          (is (false? (:visible? status)))))
+      (testing "malformed handles keep the established typed refusal"
+        (doseq [f [v/believed? v/belief-status]]
+          (let [e (try (f kb [h] CxStatus) nil (catch clojure.lang.ExceptionInfo e e))]
+            (is (= :bad-handle (:type (ex-data e))))))))))
+
+(tu/deftest-kb exception-forest-order-follows-content-not-allocation
+  (tu/with-terms [glows Alpha Beta CxA CxB CxReader]
+    (v/assert kb (list 'genlCx CxReader CxA) 'CxUniverse {:strength :monotonic})
+    (v/assert kb (list 'genlCx CxReader CxB) 'CxUniverse {:strength :monotonic})
+    (let [h1 (v/assert kb (list glows Alpha) CxReader {:strength :monotonic})
+          h2 (v/assert kb (list glows Beta) CxReader {:strength :monotonic})]
+      ;; Same semantic branches, opposite assertion order.
+      (v/assert kb (list 'except (sx/sentex-handle h1)) CxA {:strength :monotonic})
+      (v/assert kb (list 'except (sx/sentex-handle h1)) CxB {:strength :monotonic})
+      (v/assert kb (list 'except (sx/sentex-handle h2)) CxB {:strength :monotonic})
+      (v/assert kb (list 'except (sx/sentex-handle h2)) CxA {:strength :monotonic})
+      (let [contexts (fn [h]
+                       (mapv #(-> (v/sentex kb (:handle %)) :context)
+                             (:exceptions (v/belief-status kb h CxReader))))]
+        (is (= (sort-by str [CxA CxB]) (contexts h1) (contexts h2)))))))
+
+(tu/deftest-kb linear-meta-except-chain-is-evaluated-once-per-node
+  (tu/with-terms [rings Bell CxChain]
+    (let [target (v/assert kb (list rings Bell) CxChain {:strength :monotonic})
+          depth 40]
+      (loop [target target, n depth]
+        (when (pos? n)
+          (recur (v/assert kb (list 'except (sx/sentex-handle target)) CxChain
+                           {:strength :monotonic})
+                 (dec n))))
+      (let [reads (atom 0)
+            in? jtms/in?
+            status (with-redefs [jtms/in? (fn [& args]
+                                            (swap! reads inc)
+                                            (apply in? args))]
+                     (v/belief-status kb target CxChain))
+            node-count (fn node-count [nodes]
+                         (+ (count nodes)
+                            (reduce + 0 (map #(node-count (:excepted-by %)) nodes))))]
+        (is (= depth (node-count (:exceptions status))))
+        (is (<= @reads (+ depth 2))
+            "one raw target read plus at most one cascade read per exception")))))

--- a/test/vaelii/serve_test.clj
+++ b/test/vaelii/serve_test.clj
@@ -114,6 +114,14 @@
           (is (:ok r))
           (is (map? (:result r)))
           (is (= (list dog Muffet) (:sentence (:result r))))))
+      (testing "contextual belief and its status dispatch as EDN-clean reads"
+        (let [h (v/handle-of kb (list dog Muffet) CxServe)
+              believed-r (post-op handler :believed? [h CxServe])
+              status-r   (post-op handler :belief-status [h CxServe])]
+          (is (= {:ok true :result true :status 200} believed-r))
+          (is (:ok status-r))
+          (is (= h (get-in status-r [:result :handle])))
+          (is (true? (get-in status-r [:result :visible?])))))
       (testing "preview answers what a batch would believe, and stores nothing"
         ;; served with the writes because it applies the batch and rolls it back — the
         ;; daemon is the single writer, which is exactly the condition it needs


### PR DESCRIPTION
Reauthored from #35 as Pace Heart per authorship policy.

## Changes
- Public `believed?` and `belief-status` APIs
- Deterministic exception-cascade diagnostic forest
- Client/wire/access/spec/docs/golden parity
- Lazy `hidden-fn` performance repair at the resolution seam
- Discoverability breadcrumb: `(doc v/in?)` now points to `belief-status`

## Verification
- Focused suite: 5 tests, 75 assertions, green
- Full suite: 31/513 focused, 3513/254305 all, 13 backend configs green
- Zero confirmed findings at every severity
- Visibility benchmark: 1.35× within 3.00× bound

Supersedes #35 (same code, reauthored commits).