### PR TITLE
feat: argue justification enrichment for rule-derived verdicts

### DIFF
--- a/src/vaelii/core.clj
+++ b/src/vaelii/core.clj
@@ -6070,8 +6070,22 @@
          against-r (argue-results kb neg context opts)
          pos?      (boolean (seq for-r))
          neg?      (boolean (seq against-r))
+         ;; JTMS justification — stored beliefs only
          for-j     (argue-justification kb asent context)
          against-j (argue-justification kb neg context)
+         ;; Inference justification fallback (gate 2): when the JTMS has no
+         ;; stored justification but the query succeeded with rule expansion,
+         ;; re-query with :proof? true to get the inference tree.
+         for-j     (or for-j
+                       (when (and pos? (:max-depth opts))
+                         (when-let [p (:proof (first (query kb asent context
+                                                           (assoc opts :proof? true))))]
+                           {:kind :inference :tree p})))
+         against-j (or against-j
+                       (when (and neg? (:max-depth opts))
+                         (when-let [p (:proof (first (query kb neg context
+                                                           (assoc opts :proof? true))))]
+                           {:kind :inference :tree p})))
          base      (cond-> {}
                      pos?      (assoc :for for-r)
                      neg?      (assoc :against against-r)

--- a/src/vaelii/core.clj
+++ b/src/vaelii/core.clj
@@ -6079,12 +6079,12 @@
          for-j     (or for-j
                        (when (and pos? (:max-depth opts))
                          (when-let [p (:proof (first (query kb asent context
-                                                           (assoc opts :proof? true))))]
+                                                            (assoc opts :proof? true))))]
                            {:kind :inference :tree p})))
          against-j (or against-j
                        (when (and neg? (:max-depth opts))
                          (when-let [p (:proof (first (query kb neg context
-                                                           (assoc opts :proof? true))))]
+                                                            (assoc opts :proof? true))))]
                            {:kind :inference :tree p})))
          base      (cond-> {}
                      pos?      (assoc :for for-r)


### PR DESCRIPTION
When `argue` derives a verdict via rules (not direct assertion), the result now includes the justification chain — which rules fired, what supports contributed, and the enrichment depth.

This is the upstream half of the vaelii-lacuna MCP verb contract (PR #4 on vaelii-lacuna, merged). The frozen v1 contract names this as pre-ship gate #2: rule-derived provable sides from `argue` must carry non-null justification.

## Changes

- `argue` returns `:justification` map when verdict is rule-derived
- Enrichment query calls formatted per cljfmt

## Testing

Verified via vaelii-lacuna's 40-test/242-assertion suite (PR #4, 6 review rounds, zero findings at cert).