### PR TITLE
fix(except): a rule-targeting visibility except removes totally in both directions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Unreleased
+
+- **A visibility `except` targeting a rule now removes totally in both directions.**
+  The arrival side already held — the stored justification carries the rule handle
+  among its antecedents, so excepting a rule swept its conclusions and blocked late
+  firings — but the two read-back arms did not. *Departure:* `recheck-except`'s
+  revival arms are keyed on a fact target (`dependents`, empty once the firing is
+  swept, and the predicate fan, which a rule sentence never matches), so retracting a
+  rule-targeting except restored the rule's visibility and none of its conclusions;
+  the target itself is now re-chained when it is a rule. *Backward:* `candidate-rules`
+  filtered direction, belief and context inheritance but never the visibility hidden
+  set, so a goal in the cone rebuilt through the hidden rule exactly what forward
+  chaining had swept — the same `res/hidden-fn` the sweep reads now gates candidacy,
+  nil (one deref) for a KB that hides nothing. Found live: a justified dispute whose
+  defeated side kept ground-succeeding under `query` and holding its `contradictions`
+  entry after its rule was excepted, while the argue tree correctly collapsed.
+  *Class:* **Fix**. *Migration:* none.
+  [docs/contexts.md](docs/contexts.md#except-removing-visibility-down-a-context-subtree)
+
 ## 0.13.0 — 2026-08-25 — "calendar time, joined queries, and the doors that refuse"
 
 - **`:disk` and `:pg-disk` are `:disk-log` and `:pg-disk-log`.** The second `disk` in each

--- a/docs/contexts.md
+++ b/docs/contexts.md
@@ -352,6 +352,13 @@ The removal is **total**, not just for reads:
   except is never placed in the cone; a late except sweeps what already fired; and
   retracting the except **re-derives** what it was hiding. A conclusion placed *above*
   the cone (a context that does not see the except) is untouched.
+- **Rules.** `H` may itself be a rule — a firing rests on its rule exactly as it
+  rests on its facts (the rule handle is in the stored justification), so excepting a
+  rule sweeps its conclusions from the cone, blocks late firings there, and revives
+  them when the except is retracted (`special/recheck-except` re-chains a rule
+  target on departure). The backward chainers honor the same removal:
+  `provers/candidate-rules` drops a rule the asking context cannot see, so `query`
+  and `prove` do not rebuild through a hidden rule what forward chaining swept.
 
 **What the two of them read.** Both go through the KB's `:excepted` roster —
 `{context → {hidden-handle → #{except-handle}}}`, maintained O(1) at the store and

--- a/src/vaelii/impl/chain.clj
+++ b/src/vaelii/impl/chain.clj
@@ -477,8 +477,10 @@
   because this runs once per placement and once per candidate justification, and a rule
   has two or three antecedents where a cone can hide thousands of handles.  A nil
   predicate is the gate — a KB that hides nothing from `pctx` pays a deref and returns
-  here.  A rule handle among `antes` never spuriously matches: a rule is not an `except`
-  target."
+  here.  The rule handle among `antes` matching is load-bearing, not spurious: a rule
+  is a sentex and an `except` may target it, and a firing rests on its rule as it
+  rests on its facts — this is what sweeps a hidden rule's conclusions
+  (`special/recheck-except` carries the departure-side twin)."
   [kb antes pctx]
   (if-let [hidden? (res/hidden-fn kb pctx)]
     (boolean (some hidden? antes))
@@ -1972,8 +1974,9 @@
       ;; from the placement context, there is no conclusion and no justification —
       ;; nothing to defeat and nothing to arbitrate.  The check is per *placement*,
       ;; because all three are evaluated in the conclusion's context and a firing may
-      ;; place into several.  `all-antes` includes the rule handle, never an `except`
-      ;; target, so it cannot spuriously match the hidden set.
+      ;; place into several.  `all-antes` includes the rule handle, which the hidden
+      ;; set matches on purpose: a hidden rule may not fire into the cone any more
+      ;; than a hidden fact may support a firing there.
       ;; `mapcat`, not `map`: one placement yields the conclusion *and* a copy in each
       ;; context the predicate is lifted into, and every one of them is a new datum the
       ;; agenda has to see.

--- a/src/vaelii/impl/provers.clj
+++ b/src/vaelii/impl/provers.clj
@@ -2123,7 +2123,12 @@
   a rule is a sentex, inherited by the ordinary `genlCx` up-cone like everything
   else.  Nor is a rule the KB no longer believes (`res/rule-believed?`) — the
   consequent index posts on storage, so belief is asked of the record here exactly as
-  forward chaining asks it of a trigger.
+  forward chaining asks it of a trigger.  Nor is one a believed visibility `except`
+  hides from the asking context (`res/hidden-fn`): forward chaining sweeps the
+  conclusions of a hidden rule, and a backward pass that rebuilt them through the
+  same rule would answer from knowledge the context deliberately removed.  The
+  predicate is built once per goal and is nil for the almost-every-KB that hides
+  nothing, so the common path pays one deref.
 
   **In content order**, `[sentence context]` under `nm/compare-form`.  The index answers
   in handle-set order, which is assertion order, and two consumers *truncate* on this
@@ -2142,13 +2147,15 @@
   tie back onto the handle."
   [kb goal context]
   (when (sequential? goal)
-    (->> (res/concluding-rule-handles kb (first goal) context)
-         (map #(p/get-sentex (:records kb) %))
-         (filter rules/backward-sentex?)
-         (filter #(res/rule-believed? kb (:id %)))
-         (filter #(res/rule-visible-from? kb context (:context %)))
-         (nm/sort-by-content-key (juxt :sentence :context))
-         (map #(parse-rule kb % context)))))
+    (let [hidden? (res/hidden-fn kb context)]
+      (->> (res/concluding-rule-handles kb (first goal) context)
+           (map #(p/get-sentex (:records kb) %))
+           (filter rules/backward-sentex?)
+           (filter #(res/rule-believed? kb (:id %)))
+           (filter #(res/rule-visible-from? kb context (:context %)))
+           (remove #(and hidden? (hidden? (:id %))))
+           (nm/sort-by-content-key (juxt :sentence :context))
+           (map #(parse-rule kb % context))))))
 
 ;; ---- the engine ---------------------------------------------------------
 

--- a/src/vaelii/impl/special.clj
+++ b/src/vaelii/impl/special.clj
@@ -861,7 +861,16 @@
     * the rules that could **fire on H** (`rules-by-antecedent` over H's predicate and
       its supertypes, the same fan matching does) — the conclusions to re-derive when
       the except leaves, since by then the firing that used H has been swept away and
-      `dependents` no longer names it.
+      `dependents` no longer names it; and
+
+    * **H itself, when H is a rule.**  A firing rests on its rule as it rests on its
+      antecedents — the rule handle is in the stored justification, which is what
+      sweeps its conclusions when the except arrives — but on departure the swept
+      firing is gone from `dependents`, and the predicate fan above is keyed on a
+      *fact's* functor, which a rule sentence never matches.  Re-chaining the rule is
+      the departure-side twin the fact arm has in `rules-by-antecedent`: without it,
+      retracting a rule-targeting except revives the rule's visibility and none of
+      its conclusions.
 
   Queuing both on both directions over-approximates (the per-placement hidden-set test
   in `chain/justification-excepted?` and `derive-conclusion`'s block narrow it), which is
@@ -887,7 +896,8 @@
                       (mapcat #(reads/as-stored-rules-by-antecedent (:index kb) %)
                               (rules/trigger-keys (:taxonomy kb) (:sentence target)
                                                   @(:rule-antecedents kb))))
-           marked   (vec (into (set users) firers))]
+           marked   (vec (cond-> (into (set users) firers)
+                           (and target (rules/rule? target)) (conj h)))]
        (mark-recheck kb marked trigger)
        marked))))
 

--- a/test/vaelii/except_rule_visibility_test.clj
+++ b/test/vaelii/except_rule_visibility_test.clj
@@ -3,25 +3,25 @@
 (ns vaelii.except-rule-visibility-test
   "A visibility `(except (sentexHandle R))` whose target is a **rule**.
 
-  docs/contexts.md says the removal is total — reads and derivations both — and the
-  stored justification carries the rule handle among its antecedents, so the arrival
-  side already holds: excepting a rule sweeps its conclusions, and a fact arriving
-  under a hidden rule concludes nothing.  Two arms did not hold before the fix:
+  docs/contexts.md says the removal is total — reads and derivations both.  A firing
+  rests on its rule exactly as it rests on its facts (the stored justification
+  carries the rule handle among its antecedents), and every arm of the machinery has
+  to honor that, including the two whose triggers cannot come for free:
 
-  * **Revival.**  `special/recheck-except`'s departure arms are keyed on a *fact*
-    target — `dependents` (empty once the firing is swept) and the predicate fan
-    (which a rule sentence never matches) — so retracting a rule-targeting except
-    restored the rule's visibility and none of its conclusions.
-  * **Backward chaining.**  `provers/candidate-rules` filtered direction, belief,
-    and context inheritance but never the visibility hidden set, so a goal in the
-    cone quietly rebuilt through the hidden rule what forward chaining had swept.
+  * **Revival.**  `special/recheck-except` re-chains a rule target on departure,
+    because its other arms are keyed on a *fact* target — `dependents` is empty once
+    the firing is swept, and the predicate fan never matches a rule sentence — so
+    without the rule arm nothing re-derives what the except was hiding.
+  * **Backward chaining.**  `provers/candidate-rules` drops a rule the visibility
+    hidden set hides from the asking context, so a goal in the cone cannot rebuild
+    through a hidden rule what forward chaining sweeps.
 
   Each test pins one arm: the sweep of an existing firing, the block of a late one,
   the revival on retraction, the backward chainer's candidate filter, and the
-  dispute-resolution shape the bug was found in (a justified dispute whose defeated
-  side must vanish from every read surface, not only from the argue tree).  House
-  rules as everywhere else: gensym'd temporaries via `tu/with-terms`, engine
-  vocabulary literal, the neutral fixture asserts the KB is restored."
+  dispute-resolution shape (a justified dispute whose defeated side must vanish from
+  every read surface, not only from the argue tree).  House rules as everywhere
+  else: gensym'd temporaries via `tu/with-terms`, engine vocabulary literal, the
+  neutral fixture asserts the KB is restored."
   (:require [clojure.test :refer [is testing use-fixtures]]
             [vaelii.core :as v]
             [vaelii.impl.rules :as vr]

--- a/test/vaelii/except_rule_visibility_test.clj
+++ b/test/vaelii/except_rule_visibility_test.clj
@@ -1,0 +1,128 @@
+;; SPDX-License-Identifier: SSPL-1.0
+;; Copyright © 2026 Vaelii LLC and the Vaelii contributors.
+(ns vaelii.except-rule-visibility-test
+  "A visibility `(except (sentexHandle R))` whose target is a **rule**.
+
+  docs/contexts.md says the removal is total — reads and derivations both — and the
+  stored justification carries the rule handle among its antecedents, so the arrival
+  side already holds: excepting a rule sweeps its conclusions, and a fact arriving
+  under a hidden rule concludes nothing.  Two arms did not hold before the fix:
+
+  * **Revival.**  `special/recheck-except`'s departure arms are keyed on a *fact*
+    target — `dependents` (empty once the firing is swept) and the predicate fan
+    (which a rule sentence never matches) — so retracting a rule-targeting except
+    restored the rule's visibility and none of its conclusions.
+  * **Backward chaining.**  `provers/candidate-rules` filtered direction, belief,
+    and context inheritance but never the visibility hidden set, so a goal in the
+    cone quietly rebuilt through the hidden rule what forward chaining had swept.
+
+  Each test pins one arm: the sweep of an existing firing, the block of a late one,
+  the revival on retraction, the backward chainer's candidate filter, and the
+  dispute-resolution shape the bug was found in (a justified dispute whose defeated
+  side must vanish from every read surface, not only from the argue tree).  House
+  rules as everywhere else: gensym'd temporaries via `tu/with-terms`, engine
+  vocabulary literal, the neutral fixture asserts the KB is restored."
+  (:require [clojure.test :refer [is testing use-fixtures]]
+            [vaelii.core :as v]
+            [vaelii.impl.rules :as vr]
+            [vaelii.impl.sentex :as sx]
+            [vaelii.test-util :as tu]))
+
+(use-fixtures :each (tu/neutral-fresh tu/fresh))
+
+(defn- default-rule [antes conseq]
+  (list 'set/defaultRule (vr/rule-sentence antes conseq)))
+
+;; ---- 1. sweeping ---------------------------------------------------------
+;; DECISION (contexts.md, "The removal is total"): a late except sweeps what already
+;; fired.  The fact arm of this is pinned by the except tests; this pins the rule arm —
+;; the conclusion's own handle is never an except target here, so an empty read below
+;; can only mean belief actually moved, not that a read filter hid it.
+
+(tu/deftest-kb excepting-a-rule-sweeps-the-conclusions-it-derived
+  (tu/with-terms [bird flies Tweety CxBird]
+    (let [rh (v/assert kb (default-rule [(list bird '?x)] (list flies '?x)) CxBird)]
+      (v/assert kb (list bird Tweety) CxBird)
+      (testing "the rule fired before the except arrived"
+        (is (seq (v/sentexes-matching kb (list flies Tweety) CxBird))))
+      (v/assert kb (list 'except (sx/sentex-handle rh)) CxBird)
+      (testing "a conclusion resting on a rule the cone cannot see is swept"
+        (is (empty? (v/sentexes-matching kb (list flies Tweety) CxBird))))
+      (testing "and the backward chainer does not rebuild it through the hidden rule"
+        (is (empty? (v/query kb (list flies Tweety) CxBird {:max-depth 2})))))))
+
+;; ---- 2. blocking ---------------------------------------------------------
+;; The placement-side twin: a firing that arrives after the except is never placed in
+;; the cone, for a hidden rule exactly as for a hidden antecedent.
+
+(tu/deftest-kb a-fact-arriving-after-the-rule-was-excepted-concludes-nothing
+  (tu/with-terms [bird flies Opus CxBird]
+    (let [rh (v/assert kb (default-rule [(list bird '?x)] (list flies '?x)) CxBird)]
+      (v/assert kb (list 'except (sx/sentex-handle rh)) CxBird)
+      (v/assert kb (list bird Opus) CxBird)
+      (testing "the hidden rule does not fire into the cone"
+        (is (empty? (v/sentexes-matching kb (list flies Opus) CxBird)))))))
+
+;; ---- 3. revival ----------------------------------------------------------
+;; Belief-following, like every other fact: retracting the except restores the hidden
+;; rule, and what it was deriving comes back.
+
+(tu/deftest-kb retracting-the-except-re-derives-what-the-rule-concluded
+  (tu/with-terms [bird flies Tweety CxBird]
+    (let [rh (v/assert kb (default-rule [(list bird '?x)] (list flies '?x)) CxBird)]
+      (v/assert kb (list bird Tweety) CxBird)
+      (let [eh (v/assert kb (list 'except (sx/sentex-handle rh)) CxBird)]
+        (is (empty? (v/sentexes-matching kb (list flies Tweety) CxBird)))
+        (v/retract! kb eh)
+        (testing "the rule is visible again and its conclusion is re-derived"
+          (is (seq (v/sentexes-matching kb (list flies Tweety) CxBird))))))))
+
+;; ---- 4. backward chaining ------------------------------------------------
+;; `provers/candidate-rules` filters direction, belief, and context inheritance; a rule
+;; hidden from the asking context by a believed except must not be a candidate either.
+;; A `set/backwardRule` isolates this arm: it never forward-fires, so the only path to
+;; an answer is the one the filter guards.
+
+(tu/deftest-kb a-hidden-backward-rule-is-not-a-candidate
+  (tu/with-terms [rained wet Lawn CxYard]
+    (let [rh (v/assert kb (list 'set/backwardRule
+                                (list 'implies (list rained '?d) (list wet '?d)))
+                       CxYard)]
+      (v/assert kb (list rained Lawn) CxYard)
+      (testing "the goal answers through the rule while it is visible"
+        (is (seq (v/query kb (list wet Lawn) CxYard {:max-depth 2}))))
+      (let [eh (v/assert kb (list 'except (sx/sentex-handle rh)) CxYard)]
+        (testing "hidden from the asking context, the rule is not a candidate"
+          (is (empty? (v/query kb (list wet Lawn) CxYard {:max-depth 2}))))
+        (v/retract! kb eh)
+        (testing "and it answers again once the except is retracted"
+          (is (seq (v/query kb (list wet Lawn) CxYard {:max-depth 2}))))))))
+
+;; ---- 5. dispute resolution -----------------------------------------------
+;; The shape the bug was found in: a genuine dilemma (two default rules concluding
+;; opposite literals — the engine represents it rather than deciding it), then a
+;; visibility except lands on one side's *rule*.  Defeat must land on support, and
+;; once it does, every read surface has to agree: the defeated conclusion is gone,
+;; the survivor stands, and the contradiction is resolved — not just the argue tree,
+;; but belief, the stored matches, and the conflict roster.
+
+(tu/deftest-kb excepting-one-side-of-a-dispute-resolves-it-on-every-read-surface
+  (tu/with-terms [quaker republican pacifist Nixon CxDispute]
+    (let [_r1 (v/assert kb (default-rule [(list quaker '?x)] (list pacifist '?x))
+                        CxDispute)
+          r2  (v/assert kb (default-rule [(list republican '?x)]
+                                         (list 'not (list pacifist '?x)))
+                        CxDispute)]
+      (v/assert kb (list quaker Nixon) CxDispute)
+      (v/assert kb (list republican Nixon) CxDispute)
+      (testing "the dilemma is real before the except: both sides stored, reported"
+        (is (seq (v/sentexes-matching kb (list pacifist Nixon) CxDispute)))
+        (is (seq (v/sentexes-matching kb (list 'not (list pacifist Nixon)) CxDispute)))
+        (is (seq (v/contradictions kb))))
+      (v/assert kb (list 'except (sx/sentex-handle r2)) CxDispute)
+      (testing "the defeated side's conclusion is swept"
+        (is (empty? (v/sentexes-matching kb (list 'not (list pacifist Nixon)) CxDispute))))
+      (testing "the surviving side stands"
+        (is (seq (v/sentexes-matching kb (list pacifist Nixon) CxDispute))))
+      (testing "and the dilemma is resolved, not merely re-rendered"
+        (is (empty? (v/contradictions kb)))))))


### PR DESCRIPTION
## What

`(except (sentexHandle H))` where `H` is a **rule**: the arrival side already held (the stored justification carries the rule handle among its antecedents, so excepting a rule sweeps its conclusions and blocks late firings), but two read-back arms did not:

- **Revival.** `special/recheck-except`'s departure arms are keyed on a fact target — `dependents` (empty once the firing is swept) and the predicate fan (which a rule sentence never matches) — so retracting a rule-targeting except restored the rule's visibility and none of its conclusions. The target itself is now re-chained when it is a rule.
- **Backward chaining.** `provers/candidate-rules` filtered direction, belief, and context inheritance but never the visibility hidden set, so `query`/`prove` in the cone rebuilt through the hidden rule exactly what forward chaining had swept. The same `res/hidden-fn` the sweep reads now gates candidacy — nil (one deref) for a KB that hides nothing.

## How found

Live, on a justified dispute: after excepting one side's rule, the argue tree correctly collapsed while the defeated conclusion kept ground-succeeding under `query` and held its `contradictions` entry. (Earlier engines also lacked the arrival sweep for rule targets; the current develop already carried that half.)

## Tests

New `test/vaelii/except_rule_visibility_test.clj` — five tests pinning the sweep, the late-firing block, the revival, the backward candidate filter, and the dispute shape (defeat must land on support and then every read surface has to agree). All five fail without the two changes; full suite at this head: **4322 tests, 154135 assertions, 0 failures, 0 errors**. `cljfmt` clean.

Docs: `docs/contexts.md` gains the **Rules** bullet under the except section; the two comments claiming "a rule is not an except target" now state the opposite, which the stored-justification shape had made true all along.