### PR TITLE
fix(checks): a rule's variables answer for every position they stand in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased — 0.11.1-SNAPSHOT
 
+- **A rule's shared variables are held to the argument constraints of every position
+  they stand in.** `args-problem` reads a ground argument and every argument of a rule is
+  a variable, so a rule feeding a text-valued binding into a type-valued slot stored
+  clean and was convicted a conclusion at a time, by a complaint naming the conclusion
+  and never the rule. `checks/check-variable-constraints!` runs on both storage doors and
+  in `check`, and refuses the new `:arg-variable` when two constraints on one variable
+  demand disjoint types; a position counts as type-level when a `genlArg` names it or
+  when its predicate is a `typeRelationPredicate`, which is what constrains `genl`'s
+  second argument. CxAbstract gains `(disjoint character_string predicate)` and
+  `(disjoint integer predicate)` — text and a number are each a thing no relation is —
+  so `(implies (comment ?x ?string) (genl ?x ?string))` is refused rather than stored.
+  *Class:* **Fix.** *Migration:* a KB holding such a rule keeps it; a rule
+  re-asserted through the front door is refused, and the refusal names the variable.
+  [docs/taxonomy.md](docs/taxonomy.md)
+
 - **`argue` explains a side a rule derived, not only a side the store holds.** A verdict
   reached by rule expansion was reported as provable and left unexplained: `:for-why` and
   `:against-why` read the JTMS, which has nothing to say about a conclusion no sentex

--- a/docs/api.md
+++ b/docs/api.md
@@ -456,7 +456,7 @@ It returns a **vector of problems**, empty when the sentence is admissible.  Eac
 map with the `:type` keyword `assert` would have thrown — `:naming`, `:not-ground`,
 `:not-well-formed`, `:not-range-restricted`, `:not-indexable`, `:not-stratified`,
 `:not-assertible`, `:exception-not-closed`, `:arg-type`, `:arg-genl`, `:arg-position`, `:inter-arg-type`,
-`:arg-constraint-kind`, `:arity`, `:disjoint`, `:functional`, `:asymmetric` — a readable
+`:arg-constraint-kind`, `:arg-variable`, `:arity`, `:disjoint`, `:functional`, `:asymmetric` — a readable
 `:message`, and whatever else that check knows (`:arg` / `:expected` / `:position` for an
 arg breach, plus `:trigger` and `:trigger-position` for the `interArg` form, which
 names the argument whose type made the constraint fire; `:cycle` for a stratification

--- a/docs/nmtms.md
+++ b/docs/nmtms.md
@@ -1024,7 +1024,7 @@ nesting of the two are classified alike. Every rejection carries an `ex-info` `:
 so a caller discriminates on that rather than guessing from which keys are present:
 `:naming` `:not-well-formed` `:not-ground` `:not-range-restricted` `:not-indexable`
 `:not-assertible` `:arity` `:arg-type` `:arg-genl` `:arg-position` `:inter-arg-type`
-`:arg-constraint-kind` `:disjoint` `:functional` `:asymmetric` `:not-stratified`
+`:arg-constraint-kind` `:arg-variable` `:disjoint` `:functional` `:asymmetric` `:not-stratified`
 `:exception-not-closed`, plus the two about the *request* rather than the knowledge —
 `:shape` (the context is not a symbol, the sentence is not an s-expression, or it is a
 vector — which is how a query spells a conjunction, so one spelling would store a

--- a/docs/taxonomy.md
+++ b/docs/taxonomy.md
@@ -2,7 +2,7 @@
 
 - **Covers:** how the `genl` type hierarchy is cached and queried, how `disjoint` /
   `disjointMetatype` are enforced, and how `arg` / `genlArg` constrain arguments as a
-  rejection check.
+  rejection check — of a ground sentence, and of a rule's shared variables.
 - **Not here:** `genlCx`, the sibling closure over contexts rather than types →
   [contexts.md](contexts.md); `arg` / `genlArg` read as an entailment that mints a
   stored, justified fact → [argtypes.md](argtypes.md).
@@ -1279,6 +1279,50 @@ rejects a wrongly-typed argument), and as an *inference* when querying — the
 `ArgTypeProver` (see [inference.md](inference.md)) concludes an individual's type
 from the arg-constrained position it fills, so a thing's type can follow from
 how it is used, not only from a stored membership.
+
+### And against the variables of a rule
+
+`args-problem` reads a **ground** argument. Every argument of a rule is a variable, so
+it passes over all of them vacuously — and a rule whose variable-binding chain feeds an
+impossible term into a position is stored, fires, and is then convicted one conclusion
+at a time by a complaint naming the conclusion and never the rule that wrote it.
+
+A variable is one term standing in several positions at once, so
+`checks/check-variable-constraints!` holds the positions to **each other** before the
+rule is stored — on both storage doors and in `check`, since it rides `check-rule!`.
+It refuses `:arg-variable`:
+
+```clojure
+(v/check kb '(implies (comment ?x ?string) (genl ?x ?string)) 'CxUniverse)
+;; [{:type :arg-variable :variable ?string :expected [character_string unaryPredicate]
+;;   :message "arg constraint: ?string must be a character_string (arg 2 of comment)
+;;             and a type (arg 2 of genl, a typeRelationPredicate), and the two types
+;;             are disjoint"}]
+```
+
+`(implies (arg ?pred ?n ?kind) (genl ?pred ?kind))` is the shape that must *pass*, and
+does: `?kind` is asked for a kind at both ends.
+
+**A type-level position asks for a `unaryPredicate`**, which is what makes the two
+demands comparable at all — `disjoint` separates *memberships*, and a subtype demand is
+not one until it is read as the membership every type carries. A position is type-level
+when a `genlArg` names it **or** when its predicate is a `typeRelationPredicate`, the
+mark saying that of every position at once; that second half is how `genl`'s second
+argument is constrained, since it deliberately carries no declaration of its own
+(CxCore says why).
+
+Three restrictions keep the arm to what it can actually prove:
+
+- **Instance demand against instance demand only.** Two *subtype* demands are left
+  alone: a type below two disjoint types is empty, not impossible, and nothing else in
+  the KB refuses an empty type.
+- **Positive literals only.** A negated antecedent says the variable does *not* fill
+  that position, so `(implies (and (dog ?x) (not (plant ?x))) …)` is saying exactly what
+  its author meant; an existential is skipped because its variables are local.
+- **Declared disjointness only**, so the arm stays as open-world as the ground one. The
+  literal types carry the declaration that makes the case above bite —
+  `(disjoint character_string predicate)` and `(disjoint integer predicate)` in
+  CxAbstract, text and a number each being a thing no relation is.
 
 ## What is cached, what is not, and why
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -152,6 +152,7 @@ without storing anything, and answers with the identical problem.
 | `:not-well-formed` | a malformed connective frame, such as a bare `(implies)` |
 | `:not-range-restricted` | a rule variable in the consequent that no antecedent binds |
 | `:arg-type` / `:arg-genl` | an `arg` / `genlArg` constraint convicted it — [argtypes.md](argtypes.md) |
+| `:arg-variable` | a **rule** variable two argument constraints demand disjoint types of — [taxonomy.md](taxonomy.md) |
 | `:disjoint` / `:functional` / `:asymmetric` | a definitional clash — [exceptions.md](exceptions.md) |
 | `:unknown-option` | an option key nothing reads, or a non-map `opts` |
 

--- a/resources/kb/CxCore.txt
+++ b/resources/kb/CxCore.txt
@@ -214,7 +214,9 @@
 ;; cannot satisfy: genl is irreflexive here, so (genl thing thing) is refused as
 ;; not-well-formed. Under the assertive reading the declaration would therefore entail
 ;; a conclusion the KB drops, once per genl edge naming thing. A constraint the root
-;; fails is the wrong constraint, not a missing one.
+;; fails is the wrong constraint, not a missing one. The position is not thereby
+;; unconstrained: genl is a typeRelationPredicate, which says of every one of its
+;; positions what genlArg says of one, and the rule-variable check reads it that way.
 
 (comment reifiableFunction
          "(reifiableFunction ?function) means that ?function denotes an object. A ground application of it is a non-atomic term, and reifies to an opaque nat/-namespaced constant before it reaches the index, so it autoindexes like an atomic symbol while every page still renders it as the expression it was minted from. See docs/nat.md.")

--- a/resources/kb/upper/CxAbstract.txt
+++ b/resources/kb/upper/CxAbstract.txt
@@ -24,6 +24,11 @@
 
 (comment character_string "A run of text. The type is stated so a text-valued argument position can name what it holds; no string carries a type membership, so nothing is ever checked against it.")
 (genl character_string intangible)
+;; Text and a relation are both intangible and are not each other, and saying so is
+;; what lets a rule be refused for feeding a text-valued argument into a position that
+;; holds a type: every type is a unaryPredicate, so the type position asks for a
+;; predicate, and a variable cannot be both at once.
+(disjoint character_string predicate)
 
 (comment clothing "An artifact worn on the body.")
 (genl clothing artifact)
@@ -57,6 +62,7 @@
 
 (comment integer "A whole number. Stated for the same reason as character_string, and inert for the same reason.")
 (genl integer intangible)
+(disjoint integer predicate)
 
 (comment language "A system of signs a person speaks, writes or signs in.")
 (genl language intangible)

--- a/src/vaelii/core.clj
+++ b/src/vaelii/core.clj
@@ -1989,7 +1989,8 @@
 (defn- rule-problems
   "The pre-storage checks a rule must pass — per conjunct of its consequent, since
   `assert` checks every conjunct of a polycanonicalized rule before storing any of
-  them.  Covers the imperative ban, range-restriction, naming, and stratification."
+  them.  Covers the imperative ban, range-restriction, naming, the argument constraints
+  the rule's own variables carry, and stratification."
   [kb sentence context]
   (first-problems
    (for [form (rules/expand-consequent sentence)]
@@ -2044,6 +2045,8 @@
     :not-stratified        a cycle through negation the rule or edge would close
     :not-assertible        a `do/` imperative inside a rule
     :arg-type              an arg constraint on an argument
+    :arg-variable          two argument constraints on one rule variable that no
+                           term satisfies at once
     :disjoint              a type membership the taxonomy separates
     :functional            a second, irreconcilable value for a functional slot
     :asymmetric            the converse of a claim a declared-asymmetric relation made
@@ -3993,7 +3996,7 @@
   | `:not-well-formed` | a minted sentence a special predicate's own structure check refuses | `:problems` `:message` |
   | `:naming` | a minted sentence breaking a naming invariant — the spellings in docs/naming.md | `:message` |
   | `:no-placement` | the join completed and no context sees the rule, every antecedent fact, and the `genl` edges the match climbed | `:rule-context` `:fact-contexts` `:subsumed` `:would-place` `:message` |
-  | `:not-range-restricted` / `:not-indexable` / `:not-assertible` / `:exception-not-closed` / `:naf-not-closed` / `:quantifier-not-local` / `:quantified-conjunction` | a rule a **generator** minted that the rule checks refuse — the list both storage doors read, so a mint owes what an author's rule owes | the refusal's own keys, and `:message` |
+  | `:not-range-restricted` / `:not-indexable` / `:not-assertible` / `:exception-not-closed` / `:naf-not-closed` / `:quantifier-not-local` / `:quantified-conjunction` / `:arg-variable` | a rule a **generator** minted that the rule checks refuse — the list both storage doors read, so a mint owes what an author's rule owes | the refusal's own keys, and `:message` |
 
   An **arbitrable** clash is not dropped when a *rule* concluded it: a firing has no
   caller to refuse, so the conclusion is placed and this settle weighs the pair, which is

--- a/src/vaelii/impl/checks.clj
+++ b/src/vaelii/impl/checks.clj
@@ -2442,6 +2442,171 @@
     (throw (ex-info (str "a do/ imperative cannot appear in a rule: " (pr-str bad))
                     {:type :not-assertible :form bad :sentence sentence}))))
 
+;; ---- the argument constraints a rule's variables carry -------------------
+;;
+;; `args-problem` holds a **ground** argument to what its position declares.  Every
+;; argument of a rule is a variable, so that arm passes over all of them vacuously and
+;; the rule is stored — and then each fact the rule concludes is convicted one at a
+;; time, by a complaint naming the conclusion and never the rule that wrote it.
+;;
+;; A variable is one term standing in several positions at once, though, so the
+;; positions can be held to **each other** before anything fires.  A variable an
+;; antecedent binds through `(arg comment 2 character_string)` and a consequent places
+;; into `(genl ?x ?string)` has to be a run of text and a type at the same time, and
+;; text and a type are declared disjoint: no term is both, so every firing of that rule
+;; would conclude something the door refuses.  The rule is the mistake, and this is
+;; where it is said.
+;;
+;; **A type-level position asks for a type, which is a `unaryPredicate`.**  That is the
+;; second reading this arm needs and the KB already holds it twice over: every type is
+;; asserted a `unaryPredicate` when the schema loads, and `declaration-problem` refuses
+;; an `arg` declaration on a `typeRelationPredicate` precisely because *its* arguments
+;; name kinds.  So a position is type-level when a `genlArg` names it **or** when its
+;; predicate is a `typeRelationPredicate` — which is how `genl`'s second argument is
+;; constrained at all.  That position carries no declaration of its own, deliberately
+;; (see CxCore), and the relation kind is what says what it holds.
+;;
+;; **Instance constraint against instance constraint, and nothing else.**  `(disjoint T
+;; U)` says the two types share no instance, which is exactly what two such constraints
+;; on one variable ask of it — the reading `args-problem` gives a ground term, asked of
+;; a term that is not there yet.  Two *subtype* constraints are left alone: a type below
+;; two disjoint types is empty rather than impossible, and nothing else in the KB
+;; refuses an empty type.
+;;
+;; **Positive literals only.**  A negated antecedent says the variable does not fill
+;; that position, so a constraint carried there is one no binding ever has to satisfy;
+;; reading it would refuse `(implies (and (dog ?x) (not (plant ?x))) …)` for saying
+;; exactly what its author meant.  An existential is skipped for the reason its
+;; variables are local: what it binds inside is not the variable the rest shares.
+
+(def ^:private collection-type
+  "The type a **type-level** argument position asks its filler to be an instance of.
+  Every type in the KB is asserted a `unaryPredicate` as the schema loads, so this is
+  what `genlArg`'s \"a subtype of T\" and `typeRelationPredicate`'s \"relates kinds\"
+  both amount to as a membership — and a membership is what `disjoint` separates."
+  'unaryPredicate)
+
+(defn- binding-literals
+  "The literals of rule `inner` that **bind** its variables: every positive antecedent,
+  plus the consequent — with an `(ist Ctx S)` consequent replaced by the `S` it places,
+  since that is the sentence the conclusion is stored as and so the one whose argument
+  positions the conclusion has to satisfy."
+  [inner]
+  (let [c (rules/consequent inner)
+        c (if (and (sequential? c) (= sx/ist-functor (first c)) (= 3 (count c)))
+            (nth c 2)
+            c)]
+    (conj (into []
+                (remove #(or (sx/negation? %) (sx/unknown? %) (sx/there-exists? %)))
+                (rules/antecedents inner))
+          c)))
+
+(defn- literal-variable-constraints
+  "The memberships one literal demands of the variables sitting in its arguments, as
+  `[[variable {:type T :position n :pred P :via V :level :arg|:genlArg|:kind}] …]`.
+
+  Two sources, and they are the two readings a position can carry.  An `(arg P n T)`
+  declaration types the filler directly.  A **type-level** position — one a `genlArg`
+  names, or any position of a `typeRelationPredicate` — types it as a
+  `unaryPredicate`, since what stands there is a kind.  `:level` is kept so the refusal
+  can say which reading it read, and `:via` so a constraint that descended from a
+  super-predicate names the predicate it was written of, exactly as `args-problem` does.
+
+  Walked in `in-content-order`, so which declaration a refusal names is decided by what
+  the KB says rather than by how the retrieval happened to enumerate."
+  [kb lit context]
+  (let [pred (nm/functor lit)
+        as   (vec (nm/args lit))]
+    (when (and (sequential? lit) (symbol? pred) (some sx/variable? as))
+      (let [decls    (declaration-reader kb pred context)
+            type-rel (seq (res/matches-visible kb (list 'typeRelationPredicate pred) context))
+            of-kind  (fn [kind mk]
+                       (for [m     (in-content-order (decls kind))
+                             :let  [b (nth m 1)
+                                    n (get b '?n)
+                                    a (arg-at as n)]
+                             :when (and (sx/variable? a) (symbol? (get b '?type)))]
+                         [a (mk m b n)]))]
+        (concat
+         (of-kind 'arg
+                  (fn [m b n] {:type (get b '?type) :position n :pred pred
+                               :via (declared-of m) :level :arg}))
+         (of-kind 'genlArg
+                  (fn [m _ n] {:type collection-type :position n :pred pred
+                               :via (declared-of m) :level :genlArg}))
+         (when type-rel
+           (for [[i a] (map-indexed vector as)
+                 :when (sx/variable? a)]
+             [a {:type collection-type :position (inc i) :pred pred
+                 :via pred :level :kind}])))))))
+
+(defn- variable-constraints
+  "`variable -> [{…} …]` over `literals`, in literal order — the whole of what a rule's
+  own text says its variables have to be."
+  [kb literals context]
+  (reduce (fn [acc lit]
+            (reduce (fn [acc [v c]] (update acc v (fnil conj []) c))
+                    acc
+                    (literal-variable-constraints kb lit context)))
+          {} literals))
+
+(defn- variable-constraint-clause
+  "How a refusal names one constraint it found — **a character_string (arg 2 of
+  comment)**, or **a type (arg 2 of genl, a typeRelationPredicate)** for a position
+  whose demand comes from the relation kind rather than from a declaration.  Carries
+  `via-clause` for a constraint that descended from a super-predicate, exactly as
+  `args-problem`'s message does."
+  [{:keys [type position pred via level]}]
+  (str (case level
+         :arg     (str "a " type)
+         :genlArg "a type"
+         :kind    "a type")
+       " (arg " position " of " pred
+       (case level
+         :genlArg (str ", constrained with genlArg" (via-clause via pred))
+         :kind    ", a typeRelationPredicate"
+         (via-clause via pred))
+       ")"))
+
+(defn- variable-clash-problem
+  "The first pair of constraints on one of rule `inner`'s variables that no term
+  satisfies at once, or nil.
+
+  Only two **instance** demands can convict: `disjoint` says two types share no
+  instance, and a membership is what each of these constraints asks for — the
+  `unaryPredicate` a type-level position asks for included.  Variables are taken in
+  name order and each one's constraints in literal-then-content order, so a rule
+  several of whose variables clash is refused for the same one every time."
+  [kb inner context]
+  (let [taxo   (:taxonomy kb)
+        by-var (variable-constraints kb (binding-literals inner) context)]
+    (first
+     ;; `str` rather than `pr-str`: a rule variable is a symbol, so the key is a scalar
+     ;; that no ambient `*print-length*` can collapse to a shared prefix
+     (for [v     (sort-by str (keys by-var))
+           :let  [cs (get by-var v)]
+           :when (< 1 (count cs))
+           [i a] (map-indexed vector cs)
+           b     (drop (inc i) cs)
+           :when (and (not= (:type a) (:type b))
+                      (tax/disjoint? taxo (:type a) (:type b) context))]
+       {:type :arg-variable :sentence inner :variable v
+        :expected [(:type a) (:type b)]
+        :message (str "arg constraint: " v " must be " (variable-constraint-clause a)
+                      " and " (variable-constraint-clause b)
+                      ", and the two types are disjoint")}))))
+
+(defn- check-variable-constraints!
+  "Throw when a variable of rule `inner` carries two argument constraints no term can
+  satisfy together.  The value form is `variable-clash-problem`; this is the door's.
+
+  Private, unlike the cross-namespace rule checks beside it in `check-rule!`: every
+  door that stores a rule reaches this through that list, so there is no second caller
+  for a public name to serve."
+  [kb inner context]
+  (when-let [p (variable-clash-problem kb inner context)]
+    (throw (ex-info (:message p) (dissoc p :message)))))
+
 ;; ---- generators: the refusals a rule concluding a rule owes ---------------
 ;; A generator is a rule and passes everything a rule passes.  What follows is what it
 ;; owes *as* a generator, and every one of them is asked of each nesting level, since a
@@ -2609,6 +2774,12 @@
   C1 already stored, indexed, and chained from, while the caller saw a throw and
   reasonably concluded nothing had been asserted.
 
+  One arm here has no counterpart on the fact path at all —
+  `check-variable-constraints!`, which holds a rule's shared variables to the argument
+  constraints of every position they stand in.  A ground argument is checked by
+  `constraint-checks` on the way in; a variable is checked here or nowhere, since the
+  term it will hold does not exist yet.
+
   A **generator** owes three more (`check-generator!`), and they run last so the
   sharper complaint comes first: a rule that is unbound *and* backward-only is refused
   for the unbound variable, which is the one its author can act on."
@@ -2637,6 +2808,12 @@
     (when-not (= :inert direction)
       (rules/check-indexable-functors inner))
     (nm/check! (:naming kb) inner context)
+    ;; the argument constraints the rule's own variables carry, checked against each
+    ;; other — the arm above this file's `binding-literals` explains.  Here rather than
+    ;; on the fact path because a variable is not an argument any ground check can see,
+    ;; and after naming because it reads declarations off the functors naming just
+    ;; passed.
+    (check-variable-constraints! kb inner context)
     ;; the rule-set check, before anything is stored: an `exceptWhen` is negation as
     ;; failure, and a cycle through it would make the settled state depend on
     ;; arrival order (docs/exceptions.md)

--- a/src/vaelii/impl/sentex.clj
+++ b/src/vaelii/impl/sentex.clj
@@ -491,7 +491,10 @@
        (symbol? (first form))
        (= do-namespace (namespace (first form)))))
 
-(defn- negation? [form]
+(defn negation?
+  "Is `form` a negation `(not <body>)`?  Arity checked, so a `not` at any other arity
+  is not one."
+  [form]
   (and (sequential? form) (= not-functor (first form)) (= 2 (count form))))
 
 (defn implies?

--- a/src/vaelii/impl/serve.clj
+++ b/src/vaelii/impl/serve.clj
@@ -274,7 +274,8 @@
   born, and `wire_contract_test` pins the pairing."
   #{:naming :not-well-formed :not-ground :not-range-restricted :not-indexable
     :shape :not-encodable
-    :arg-type :inter-arg-type :arg-genl :quoted-arg-type :arg-position :arg-constraint-kind :arity
+    :arg-type :inter-arg-type :arg-genl :quoted-arg-type :arg-position :arg-constraint-kind
+    :arg-variable :arity
     :disjoint :functional :asymmetric :anti-transitive :unknown-option :bad-handle
     :unknown-handle :bad-level :exception-not-closed :not-stratified :naf-not-closed
     :quantifier-not-local :quantified-conjunction

--- a/src/vaelii/impl/web.clj
+++ b/src/vaelii/impl/web.clj
@@ -1101,6 +1101,7 @@
    :quoted-arg-type      "quoted arg"
    :arg-position         "arg slot"
    :arg-constraint-kind  "arg kind"
+   :arg-variable         "arg var"
    :arity                "arity"
    :disjoint             "disjoint"
    :asymmetric           "both ways"

--- a/test/vaelii/rule_variable_arg_test.clj
+++ b/test/vaelii/rule_variable_arg_test.clj
@@ -1,0 +1,150 @@
+;; SPDX-License-Identifier: SSPL-1.0
+;; Copyright © 2026 Vaelii LLC and the Vaelii contributors.
+(ns vaelii.rule-variable-arg-test
+  "The argument constraints a rule's own variables carry, checked against each other.
+
+  `args-problem` reads a ground argument, and every argument of a rule is a variable, so
+  it passes over all of them vacuously.  Without the arm below, a rule whose binding
+  chain feeds an impossible term into a position stores clean and is convicted later,
+  one conclusion at a time, by a complaint naming the conclusion and never the rule.
+  `checks/check-variable-constraints!` holds the positions a variable stands in to each
+  other instead, and refuses `:arg-variable`.
+
+  Two arms, and the second is the one that needs saying: a position is type-level when a
+  `genlArg` names it **or** when its predicate is a `typeRelationPredicate`, which says
+  it of every position at once.  That second half is what constrains `genl`'s second
+  argument, the one position in CxCore's schema carrying no declaration of its own."
+  (:require [clojure.test :refer [is testing use-fixtures]]
+            [vaelii.core :as v]
+            [vaelii.impl.starter :as starter]
+            [vaelii.test-util :as tu]))
+
+(use-fixtures :once (tu/loaded starter/load-into))
+(use-fixtures :each (tu/neutral))
+
+(defn- ex-type
+  "The `:type` on the ex-info a thunk throws, or nil when it does not throw.  Named
+  rather than a bare `thrown?` for `arggenl_test`'s reason: an `:arg-variable` refusal
+  collapsing into a naming or range-restriction one is exactly the regression a
+  type-blind assertion stays green through."
+  [f]
+  (try (f) nil (catch clojure.lang.ExceptionInfo e (:type (ex-data e)))))
+
+(defn- disjoint-pair
+  "Two types the KB has been told share no instance, plus a third unrelated to both.
+  Returns `[a b c]`."
+  [kb]
+  (let [a (tu/tmp-type) b (tu/tmp-type) c (tu/tmp-type)]
+    (doseq [t [a b c]] (v/assert kb (list 'genl t 'thing) 'CxUniverse))
+    (v/assert kb (list 'disjoint a b) 'CxUniverse)
+    [a b c]))
+
+;; ---- two instance constraints on one variable ---------------------------
+
+(tu/deftest-kb a-variable-two-arg-constraints-separate-is-refused
+  (let [[a b] (disjoint-pair kb)
+        p (tu/tmp-pred) q (tu/tmp-pred)]
+    (v/assert kb (list 'arg p 1 a) 'CxUniverse)
+    (v/assert kb (list 'arg q 1 b) 'CxUniverse)
+    (testing "the antecedent binds ?x an a, the consequent places it where a b belongs"
+      (is (= :arg-variable
+             (ex-type #(v/assert kb (list 'implies (list p '?x) (list q '?x)) 'CxUniverse)))))
+    (testing "check predicts the refusal, and writes nothing"
+      (let [ps (v/check kb (list 'implies (list p '?x) (list q '?x)) 'CxUniverse)]
+        (is (= [:arg-variable] (mapv :type ps)))
+        (is (= '?x (:variable (first ps))))
+        (is (= #{a b} (set (:expected (first ps)))))))))
+
+(tu/deftest-kb a-variable-two-compatible-arg-constraints-stands
+  (let [[a _ c] (disjoint-pair kb)
+        p (tu/tmp-pred) q (tu/tmp-pred)]
+    (v/assert kb (list 'arg p 1 a) 'CxUniverse)
+    (v/assert kb (list 'arg q 1 c) 'CxUniverse)
+    (testing "nothing separates the two types, so the rule is admissible"
+      (is (= [] (v/check kb (list 'implies (list p '?x) (list q '?x)) 'CxUniverse)))
+      (is (v/assert kb (list 'implies (list p '?x) (list q '?x)) 'CxUniverse)))))
+
+(tu/deftest-kb the-clash-is-found-inside-one-literal-too
+  (let [[a b] (disjoint-pair kb)
+        p (tu/tmp-pred) q (tu/tmp-pred)]
+    (v/assert kb (list 'arity q 2) 'CxUniverse)
+    (v/assert kb (list 'arg p 1 a) 'CxUniverse)
+    (v/assert kb (list 'arg q 1 a) 'CxUniverse)
+    (v/assert kb (list 'arg q 2 b) 'CxUniverse)
+    (testing "one variable in both positions of a literal is still one term"
+      (is (= :arg-variable
+             (ex-type #(v/assert kb (list 'implies (list p '?x) (list q '?x '?x))
+                                 'CxUniverse)))))))
+
+(tu/deftest-kb a-negated-antecedent-constrains-nothing
+  (let [[a b] (disjoint-pair kb)
+        p (tu/tmp-pred) q (tu/tmp-pred) r (tu/tmp-pred)]
+    (v/assert kb (list 'arg p 1 a) 'CxUniverse)
+    (v/assert kb (list 'arg q 1 b) 'CxUniverse)
+    (v/assert kb (list 'arg r 1 a) 'CxUniverse)
+    (testing "`(not (q ?x))` says ?x is not a b — which is what its author meant"
+      (is (= [] (v/check kb (list 'implies (list 'and (list p '?x) (list 'not (list q '?x)))
+                                  (list r '?x))
+                         'CxUniverse)))
+      (is (v/assert kb (list 'implies (list 'and (list p '?x) (list 'not (list q '?x)))
+                             (list r '?x))
+                    'CxUniverse)))))
+
+(tu/deftest-kb the-constraint-descends-the-predicate-hierarchy
+  (let [[a b] (disjoint-pair kb)
+        p (tu/tmp-pred) q (tu/tmp-pred) sub (tu/tmp-pred)]
+    (v/assert kb (list 'arg p 1 a) 'CxUniverse)
+    (v/assert kb (list 'arg q 1 b) 'CxUniverse)
+    (v/assert kb (list 'genl sub q) 'CxUniverse)
+    (testing "a super-predicate's declaration binds the sub-predicate's tuples here too"
+      (is (= :arg-variable
+             (ex-type #(v/assert kb (list 'implies (list p '?x) (list sub '?x)) 'CxUniverse))))
+      (is (re-find (re-pattern (str "declared of " q))
+                   (:message (first (v/check kb (list 'implies (list p '?x) (list sub '?x))
+                                             'CxUniverse))))))))
+
+;; ---- the type-level half ------------------------------------------------
+
+(tu/deftest-kb a-genlArg-position-asks-for-a-type
+  (let [text (tu/tmp-type)
+        p (tu/tmp-pred) rel (tu/tmp-pred)]
+    (v/assert kb (list 'genl text 'thing) 'CxUniverse)
+    (v/assert kb (list 'disjoint text 'unaryPredicate) 'CxUniverse)
+    (v/assert kb (list 'arg p 1 text) 'CxUniverse)
+    (v/assert kb (list 'typeRelationPredicate rel) 'CxUniverse)
+    (v/assert kb (list 'genlArg rel 1 'thing) 'CxUniverse)
+    (testing "a variable bound to a text is not a kind, so it cannot fill a kind slot"
+      (is (= :arg-variable
+             (ex-type #(v/assert kb (list 'implies (list p '?x) (list rel '?x)) 'CxUniverse)))))))
+
+(tu/deftest-kb a-typeRelationPredicate-constrains-a-position-no-declaration-names
+  (let [text (tu/tmp-type)
+        p (tu/tmp-pred) rel (tu/tmp-pred)]
+    (v/assert kb (list 'genl text 'thing) 'CxUniverse)
+    (v/assert kb (list 'disjoint text 'unaryPredicate) 'CxUniverse)
+    (v/assert kb (list 'arity rel 2) 'CxUniverse)
+    (v/assert kb (list 'arg p 1 text) 'CxUniverse)
+    (v/assert kb (list 'typeRelationPredicate rel) 'CxUniverse)
+    (v/assert kb (list 'genlArg rel 1 'thing) 'CxUniverse)   ; position 1 only
+    (testing "the relation kind says of position 2 what no genlArg was written for"
+      (is (= :arg-variable
+             (ex-type #(v/assert kb (list 'implies (list p '?x) (list rel (tu/tmp-type) '?x))
+                                 'CxUniverse))))
+      (is (re-find #"typeRelationPredicate"
+                   (:message (first (v/check kb (list 'implies (list p '?x)
+                                                      (list rel (tu/tmp-type) '?x))
+                                             'CxUniverse))))))))
+
+;; ---- the two forms the issue named --------------------------------------
+
+(tu/deftest-kb the-shipped-schema-refuses-a-string-fed-into-a-type-slot
+  (testing "?kind is asked for a kind at both ends — admissible"
+    (is (= [] (v/check kb '(implies (arg ?pred ?n ?kind) (genl ?pred ?kind)) 'CxUniverse)))
+    (is (v/assert kb '(implies (arg ?pred ?n ?kind) (genl ?pred ?kind)) 'CxUniverse)))
+  (testing "?string is a character_string in the antecedent and a kind in the consequent"
+    (let [form '(implies (comment ?x ?string) (genl ?x ?string))
+          ps   (v/check kb form 'CxUniverse)]
+      (is (= [:arg-variable] (mapv :type ps)))
+      (is (= '?string (:variable (first ps))))
+      (is (= '[character_string unaryPredicate] (:expected (first ps))))
+      (is (= :arg-variable (ex-type #(v/assert kb form 'CxUniverse)))))))

--- a/test/vaelii/type_contract_test.clj
+++ b/test/vaelii/type_contract_test.clj
@@ -150,7 +150,7 @@
   or renamed keyword fails the comparison below until it is added here deliberately —
   with a changelog entry, since callers discriminate on it (CONTRIBUTING.md §3.8)."
   #{:already-loaded :anti-symmetric :anti-transitive :arg-constraint-kind :arg-genl :arg-position
-    :arg-type :arity :asymmetric :bad-algebra :bad-arg
+    :arg-type :arg-variable :arity :asymmetric :bad-algebra :bad-arg
     :bad-args :bad-cursor :bad-foreign-manifest :bad-handle :bad-host
     :bad-level :bad-registrant :bad-reply
     :bad-snapshot :bad-table-entry :base-is-overlay :body-too-large

--- a/test/vaelii/violation_roster_test.clj
+++ b/test/vaelii/violation_roster_test.clj
@@ -222,7 +222,7 @@
    "checks/rule-violation"
    {:kinds #{:naming :not-well-formed :not-stratified :not-range-restricted :not-indexable
              :not-assertible :exception-not-closed :naf-not-closed :quantifier-not-local
-             :quantified-conjunction}
+             :quantified-conjunction :arg-variable}
     :why   (str "carries out whatever `:type` `check-rule!` threw, defaulting to "
                 "`:not-well-formed` — so its kinds are the rule checks' refusal "
                 "vocabulary, minted across `checks`, `rules`, `sentex` and `naming`")}


### PR DESCRIPTION
Closes #39.

## The gap

`checks/args-problem` reads a **ground** argument, and every argument of a rule is a variable — so the arm passed over all of them vacuously. A rule whose binding chain fed an impossible term into a position stored clean, fired, and was then convicted one conclusion at a time, by a complaint naming the conclusion and never the rule that wrote it.

## What was off in the report

The negative control's premise — "`genl` arg 2 is a type" — is not something the shipped ontology says. `genl`'s second argument carries **no** `arg` / `genlArg` declaration, deliberately: `(genlArg genl 2 thing)` reads "the supertype is a subtype of thing", which the root cannot satisfy, and CxCore says so where the position is left blank. Nothing separated `character_string` from a type name either. So comparing declarations alone would not have convicted the form the issue asks to be refused, and the fix needs two more pieces than that.

## The fix

`checks/check-variable-constraints!` rides `check-rule!` — the list both storage doors read, and what `core/check` predicts from — and refuses the new `:arg-variable` when two constraints on one variable demand types the KB has declared disjoint.

**A type-level position asks for a `unaryPredicate`.** That is what makes a subtype demand comparable to an instance demand at all: `disjoint` separates *memberships*, and "a subtype of T" is not one until it is read as the membership every type carries. A position is type-level when a `genlArg` names it **or** when its predicate is a `typeRelationPredicate` — the mark saying it of every position at once, which is already why `declaration-problem` refuses an `arg` declaration on one. That second half is what constrains `genl`'s second argument without adding the declaration CxCore explains it cannot carry.

**`(disjoint character_string predicate)` and `(disjoint integer predicate)`** in CxAbstract. Text and a number are each a thing no relation is; without this the arm has nothing to convict on.

Three restrictions keep it to what it can actually prove:

- **Instance demand against instance demand only.** Two *subtype* demands are left alone — a type below two disjoint types is empty, not impossible, and nothing else in the KB refuses an empty type.
- **Positive literals only.** A negated antecedent says the variable does *not* fill that position, so `(implies (and (dog ?x) (not (plant ?x))) …)` is saying exactly what its author meant; an existential is skipped because its variables are local.
- **Declared disjointness only**, so the arm stays as open-world as the ground check it extends.

## Both controls from the issue

```clojure
(v/check kb '(implies (arg ?pred ?n ?kind) (genl ?pred ?kind)) 'CxUniverse)
;; => []        — ?kind is asked for a kind at both ends, so it must pass, and does

(v/check kb '(implies (comment ?x ?string) (genl ?x ?string)) 'CxUniverse)
;; => [{:type :arg-variable :variable ?string :expected [character_string unaryPredicate]
;;      :message "arg constraint: ?string must be a character_string (arg 2 of comment)
;;                and a type (arg 2 of genl, a typeRelationPredicate), and the two types
;;                are disjoint"}]
```

`assert` refuses the second with the same type and message.

## Also in here

- `sentex/negation?` is published — the rule check is a second namespace that has to tell a negated antecedent from a positive one.
- `:arg-variable` is registered where a refusal type has to be: `serve/refusal-types` (so the wire answers 400, not 500), the web label map, `core/check`'s type list, the violation roster's generator-mint row, `type_contract_test` and `violation_roster_test`.
- `test/vaelii/rule_variable_arg_test.clj` — 8 tests: both issue controls, plus synthetic arms for constraint descension across a `genl` edge between predicates, a negated antecedent constraining nothing, a clash inside one literal, and each of the two type-level sources.
- Documented in `docs/taxonomy.md` ("And against the variables of a rule"), with the roster lines in `api.md`, `nmtms.md` and `troubleshooting.md`.

## Verification

- `lein gate` on this branch: lint 10/10, **3682 tests / 146,804 assertions, 0 failures**.
- `lein perf`: **40/40 checks ok**.
