### PR TITLE
feat(types): refine integer argument constraints

### DIFF
--- a/docs/argtypes.md
+++ b/docs/argtypes.md
@@ -313,14 +313,16 @@ decides at all, rather than every non-symbol being exempt:
 [defenses.md](defenses.md#a-literal-is-typed-by-its-kind-and-the-openness-moves-to-the-declared-type).
 
 **One vocabulary, not two.** `string`, `number`, `integer`, `keyword`, `boolean`,
-`character` and `symbol` are the KB's only names for the kinds a literal argument can
-carry — one per leaf kind, deliberately complete — and both declarations read them: the
-use/mention distinction is carried by *which predicate you write*, not by a second set of
-type names. A string literal denotes itself, so `(arg comment 2 string)` and
-`(quotedArg p n string)` ask two questions of one set — what the argument denotes, and
-what is written there. A parallel domain spelling would buy nothing and cost a trap:
-`quotedArg` reads a type outside the syntactic lattice open-world, so a second spelling
-stores clean and convicts nothing, with no report
+`character` and `symbol` name the EDN kinds a literal argument can carry — one per leaf
+kind, deliberately complete — and both declarations read them. `arg` can additionally
+use the value-refined integer types `positive_integer`, `negative_integer`,
+`non_negative_integer` and `non_positive_integer`; zero satisfies both non-positive and
+non-negative. `quotedArg` still asks only what syntax was written, so an integer literal
+is an `integer` there regardless of its value. A string literal denotes itself, so
+`(arg comment 2 string)` and `(quotedArg p n string)` ask two questions of one set — what
+the argument denotes, and what is written there. A parallel domain spelling would buy
+nothing and cost a trap: `quotedArg` reads a type outside the syntactic lattice
+open-world, so a second spelling stores clean and convicts nothing, with no report
 ([why one vocabulary](defenses.md#one-vocabulary-not-two)).
 
 `symbol` is the exception, and is **mention-only**. A symbol does not denote itself, so

--- a/docs/kbs.md
+++ b/docs/kbs.md
@@ -18,7 +18,7 @@ OpenCyc reader is in this repo. This page is the **sequence**, and what each ste
 | KB | comes from | to first load | once loaded |
 |---|---|---|---|
 | Starter ontology | the classpath | seconds | ~1,843 sentexes |
-| Core vocabulary | the classpath | seconds | 392 sentexes |
+| Core vocabulary | the classpath | seconds | 416 sentexes |
 | cyc-tiny | a test fixture in the plugin | one dependency, then seconds | 8,181 sentexes |
 | OpenCyc 4.0 | a distribution you supply | a conversion, then ~10 minutes | ~1.2M sentexes |
 

--- a/resources/kb/CxCore.txt
+++ b/resources/kb/CxCore.txt
@@ -54,14 +54,14 @@
          "(genlArg ?predicate ?position ?type) means that argument ?position of ?predicate must be a subtype of ?type. The arg constraint one level up, for a typeRelationPredicate whose arguments name kinds rather than instances: (genlArg partType 1 physical_object) says the argument names a kind of physical object, where (arg partOf 1 physical_object) says it names one. Open-world, so an argument with no place in the genl hierarchy cannot violate it.")
 (ternaryPredicate genlArg)
 (arg genlArg 1 predicate)
-(arg genlArg 2 integer)
+(arg genlArg 2 positive_integer)
 (genlArg genlArg 3 thing)
 
 (comment arg
          "(arg ?predicate ?position ?type) means that argument ?position of ?predicate must be of ?type. Checked through genl transitivity whenever a sentex is asserted, and open-world: an argument whose type is unknown cannot violate it, so this narrows what can be said without demanding that everything be typed.")
 (ternaryPredicate arg)
 (arg arg 1 predicate)
-(arg arg 2 integer)
+(arg arg 2 positive_integer)
 (genlArg arg 3 thing)
 ;; arg / genlArg / interArg generalize along genl on the query surface the way
 ;; check walks them internally — a stored subtype constraint answers its supertypes, and
@@ -75,7 +75,7 @@
          "(quotedArg ?predicate ?position ?type) means that argument ?position of ?predicate, taken AS A TERM — the syntactic object written in that position, not what it denotes — must be of ?type. The mention twin of arg: (arg nameOfGuy 1 agent) types what the first argument names, (quotedArg nameOfGuy 1 string) types the argument itself, the literal sitting there. Its ?type is a syntactic type — string, number (with integer below it), symbol — and the argument is classified by its EDN kind, then checked through genl like arg. Closed about a literal whose kind is decidable: (nameOfGuy 5) violates (quotedArg nameOfGuy 1 string), 5 being a number and not a string. It does not read the referent's type, which is arg's business.")
 (ternaryPredicate quotedArg)
 (arg quotedArg 1 predicate)
-(arg quotedArg 2 integer)
+(arg quotedArg 2 positive_integer)
 (genlArg quotedArg 3 thing)
 
 ;; The literal types — the EDN kinds a literal argument can carry, placed in the genl
@@ -106,6 +106,10 @@
 (comment string  "A run of text. The EDN string kind, and what a text-valued argument position holds — either as the literal written there (quotedArg) or as what the term written there denotes (arg).")
 (comment number  "A number, with integer below it. The EDN numeric kinds.")
 (comment integer "A whole number.")
+(comment positive_integer "A whole number greater than zero.")
+(comment negative_integer "A whole number less than zero.")
+(comment non_negative_integer "A whole number greater than or equal to zero.")
+(comment non_positive_integer "A whole number less than or equal to zero.")
 (comment keyword "An EDN keyword, :like_this. A term that names itself and carries no denotation the KB reasons about.")
 (comment boolean "True or false, written as the literal.")
 (comment character "A single character, written \\a. Not a one-letter string: the two are separate EDN kinds and neither is below the other.")
@@ -113,6 +117,14 @@
 (genl string thing)
 (genl number thing)
 (genl integer number)
+(genl positive_integer integer)
+(genl negative_integer integer)
+(genl non_negative_integer integer)
+(genl non_positive_integer integer)
+(defnIff positive_integer (and (integer ?x) (greaterThan ?x 0)))
+(defnIff negative_integer (and (integer ?x) (lessThan ?x 0)))
+(defnIff non_negative_integer (and (integer ?x) (greaterThan ?x -1)))
+(defnIff non_positive_integer (and (integer ?x) (lessThan ?x 1)))
 (genl keyword thing)
 (genl boolean thing)
 (genl character thing)
@@ -123,9 +135,9 @@
 (arity interArg 5)
 (instanceRelationPredicate interArg)
 (arg interArg 1 predicate)
-(arg interArg 2 integer)
+(arg interArg 2 positive_integer)
 (arg interArg 3 unaryPredicate)
-(arg interArg 4 integer)
+(arg interArg 4 positive_integer)
 (arg interArg 5 unaryPredicate)
 
 (comment arity
@@ -134,7 +146,7 @@
 (instanceRelationPredicate arity)
 (functional arity)
 (arg arity 1 predicate)
-(arg arity 2 integer)
+(arg arity 2 non_negative_integer)
 
 ;; The meta-ontology rules below conclude into the ORDINARY placement — the maximal
 ;; context that sees the rule and the declaration — and not into a named one.  Every
@@ -311,7 +323,7 @@
          "(contextArgSubrelation ?function ?position ?subrelation) means that two contexts denoted by ?function and identical except at argument ?position are ordered by ?subrelation on that argument: the context whose argument is ?subrelation-below the other's is a spec (sub)context of it, and the producer materializes the genlCx edge. So (contextArgSubrelation CxTimeFn 2 subintervalOf) makes (CxTimeFn CxMonad (DatetimeFn \"2000-01\")) a subcontext of (CxTimeFn CxMonad (DatetimeFn \"2000\")) because January 2000 is a subinterval of 2000 — with nobody asserting that genlCx edge. ?position is 1-based over ?function's arguments. See docs/context-nat.md.")
 (ternaryPredicate contextArgSubrelation)
 (arg contextArgSubrelation 1 function)
-(arg contextArgSubrelation 2 integer)
+(arg contextArgSubrelation 2 positive_integer)
 (arg contextArgSubrelation 3 predicate)
 
 (comment termOfUnit
@@ -494,14 +506,14 @@
          "(transitiveInArg ?predicate ?position ?relation) means that argument ?position of ?predicate is preserved along the transitive ?relation. A stored (?predicate … W …) then licenses the same claim about A whenever (?relation A W) holds. With genl that is downward inheritance among kinds, so (largerThan dog cat) reaches a golden retriever — and stops at the kinds, since preservation moves an argument and never the level the predicate relates at. Whether a relation distributes over a kind's subkinds is a claim about that relation, so it is declared rather than assumed; a more specific claim undercuts an inherited default, and never an inherited monotonic one. Several declarations may name one position, and their reaches union. ?relation must be genl, genlCx, or a predicate already declared transitive: assert refuses the declaration otherwise, since the reach is walked to a fixpoint and would manufacture a transitivity nobody stated.")
 (ternaryPredicate transitiveInArg)
 (arg transitiveInArg 1 predicate)
-(arg transitiveInArg 2 integer)
+(arg transitiveInArg 2 positive_integer)
 (arg transitiveInArg 3 predicate)
 
 (comment transitiveInArgInverse
          "(transitiveInArgInverse ?predicate ?position ?relation) means that argument ?position of ?predicate is preserved along ?relation read backwards. A stored (?predicate … W …) licenses the claim about A whenever (?relation W A) holds, so with genl this is upward inheritance. It exists so that direction never requires declaring an inverse predicate with no other use. Same restriction on ?relation.")
 (ternaryPredicate transitiveInArgInverse)
 (arg transitiveInArgInverse 1 predicate)
-(arg transitiveInArgInverse 2 integer)
+(arg transitiveInArgInverse 2 positive_integer)
 (arg transitiveInArgInverse 3 predicate)
 
 (comment ternaryPredicate    "A predicate of three arguments, such as arg.")

--- a/src/vaelii/impl/checks.clj
+++ b/src/vaelii/impl/checks.clj
@@ -97,6 +97,20 @@
     (and (symbol? x) (not (sx/variable? x))) 'symbol
     :else                                    nil))
 
+(defn- literal-denotation-types
+  "The most specific built-in types known from a literal's value.
+
+  Most literals have only their EDN kind. Integers additionally carry the sign-refined
+  types declared in CxCore. Zero belongs to both non-negative and non-positive; returning
+  a set rather than forcing one artificial leaf keeps both argument constraints exact."
+  [x]
+  (if (integer? x)
+    (cond
+      (pos? x) '#{positive_integer non_negative_integer}
+      (neg? x) '#{negative_integer non_positive_integer}
+      :else    '#{non_negative_integer non_positive_integer})
+    (if-some [t (literal-type x)] #{t} #{})))
+
 (defn- syntactic-type?
   "Is `t` a type `quotedArg` can judge a literal against — a syntactic root or a subtype
   of one?  A declared type outside this lattice leaves the constraint open-world."
@@ -237,10 +251,11 @@
     (let [ms (types arg)]
       (and (kb/isa-among? (:closures ms) 'thing)
            (not (kb/isa-among? (:closures ms) t))))
-    (when-some [k (literal-type arg)]
-      (and (symbol? t)
-           (tax/genl? tax t 'thing context)
-           (not (tax/genl? tax k t context))))))
+    (let [ks (literal-denotation-types arg)]
+      (when (seq ks)
+        (and (symbol? t)
+             (tax/genl? tax t 'thing context)
+             (not-any? #(tax/genl? tax % t context) ks))))))
 
 (defn- application-term?
   "Is `x` a function **application** — a compound whose head is a name?

--- a/src/vaelii/impl/vocabulary.clj
+++ b/src/vaelii/impl/vocabulary.clj
@@ -69,11 +69,15 @@
 
     ;; ---- the literal types, read by name ----------------------------------
     ;; One vocabulary for both readings (docs/argtypes.md): `arg` types what an argument
-    ;; denotes and `quotedArg` the term written there, and a literal denotes itself, so
-    ;; the same four names answer both.  `symbol` is the exception and is mention-only.
+    ;; denotes and `quotedArg` the term written there. The EDN kinds answer both; the
+    ;; sign-refined integers are value types read only by the denotation path.
     string      {:enforced "checks/syntactic-roots — the kind quotedArg judges a literal against, matched by name"}
     number      {:enforced "checks/syntactic-roots — the same, with integer below it"}
     integer     {:enforced "checks/syntactic-roots — the same"}
+    positive_integer     {:enforced "checks/literal-denotation-types — a positive integer literal satisfies an arg constraint naming it"}
+    negative_integer     {:enforced "checks/literal-denotation-types — a negative integer literal satisfies an arg constraint naming it"}
+    non_negative_integer {:enforced "checks/literal-denotation-types — zero and positive integer literals satisfy an arg constraint naming it"}
+    non_positive_integer {:enforced "checks/literal-denotation-types — zero and negative integer literals satisfy an arg constraint naming it"}
     keyword     {:enforced "checks/syntactic-roots — the same"}
     boolean     {:enforced "checks/syntactic-roots — the same"}
     character   {:enforced "checks/syntactic-roots — the same; a one-letter string is not one"}

--- a/test/vaelii/core_context_test.clj
+++ b/test/vaelii/core_context_test.clj
@@ -59,5 +59,5 @@
   ;; docs/kbs.md's shipped-KB table quotes this number, and nothing else pins it —
   ;; the figure went stale once already (a 62% shortfall against the doc).  The
   ;; fixture loads CxCore alone, which is exactly the row's claim.
-  (is (= 392 (v/sentex-count kb))
+  (is (= 416 (v/sentex-count kb))
       "the Core vocabulary row of docs/kbs.md quotes this count — update both together"))

--- a/test/vaelii/integer_sign_types_test.clj
+++ b/test/vaelii/integer_sign_types_test.clj
@@ -1,0 +1,79 @@
+;; SPDX-License-Identifier: SSPL-1.0
+;; Copyright © 2026 Vaelii LLC and the Vaelii contributors.
+(ns vaelii.integer-sign-types-test
+  "The four sign-refined integer types and their executable `defnIff` boundaries."
+  (:require [clojure.test :refer [is testing use-fixtures]]
+            [vaelii.core :as v]
+            [vaelii.impl.starter :as starter]
+            [vaelii.test-util :as tu]))
+
+(use-fixtures :once (tu/loaded starter/load-into))
+(use-fixtures :each (tu/neutral))
+
+(def cases
+  [['positive_integer     '(and (integer ?x) (greaterThan ?x 0))       1  0]
+   ['negative_integer     '(and (integer ?x) (lessThan ?x 0))         -1  0]
+   ['non_negative_integer '(and (integer ?x) (greaterThan ?x -1)) 0 -1]
+   ['non_positive_integer '(and (integer ?x) (lessThan ?x 1))     0  1]])
+
+(def positive-position-slots
+  "Every core argument slot whose value is a one-based position."
+  [['genlArg 2]
+   ['arg 2]
+   ['quotedArg 2]
+   ['interArg 2]
+   ['interArg 4]
+   ['contextArgSubrelation 2]
+   ['transitiveInArg 2]
+   ['transitiveInArgInverse 2]])
+
+(tu/deftest-kb sign-refined-integers-are-specializations-of-integer
+  (doseq [[type] cases]
+    (is (v/genl? kb type 'integer) (str type " specializes integer"))))
+
+(tu/deftest-kb sign-refined-integers-state-their-boundaries-with-defniff
+  (doseq [[type condition] cases]
+    (is (some? (v/handle-of kb (list 'defnIff type condition) 'CxCore))
+        (str type " has the expected executable definition"))))
+
+(tu/deftest-kb sign-refined-integer-definitions-materialize-both-rules
+  (doseq [[type condition] cases]
+    (testing (str type)
+      (let [[_ & conjuncts] condition]
+        (doseq [conjunct conjuncts]
+          (is (some? (v/handle-of kb (list 'implies (list type '?x) conjunct) 'CxCore))
+              "membership entails every defining conjunct"))
+        (is (some? (v/handle-of kb (list 'implies condition (list type '?x)) 'CxCore))
+            "the complete condition entails membership")))))
+
+(tu/deftest-kb sign-refined-integers-work-as-literal-argument-types
+  (tu/with-terms [takesPositive takesNegative takesNonNegative takesNonPositive]
+    (doseq [[pred type accepted rejected]
+            [[takesPositive 'positive_integer 1 0]
+             [takesNegative 'negative_integer -1 0]
+             [takesNonNegative 'non_negative_integer 0 -1]
+             [takesNonPositive 'non_positive_integer 0 1]]]
+      (v/assert kb (list 'unaryPredicate pred) 'CxUniverse)
+      (v/assert kb (list 'arg pred 1 type) 'CxUniverse)
+      (is (integer? (v/assert kb (list pred accepted) 'CxUniverse))
+          (str type " accepts a member literal"))
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (v/assert kb (list pred rejected) 'CxUniverse))
+          (str type " rejects a literal outside its boundary")))))
+
+(tu/deftest-kb core-integer-constraints-use-the-tightest-sign-type
+  (doseq [[pred slot] positive-position-slots]
+    (is (some? (v/handle-of kb (list 'arg pred slot 'positive_integer) 'CxCore))
+        (str pred " argument " slot " is a one-based position")))
+  (is (some? (v/handle-of kb '(arg arity 2 non_negative_integer) 'CxCore))
+      "a predicate may have zero arguments, but never a negative arity"))
+
+(tu/deftest-kb arity-is-non-negative-rather-than-positive
+  (tu/with-terms [nullary impossible]
+    (is (integer? (v/assert kb (list 'arity nullary 0) 'CxUniverse))
+        "zero is a valid arity")
+    (is (integer? (v/assert kb (list nullary) 'CxUniverse))
+        "a declared nullary predicate can be asserted")
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (v/assert kb (list 'arity impossible -1) 'CxUniverse))
+        "a negative arity is impossible")))

--- a/test/vaelii/rule_variable_arg_test.clj
+++ b/test/vaelii/rule_variable_arg_test.clj
@@ -170,12 +170,13 @@
 
 (tu/deftest-kb the-literal-types-are-one-vocabulary-and-symbol-is-mention-only
   (testing "the disjointness on number carries integer with it"
-    ;; `(arg arity 2 integer)`, and integer is below number, which no relation is
+    ;; `(arg arity 2 non_negative_integer)`, and that type is below integer and number,
+    ;; which no relation is
     (let [form '(implies (arity ?p ?n) (genl ?p ?n))
           ps   (v/check kb form 'CxUniverse)]
       (is (= [:arg-variable] (mapv :type ps)))
       (is (= '?n (:variable (first ps))))
-      (is (= '[integer unaryPredicate] (:expected (first ps))))))
+      (is (= '[non_negative_integer unaryPredicate] (:expected (first ps))))))
   (testing "symbol carries no disjointness, a name being how a predicate is written"
     ;; the deliberate absence, and the one that has to be pinned: `(disjoint symbol
     ;; predicate)` would read as a use-level claim and be false of every predicate name,


### PR DESCRIPTION
Tightens every one-based position slot in the core vocabulary from `integer` to `positive_integer`, and gives `arity` its own narrower spec.

## What changes

`positive_integer` on the argument-number slot of:

- `arg`, `genlArg`, `quotedArg`
- both `interArg` positions
- `contextArgSubrelation`
- `transitiveInArg` and `transitiveInArgInverse`

`arity` is the deliberate exception and becomes **`non_negative_integer`**: arity 0 and nullary assertions already work, so `positive_integer` would refuse something the engine supports. Negative arity now fails, which it previously did not.

No `(arg … … integer)` declaration remains in the core vocabulary.

## Why

These slots are all one-based positions. `integer` admitted `0` and negatives on every one of them, so a declaration naming position `0` or `-3` was well-formed and silently inert — the constraint existed but could never bind a real argument. Narrowing the spec turns that from a quiet no-op into a refusal at the point of declaration.

## Testing

- New sign-boundary tests fail against all nine prior declarations, plus negative arity, before the change
- Focused: 106 tests / 726 assertions green
- Full suite: 4,328 tests / 154,201 assertions green
- Formatter and diff checks clean

## Note

Separated deliberately from the `functionalInArg` work that motivated it. That is a distinct semantic feature which merely *depends* on `positive_integer`, and it will follow as its own PR against `develop` once this lands — two bisectable units rather than one bundle.
