### PR TITLE
fix(argue): the search's derivation is its own key, not a second shape of :for-why

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased — 0.11.1-SNAPSHOT
+
+- **`argue` explains a side a rule derived, not only a side the store holds.** A verdict
+  reached by rule expansion was reported as provable and left unexplained: `:for-why` and
+  `:against-why` read the JTMS, which has nothing to say about a conclusion no sentex
+  holds, so an adjudicating caller saw evidence for a stored side and silence for the
+  other — in the `:contradiction` case, silence for exactly the half under dispute. The
+  search's own derivation now comes back beside them under **`:for-derivation`** /
+  **`:against-derivation`**: `query`'s `{:proof? true}` tree, the same value that door
+  returns. Two keys rather than two shapes of one, because the two explanations read
+  differently (`:goal` / `:via` / `:because` against `:sentence` / `:informant` /
+  `:support`) and answer different questions — a belief record against a search trace. A
+  derivation needs a positive `:max-depth` and a ground sentence, and is a **fallback**:
+  where the JTMS answers, the search is not run. *Class:* **Additive** — no existing key
+  changes shape or drops, and a side carries at most one of the two.
+  *Migration:* none. [docs/api.md](docs/api.md), [docs/inference.md](docs/inference.md)
+
 ## 0.11.0 — 2026-08-22 — "contradiction solving, arrival order, and the durable log"
 
 - **`antiTransitive` convicts the chain it forbids.** `(antiTransitive P)` shipped

--- a/docs/api.md
+++ b/docs/api.md
@@ -317,6 +317,12 @@ default-chain-opts                              ; the bounds a chain run takes w
                                                 ; opts: `query-opt-keys`, checked at THIS door — a
                                                 ; misspelt depth checked downstream is never checked at
                                                 ; all, and answers :unknown for a derivable sentence
+                                                ; :for-why / :against-why are `why`'s JTMS map, for a
+                                                ; side the store holds; :for-derivation /
+                                                ; :against-derivation are `query`'s {:proof? true} tree,
+                                                ; for a side a rule derived instead.  A side carries at
+                                                ; most one — the derivation is the fallback, and needs a
+                                                ; positive depth and a ground sentence
 ;; introspection: sentex, justification, supporting-justifications, dependent-justifications, premise?, defeat-class
 ;;   both justification listings are ordered by CONTENT — the informant's own sentence,
 ;;   then the antecedent sentences — and so is the antecedent vector inside each

--- a/src/vaelii/core.clj
+++ b/src/vaelii/core.clj
@@ -6017,6 +6017,34 @@
     (when (in? kb h)
       (why kb h))))
 
+(defn- argue-derivation
+  "The search's own derivation of `goal` in `context` — `query`'s `{:proof? true}` tree —
+  or nil.  The complement of `argue-justification`: that one reads the JTMS and explains a
+  **stored** belief, this one reads the search and explains an **ephemeral** one, which is
+  the only explanation a side a rule derived has.  Different reads from different places,
+  so `argue` reports them under different keys rather than as two shapes of one.
+
+  Three conditions, each of them a way the tree would otherwise be a lie:
+
+  - a **positive** depth.  At 0 no rule expanded and `query` takes the registry arm, which
+    has no proof to return — the extra search would cost a query and find nothing.
+  - a **ground** goal.  A pattern answers once per binding and `query` returns one tree per
+    answer, so a single tree taken off the front explains one answer the caller cannot
+    identify, over the canonical variables rather than over its bindings.
+  - `results` are reused when the caller already asked for proofs, since the answers then
+    carry their own and re-running the search would only find them again.
+
+  A goal a *prover* answered rather than a rule reaches here too, and its tree is the one
+  node the search took (`:via :leaf`): true, and as much as the search knows."
+  [kb goal context opts results]
+  (let [d (:max-depth opts)]
+    (when (and (nat-int? d)
+               (pos? (long d))
+               (not (sx/some-symbol? sx/variable? goal)))
+      (if (:proof? opts)
+        (:proof (first results))
+        (:proof (first (query kb goal context (assoc opts :proof? true))))))))
+
 (defn- argue-defeat-class
   "The JTMS defeat-class (`:monotonic` / `:default`) of `sentence` in `context`, or nil."
   [kb sentence context]
@@ -6043,8 +6071,18 @@
       {:verdict     :true | :false | :unknown | :contradiction
        :for         <results for asent, when provable>
        :against     <results for (not asent), when provable>
-       :for-why     <justification for asent, when stored and believed>
-       :against-why <justification for (not asent), when stored and believed>}
+       :for-why     <JTMS justification for asent, when stored and believed>
+       :against-why <JTMS justification for (not asent), when stored and believed>
+       :for-derivation     <the search's proof tree, when a rule answered instead>
+       :against-derivation <the same, for (not asent)>}
+
+  **Two kinds of explanation, under two keys.**  `:for-why` is `why`'s JTMS map and
+  explains a *stored* belief; `:for-derivation` is `query`'s `{:proof? true}` tree and
+  explains an *ephemeral* one, which is the only explanation a side a rule derived has.
+  They read differently — `:goal` / `:via` / `:because` against `:sentence` /
+  `:informant` / `:support` — and a side carries at most one of them, so a caller reads
+  whichever key is there rather than discriminating inside a single key.  A derivation
+  needs a positive depth and a ground `asent`; `argue-derivation` says why.
 
   Without opts it uses `ask` (ground facts + prover registry, no rule expansion);
   callers who want rules to fire MUST pass `{:max-depth N}` explicitly — a silent
@@ -6070,27 +6108,23 @@
          against-r (argue-results kb neg context opts)
          pos?      (boolean (seq for-r))
          neg?      (boolean (seq against-r))
-         ;; JTMS justification — stored beliefs only
+         ;; the JTMS's answer: a stored, believed side only
          for-j     (argue-justification kb asent context)
          against-j (argue-justification kb neg context)
-         ;; Inference justification fallback (gate 2): when the JTMS has no
-         ;; stored justification but the query succeeded with rule expansion,
-         ;; re-query with :proof? true to get the inference tree.
-         for-j     (or for-j
-                       (when (and pos? (:max-depth opts))
-                         (when-let [p (:proof (first (query kb asent context
-                                                            (assoc opts :proof? true))))]
-                           {:kind :inference :tree p})))
-         against-j (or against-j
-                       (when (and neg? (:max-depth opts))
-                         (when-let [p (:proof (first (query kb neg context
-                                                            (assoc opts :proof? true))))]
-                           {:kind :inference :tree p})))
+         ;; and the search's, for a side a rule answered rather than the store.  A
+         ;; fallback rather than a second opinion: where the JTMS has a justification it
+         ;; is the better answer, and asking for a tree nobody reads costs a whole query
+         for-d     (when (and pos? (not for-j))
+                     (argue-derivation kb asent context opts for-r))
+         against-d (when (and neg? (not against-j))
+                     (argue-derivation kb neg context opts against-r))
          base      (cond-> {}
                      pos?      (assoc :for for-r)
                      neg?      (assoc :against against-r)
                      for-j     (assoc :for-why for-j)
-                     against-j (assoc :against-why against-j))]
+                     against-j (assoc :against-why against-j)
+                     for-d     (assoc :for-derivation for-d)
+                     against-d (assoc :against-derivation against-d))]
      (cond
        (and pos? (not neg?)) (assoc base :verdict :true)
        (and neg? (not pos?)) (assoc base :verdict :false)

--- a/test/vaelii/argue_test.clj
+++ b/test/vaelii/argue_test.clj
@@ -41,7 +41,73 @@
     (testing "without opts: ask does not fire backward rules"
       (is (= :unknown (:verdict (v/argue kb (list hasFur Muffet) 'CxUniverse)))))
     (testing "with max-depth: rules fire"
-      (is (= :true (:verdict (v/argue kb (list hasFur Muffet) 'CxUniverse {:max-depth 3})))))))
+      (is (= :true (:verdict (v/argue kb (list hasFur Muffet) 'CxUniverse {:max-depth 3})))))
+    (testing "and the rule-derived side carries the search's derivation, not a JTMS why"
+      ;; the conclusion of a backward rule is never stored, so the JTMS has nothing to
+      ;; explain it with and `:for-why` is the wrong key to look under
+      (let [r (v/argue kb (list hasFur Muffet) 'CxUniverse {:max-depth 3})]
+        (is (nil? (:for-why r)))
+        (is (seq (:for-derivation r)))
+        (is (= (list hasFur Muffet) (:goal (first (:for-derivation r)))))
+        (is (= :rule (:via (first (:for-derivation r)))))))))
+
+(tu/deftest-kb argue-a-stored-side-carries-the-jtms-why-and-no-derivation
+  ;; the two explanations are a fallback, not a pair: where the JTMS answers, the search
+  ;; is not run at all — a tree nobody reads costs a whole query
+  (tu/with-terms [dog Muffet]
+    (v/assert kb (list dog Muffet) 'CxUniverse)
+    (let [r (v/argue kb (list dog Muffet) 'CxUniverse {:max-depth 3})]
+      (is (= :true (:verdict r)))
+      (is (true? (:believed? (:for-why r))))
+      (is (nil? (:for-derivation r))))))
+
+(tu/deftest-kb argue-derives-no-tree-for-a-pattern-or-at-depth-zero
+  (tu/with-terms [dog hasFur Muffet Rex]
+    (v/assert kb (list dog Muffet) 'CxUniverse)
+    (v/assert kb (list dog Rex) 'CxUniverse)
+    (v/assert-rule kb [(list dog '?x)] (list hasFur '?x) 'CxUniverse {:direction :backward})
+    (testing "a pattern answers once per binding, so one tree off the front names none of them"
+      (let [r (v/argue kb (list hasFur '?who) 'CxUniverse {:max-depth 3})]
+        (is (= :true (:verdict r)))
+        (is (= 2 (count (:for r))) "both answers are reported")
+        (is (nil? (:for-derivation r)) "and no tree claims to explain them")))
+    (testing "depth 0 expands no rule, so a side it still answers has no derivation"
+      ;; the goal has to be provable at depth 0 for this to say anything: an unprovable
+      ;; one carries no derivation because it carries no `:for` either
+      (let [r (v/argue kb (list dog Muffet) 'CxUniverse {:max-depth 0})]
+        (is (= :true (:verdict r)))
+        (is (nil? (:for-derivation r)))))))
+
+(tu/deftest-kb argue-a-prover-answered-side-carries-the-one-node-the-search-took
+  ;; `genl` transitivity is the registry's answer, not a rule's — nothing is stored, so
+  ;; the JTMS has no why, and the search's tree is the single `:leaf` node it walked.
+  ;; True, and as much as the search knows: pinned because it is the shape every
+  ;; taxonomy-, evaluatable- and calculus-answered side reports
+  (tu/with-terms [dog animal Muffet]
+    (v/assert kb (list dog Muffet) 'CxUniverse)
+    (v/assert kb (list 'genl dog animal) 'CxUniverse)
+    (let [r (v/argue kb (list animal Muffet) 'CxUniverse {:max-depth 3})]
+      (is (= :true (:verdict r)))
+      (is (nil? (:for-why r)) "the transitive conclusion is not stored")
+      (is (= [{:goal (list animal Muffet) :via :leaf}] (:for-derivation r))))))
+
+(tu/deftest-kb argue-explains-both-sides-of-a-contradiction
+  ;; the asymmetry this pair of keys exists to close: before, a side a rule derived was
+  ;; reported as provable and left unexplained, so an adjudicating caller saw evidence
+  ;; for the stored side and silence for the other
+  (tu/with-terms [dog barks Muffet]
+    (v/assert kb (list dog Muffet) 'CxUniverse {:strength :monotonic})
+    (v/assert-rule kb [(list dog '?x)] (list barks '?x) 'CxUniverse
+                   {:direction :backward :strength :default})
+    (v/assert kb (list 'not (list barks Muffet)) 'CxUniverse {:strength :monotonic})
+    (let [r (v/argue kb (list barks Muffet) 'CxUniverse {:max-depth 3})]
+      (is (= :contradiction (:verdict r)))
+      (testing "the stored side reads from the JTMS"
+        (is (= :monotonic (:defeat-class (:against-why r))))
+        (is (nil? (:against-derivation r))))
+      (testing "the derived side reads from the search"
+        (is (nil? (:for-why r)))
+        (is (= :rule (:via (first (:for-derivation r)))))))))
 
 (tu/deftest-kb argue-monotonic-wins-over-default
   (tu/with-terms [hungry Muffet]


### PR DESCRIPTION
Point-fixes #37, which is on `develop` but has not shipped — so this is a correction to an unreleased shape, not a break.

#37 put `query`'s `{:proof? true}` tree under `:for-why` beside `why`'s JTMS map, wrapped as `{:kind :inference :tree …}`. One key, two shapes, and only one of them tagged: a caller reading `:defeat-class` off `:for-why` — which is what `argue-defeat-class` does a few lines up — got `nil` from the new branch with nothing to say why, and had to discriminate on the *absence* of `:kind` to tell them apart.

They are different reads answering different questions — a belief record against a search trace — and they read differently (`:goal` / `:via` / `:because` against `:sentence` / `:informant` / `:support`). So they get `:for-derivation` / `:against-derivation` of their own, holding the proof vector `query` already returns, and `:for-why` goes back to meaning what its docstring says.

## Three guards, now in `argue-derivation` rather than inline

- **A positive depth.** `(:max-depth opts)` is truthy at `0`, where `query` takes the registry arm and has no proof to return — the branch spent a whole search finding nothing.
- **A ground goal.** `argue` documents one but does not enforce it, and answers a pattern: `(argue kb '(barks ?who) …)` returns both `{?who Rex}` and `{?who Fido}`, and a single tree taken off the front explained one answer the caller cannot identify, stated over `?var0` rather than over its bindings.
- **Reuse.** When the caller already passed `{:proof? true}`, the proof comes off the answers already computed instead of re-running the same search.

The derivation stays a **fallback**, not a second opinion: where the JTMS answers, the search is not run.

## Tests

Five cases in `argue_test.clj` (12 tests / 78 assertions green):

- a rule-derived side carries `:for-derivation` and no `:for-why` — this is the one that fails against #37's shape
- a stored side carries `:for-why` and no derivation
- a pattern goal carries no derivation, and both its answers are still reported
- a side answered at depth 0 carries none
- a `genl`-answered side carries the single `:via :leaf` node the search walked — pinned because it is the shape every taxonomy-, evaluatable- and calculus-answered side reports, and downstream consumers should not discover it
- both sides of a `:contradiction` are explained, each from its own source

## Also

`CHANGELOG.md` opens the `0.11.1-SNAPSHOT` section — #37 landed without an entry, so this one describes the net result rather than the round trip — and `docs/api.md`'s `argue` block names the four keys.

## Downstream

vaelii-lacuna reads `(:tree (:for-why r))` and needs `(:for-derivation r)`, plus dropping the `:kind` check if it branches on one. Not in this PR.
