### PR TITLE
Review fixes: print-guarded tie-break, byte-order Merkle sort, one home for the dump layout, prose-blind refusal roster

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -784,8 +784,8 @@ here.
 
 | Switch | Read at | Legal values | Default | What it decides |
 |---|---|---|---|---|
-| `vaelii.build` | `src/vaelii/impl/io/export.clj:190+` | any label | the git HEAD, else `dev` | How the writing build names itself in a dump's `meta.edn`. Diagnostic: a dump that will not read is first a question about which build wrote it. |
-| `VAELII_BUILD` | `src/vaelii/impl/io/export.clj:190+` | any label | as above | The same label, read after the property. |
+| `vaelii.build` | `src/vaelii/impl/io/export.clj:180+` | any label | the git HEAD, else `dev` | How the writing build names itself in a dump's `meta.edn`. Diagnostic: a dump that will not read is first a question about which build wrote it. |
+| `VAELII_BUILD` | `src/vaelii/impl/io/export.clj:180+` | any label | as above | The same label, read after the property. |
 
 ### Developer — the suite and the scripts
 

--- a/src/vaelii/impl/io/export.clj
+++ b/src/vaelii/impl/io/export.clj
@@ -72,13 +72,8 @@
   "Version 1: field-map frames, chunked framing, handles preserved."
   1)
 
-(def ^:private meta-file          "meta.edn")
-(def ^:private sentex-file        "sentexes.nippy.stream")
-(def ^:private justification-file "justifications.nippy.stream")
-(def ^:private provenance-file    "provenance.nippy.stream")
-(def ^:private index-dir          "index")
-(def ^:private index-entry-file   "entries.nippy.stream")
-(def ^:private index-meta-file    "index.edn")
+;; The stream names live in `vaelii.impl.io.frames`, shared with the import reader —
+;; the two halves of the round trip must agree on the layout, so it is stated once.
 
 (def variants
   "What a dump can hold.  `:records` is the whole KB — everything else is derived from
@@ -203,7 +198,7 @@
   "Write `meta.edn` — an array map, so the file reads in the order the schema is
   stated rather than in hash order."
   [^File d m]
-  (spit (io/file d meta-file)
+  (spit (io/file d frames/meta-file)
         (with-out-str (binding [*print-length* nil *print-level* nil] (prn m)))))
 
 ;;; ── the entry point ───────────────────────────────────────────────────
@@ -242,11 +237,11 @@
   entries, for the same reason `meta.edn` is written last: a half-written entry stream
   with no `index.edn` beside it is read as a dump that simply has no index."
   [^File d index fingerprint frame-opts]
-  (let [idx-d (io/file d index-dir)]
+  (let [idx-d (io/file d frames/index-dir)]
     (.mkdirs idx-d)
-    (let [n (frames/write-frames! (io/file idx-d index-entry-file) (snapshot/index-frames index)
+    (let [n (frames/write-frames! (io/file idx-d frames/index-entry-file) (snapshot/index-frames index)
                                   frame-opts)]
-      (spit (io/file idx-d index-meta-file)
+      (spit (io/file idx-d frames/index-meta-file)
             (with-out-str
               (binding [*print-length* nil *print-level* nil]
                 (prn (array-map :index-layout kv/index-layout-version
@@ -323,10 +318,10 @@
          ;; the writer already fetches every record, and on `:disk` that is a page read
          ;; apiece
          fprint   (when index? (fp/accumulator))
-         sx-n (frames/write-frames! (io/file d sentex-file)
+         sx-n (frames/write-frames! (io/file d frames/sentex-file)
                                     (record-frames records p/get-sentex sx-ids fprint)
                                     (assoc frame-opts :on-chunk (chunk :sentexes (count sx-set))))
-         j-n  (frames/write-frames! (io/file d justification-file)
+         j-n  (frames/write-frames! (io/file d frames/justification-file)
                                     (record-frames records p/get-justification j-ids)
                                     (assoc frame-opts :on-chunk (chunk :justifications (count j-set))))
          ;; `seq` realizes only as far as the first handle carrying provenance, so a KB
@@ -336,7 +331,7 @@
          prov (when provenance?
                 (seq (provenance-frames records (concat sx-ids j-ids))))
          p-n  (if prov
-                (frames/write-frames! (io/file d provenance-file) prov
+                (frames/write-frames! (io/file d frames/provenance-file) prov
                                       (assoc frame-opts :on-chunk (chunk :provenance nil)))
                 0)
          i-n  (if index?

--- a/src/vaelii/impl/io/frames.clj
+++ b/src/vaelii/impl/io/frames.clj
@@ -18,8 +18,12 @@
   is meant to be *a thin adapter over this framing, not a second copy of it*.  A second
   copy is exactly the drift a shared projection was created to avoid one layer up: two
   writers that agree today and diverge on the next compression tweak.  So the framing lives
-  once, here, and the container-specific concerns (a dump's `meta.edn`, an image's
-  manifest, which streams exist) stay with each caller.
+  once, here, and the container-specific concerns (what a dump's `meta.edn` records, an
+  image's manifest) stay with each caller.  The dump's stream **names** are not one of
+  those concerns: which streams exist and what each is called is the layout the writer
+  and the reader must agree on — a second copy is the same drift one level down — so the
+  names live here too, beside the framing they name (`meta-file` and its six siblings
+  below).
 
   The legacy single-window reader (`read-window-seq`) is kept for a v4/v5 foreign dump that
   wrote one compression window over the whole file; the engine's own dumps have been chunked
@@ -33,6 +37,35 @@
            (java.lang.reflect Constructor)
            (java.util.zip GZIPInputStream GZIPOutputStream)
            (org.tukaani.xz LZMA2Options XZInputStream XZOutputStream)))
+
+;;; ── the dump's on-disk layout ─────────────────────────────────────────
+;;; One home for the stream names the export writer and the import reader share, so the
+;;; two halves of the round trip cannot drift: a rename on the write side alone would
+;;; produce a dump the reader reports as *missing* rather than misnamed, and the
+;;; discovery moment would be a restore.  `round_trip_test` pins the literal spellings:
+;;; the layout is a frozen wire contract, so a change here is a format version.
+
+(def meta-file
+  "The dump's manifest — what `vaelii.impl.io.export` writes about the dump."
+  "meta.edn")
+(def sentex-file
+  "The sentex record stream."
+  "sentexes.nippy.stream")
+(def justification-file
+  "The justification record stream."
+  "justifications.nippy.stream")
+(def provenance-file
+  "The `[handle provenance-map]` stream."
+  "provenance.nippy.stream")
+(def index-dir
+  "The subdirectory a `:records+index` dump carries the index cache in."
+  "index")
+(def index-entry-file
+  "The index `[key value]` entry stream, inside `index-dir`."
+  "entries.nippy.stream")
+(def index-meta-file
+  "The index cache's own manifest, inside `index-dir`."
+  "index.edn")
 
 ;;; ── writing ───────────────────────────────────────────────────────────
 

--- a/src/vaelii/impl/io/import.clj
+++ b/src/vaelii/impl/io/import.clj
@@ -168,13 +168,8 @@
                                 " never one")
                            {:type :malformed-manifest :file (.getPath f)} e))))))
 
-(def ^:private meta-file           "meta.edn")
-(def ^:private sentex-file         "sentexes.nippy.stream")
-(def ^:private justification-file  "justifications.nippy.stream")
-(def ^:private provenance-file     "provenance.nippy.stream")
-(def ^:private index-dir           "index")
-(def ^:private index-entry-file    "entries.nippy.stream")
-(def ^:private index-meta-file     "index.edn")
+;; The stream names live in `vaelii.impl.io.frames`, shared with the export writer —
+;; the two halves of the round trip must agree on the layout, so it is stated once.
 
 ;;; ── stream readers ────────────────────────────────────────────────────
 ;;; The chunked/window nippy framing itself lives in `vaelii.impl.io.frames`, shared
@@ -274,7 +269,7 @@
   "Read a dump's `meta.edn` (the marker + schema) without loading any records — under
   `manifest-bytes`, since a dump directory is whatever an operator copied."
   [dir]
-  (let [^java.io.File f (io/file dir meta-file)]
+  (let [^java.io.File f (io/file dir frames/meta-file)]
     (when-not (.exists f)
       (throw (ex-info (str "no dump at " (.getPath f) " (missing meta.edn)")
                       {:type :no-dump :dir (str dir)})))
@@ -764,7 +759,7 @@
   this map cannot resolve is dropped rather than written under a number now holding
   something else."
   [kb dir compression read-fn handles]
-  (let [^java.io.File f (io/file dir provenance-file)]
+  (let [^java.io.File f (io/file dir frames/provenance-file)]
     (if-not (.exists f)
       0
       ;; Written a chunk at a time through `cap/put-all-provenance` — one statement per
@@ -797,7 +792,7 @@
   ordinary — a `:records` dump has none, and so does a `:records+index` export that was
   cancelled before `index.edn` was written, which is why the writer writes it last."
   [dir]
-  (let [^java.io.File f (io/file dir index-dir index-meta-file)]
+  (let [^java.io.File f (io/file dir frames/index-dir frames/index-meta-file)]
     (when (.exists f)
       ;; The `.exists` guard already ruled out absence, so this catch fires only on a
       ;; CORRUPT index.edn — a different fact from "there wasn't one", and the caller
@@ -853,7 +848,7 @@
     (try
       (let [n (snapshot/install-entries!
                (:index kb)
-               (vreset! frames (read-fn (io/file dir index-dir index-entry-file)
+               (vreset! frames (read-fn (io/file dir frames/index-dir frames/index-entry-file)
                                         compression)))]
         (when-not (= (long n) (long expected))
           (trove/log! {:level :warn :id ::index-short
@@ -1048,7 +1043,7 @@
                         (= kv/index-layout-version (:index-layout index-meta))
                         preserve?)
         result     (bulk-load-records-only!
-                    kb (read-fn (io/file dir sentex-file) compression) decode preserve?
+                    kb (read-fn (io/file dir frames/sentex-file) compression) decode preserve?
                     (not possible?) report-every on-progress (:sentex-count meta))
         preserved? (and preserve? (zero? (long (:minted result))))
         idx        (if possible?
@@ -1270,10 +1265,10 @@
                   ;; already holding every sentex the dump had (`assert-no-naf-justifications!`)
                   _ (when ours?
                       (assert-no-naf-justifications!
-                       (read-fn (io/file dir justification-file) compression)))
+                       (read-fn (io/file dir frames/justification-file) compression)))
                   {:keys [sx-meta embedding collapsed minted fingerprint naming frames
                           refused]}
-                  (import-sentexes! kb (read-fn (io/file dir sentex-file) compression)
+                  (import-sentexes! kb (read-fn (io/file dir frames/sentex-file) compression)
                                     decode ours? (tick :sentexes (:sentex-count meta)))
                   _ (check-frame-count! :sentexes frames (:sentex-count meta))
                   _ (when-let [line (nm/tally-line naming)]
@@ -1304,7 +1299,7 @@
                     ;; premise is a sentex carrying a strength
                     (let [{:keys [dropped dropped-orphaned ids frames]}
                           (import-justifications!
-                           kb (read-fn (io/file dir justification-file) compression) old->new
+                           kb (read-fn (io/file dir frames/justification-file) compression) old->new
                            orphaned kept?
                            (tick :justifications (:justification-count meta)))
                           ;; the same witness the sentex stream gets, and the stream that

--- a/src/vaelii/impl/quality.clj
+++ b/src/vaelii/impl/quality.clj
@@ -187,10 +187,16 @@
                  (if (next hs)
                    ;; the context joins the key: one implication stated in two contexts
                    ;; shares sentence and signature, and the residual tie fell to the
-                   ;; handle set's iteration order — ahead of the `take limit` cap
-                   (sort-by (fn [h] (let [rl (rule-line kb h)]
-                                      [(pr-str (:sentence rl)) (str (:context rl))]))
-                            hs)
+                   ;; handle set's iteration order — ahead of the `take limit` cap.
+                   ;; `print-key`, not a bare `pr-str`: an ambient `*print-length*`
+                   ;; elides two long sentences to one prefix and the tie falls back to
+                   ;; handle order (naming.clj says why).  Decorated, so the record
+                   ;; store is read once per rule and not once per comparison.
+                   (nm/sort-by-content-key
+                    (fn [h] (let [rl (rule-line kb h)]
+                              [(nm/print-key (:sentence rl)) (nm/name-key (:context rl))]))
+                    compare
+                    hs)
                    hs)))
        (take limit)
        (into [] (keep #(rule-line kb %)))))

--- a/src/vaelii/koinii/deref.clj
+++ b/src/vaelii/koinii/deref.clj
@@ -316,11 +316,18 @@
   (str locator-prefix (hex (sha256 (byte-array 0)))))
 
 (defn- sorted-leaves
-  "The sorted vector of leaf digests for `locators` — leaf-hash each, then order by hex
-  (equal-width, so hex order is unsigned lexicographic byte order).  Sorting is what makes
-  the root a function of the *set*: two seats at the same state build the identical tree."
+  "The sorted vector of leaf digests for `locators` — leaf-hash each, then order by
+  unsigned lexicographic byte comparison, which over equal-width digests is exactly hex
+  order.  Sorting is what makes the root a function of the *set*: two seats at the same
+  state build the identical tree.  Compared as bytes rather than by a hex key:
+  `sort-by` runs its keyfn inside the comparator, so a `(sort-by hex …)` would rebuild
+  the 64-char key ~2·n·log₂n times — 32 Formatter allocations each — on the path
+  `commit-id` folds every believed sentex through."
   [locators]
-  (->> locators (map leaf-hash) (sort-by hex) vec))
+  (->> locators
+       (map leaf-hash)
+       (sort (fn [^bytes a ^bytes b] (java.util.Arrays/compareUnsigned a b)))
+       vec))
 
 (defn- largest-pow2-below
   "The largest power of two strictly less than `n` (`n` > 1) — RFC-6962's split point."

--- a/test/vaelii/disk_codec_test.clj
+++ b/test/vaelii/disk_codec_test.clj
@@ -253,3 +253,31 @@
             (let [{other :dec} (get (codec/by-kind empty-d true) "sentexes")]
               (is (thrown? clojure.lang.ExceptionInfo (other frame))))))
         (is (= '(dog Muffet) (:sentence (dec frame))) "and the real dictionary still decodes it")))))
+
+;; ---- the two crash-damage refusals, by name ------------------------------
+;; `rebuild-premises!` discriminates on the `:type`: `:damaged-dictionary` and
+;; `:malformed-record` are crash damage and TOMBSTONE the record, while
+;; `:unknown-frame` (provoked above) rethrows — a build that cannot read a log must
+;; not delete it.  Provoking both here keeps the discrimination covered: a swapped or
+;; regressed arm would silently delete a recoverable log.
+
+(deftest an-id-the-dictionary-never-recorded-is-refused-by-name
+  (with-dict
+    (fn [d _]
+      (let [e (is (thrown? clojure.lang.ExceptionInfo (dtok/token d 99)))]
+        (is (= :damaged-dictionary (:type (ex-data e))))
+        (is (= 99 (:id (ex-data e))) "the frame's orphaned id is named")
+        (is (= 0 (:dictionary-size (ex-data e))) "and so is what the dictionary holds")))))
+
+(deftest a-body-code-outside-the-codec-is-refused-by-name
+  (with-dict
+    (fn [d _]
+      (let [{:keys [enc dec]} (get (codec/by-kind d true) "sentexes")
+            frame   (enc (sx/->AtomicSentex '(dog Muffet) 'C 7 :true nil))
+            ;; -11 is one past the codec's lowest control code; its zigzag varint is
+            ;; the single byte 21 — a body no writer of this format produces
+            corrupt (assoc frame 1 (byte-array [(byte 21)]))
+            e (is (thrown? clojure.lang.ExceptionInfo
+                           (dec (nippy/thaw (nippy/freeze corrupt)))))]
+        (is (= :malformed-record (:type (ex-data e))))
+        (is (= -11 (:code (ex-data e))) "the refusing code is named")))))

--- a/test/vaelii/koinii_deref_test.clj
+++ b/test/vaelii/koinii_deref_test.clj
@@ -593,3 +593,22 @@
         (is (thrown-with-msg? clojure.lang.ExceptionInfo #"no sentex at handle"
                               (d/marker a 999999))))
       (finally (tu/clear-kb! a)))))
+
+;; ── the leaf sort builds no hex keys ──────────────────────────────────────
+
+(deftest the-leaf-sort-orders-bytes-without-building-hex-keys
+  ;; `sort-by` runs its keyfn inside the comparator, so `(sort-by hex leaves)` rebuilds
+  ;; the 64-char key — 32 Formatter allocations each — ~2·n·log₂n times on the path
+  ;; `commit-id` folds every believed sentex through.  Equal-width digests order the
+  ;; same way under unsigned byte comparison as under their hex spelling, so the sort
+  ;; needs no hex at all; this pins both halves: no superlinear hex builds, and the
+  ;; order is still exactly hex order.
+  (let [locators (mapv #(str "probe:" %) (range 16))
+        real-hex @#'d/hex
+        calls    (atom 0)]
+    (let [leaves (with-redefs-fn {#'d/hex (fn [b] (swap! calls inc) (real-hex b))}
+                   #(@#'d/sorted-leaves locators))]
+      (is (<= @calls (count locators))
+          "the sort builds at most one key per leaf, never one per comparison")
+      (is (= (sort (map real-hex leaves)) (map real-hex leaves))
+          "and the digests come back in hex order, which is what makes the root a function of the set"))))

--- a/test/vaelii/labeling_test.clj
+++ b/test/vaelii/labeling_test.clj
@@ -334,3 +334,24 @@
                         (set (map :sentence (v/sentexes-in-context kb ctx)))))))]
     (is (= (labeled false) (labeled true))
         "the same knowledge in either order labels the same sentence")))
+
+(deftest a-labeling-that-disagrees-with-its-own-classification-is-refused-by-name
+  ;; `check-agrees` guards the seam between two solves over one program — the failure
+  ;; this design is most exposed to, per its own docstring — and refuses with
+  ;; `:labeling-inconsistent`.  A genuine disagreement cannot be staged through the
+  ;; doors (two consistent solves is what the solver contract promises), so the guard
+  ;; is provoked directly, in both directions it checks.  No solver needed: this is
+  ;; the check, not the solve.
+  (let [check @#'label/check-agrees]
+    (testing "an assumption every optimum keeps, dropped by the labeling"
+      (let [e (is (thrown? clojure.lang.ExceptionInfo
+                           (check {:fixed #{}} #{} {:true '[a1] :false []})))]
+        (is (= :labeling-inconsistent (:type (ex-data e))))
+        (is (= '[a1] (:missing-true (ex-data e))))))
+    (testing "an assumption no optimum keeps, kept by the labeling"
+      (let [e (is (thrown? clojure.lang.ExceptionInfo
+                           (check {:fixed #{}} #{'a2} {:true [] :false '[a2]})))]
+        (is (= :labeling-inconsistent (:type (ex-data e))))
+        (is (= '[a2] (:kept-false (ex-data e))))))
+    (testing "and known-true background is never an assumption the labeling owes"
+      (is (nil? (check {:fixed #{'bg}} #{} {:true '[bg] :false []}))))))

--- a/test/vaelii/quality_test.clj
+++ b/test/vaelii/quality_test.clj
@@ -152,6 +152,35 @@
             (str "and the two listed are the content-smallest, which are the two asserted "
                  "*last* — a handle ranking would have shown the other pair"))))))
 
+(tu/deftest-kb the-signature-tie-break-survives-an-ambient-print-length
+  ;; Two rules sharing one signature (same consequent predicate, same antecedent
+  ;; predicate set) are tie-broken on their *printed sentences*.  A bare `pr-str` key
+  ;; honours the caller's `*print-length*` — a REPL's, typically — which elides both
+  ;; sentences to the same `(implies ...)` prefix, collapses the key, and drops the tie
+  ;; back onto handle order, i.e. the order the author happened to write the rules in.
+  ;; The guard is `nm/print-key` (naming.clj says why); this pins that the tie-break
+  ;; wears it.
+  ;;
+  ;; The discriminator: two same-signature rules asserted in reverse content order, a
+  ;; limit of one, and `*print-length*` bound the way a REPL would leave it.  Guarded,
+  ;; the listed rule is the content-smallest; unguarded, it is whichever came first.
+  (tu/with-terms [a_type pShared]
+    ;; content-larger sentence first: `(implies (and (a_type ?x)) (pShared ?x ?x))`
+    ;; sorts *after* `(implies (and (a_type ?x) (a_type ?y)) (pShared ?x ?y))` — at the
+    ;; first divergence the two-antecedent form has a space where this one has `)`.
+    (v/assert-rule kb [(list a_type '?x)] (list pShared '?x '?x) 'CxUniverse)
+    (v/assert-rule kb [(list a_type '?x) (list a_type '?y)]
+                   (list pShared '?x '?y) 'CxUniverse)
+    (let [q     (binding [*print-length* 1]
+                  (:rules (v/kb-quality kb {:limit 1})))
+          shown (into #{} (map :sentence) (:never q))]
+      (is (= 2 (:never-count q)) "both rules are in the count")
+      (is (= #{(list 'implies (list 'and (list a_type '?x) (list a_type '?y))
+                     (list pShared '?x '?y))}
+             shown)
+          (str "and the one listed is the content-smallest, which was asserted *second*"
+               " — a collapsed print key would have listed the first-asserted rule")))))
+
 ;; ---- chain depth over the rule graph -------------------------------------
 
 (tu/deftest-kb chain-depth-is-per-rule-and-counts-the-transitive-cycle-as-one

--- a/test/vaelii/refusal_roster_test.clj
+++ b/test/vaelii/refusal_roster_test.clj
@@ -89,6 +89,45 @@
         (recur (conj out {:name (.group m 1) :pos (.start m)}))
         out))))
 
+(defn- blank-prose
+  "`src` with every string body and comment blanked to spaces — length, offsets,
+  newlines and delimiters all preserved, so `delimiter-analysis` reads the blanked
+  text exactly as it reads the original.
+
+  The scan below collects keyword literals by regex, and a keyword named in a
+  docstring or a `;;` comment is prose, not coverage: fed raw source, a refusal
+  keyword listed in a ns docstring counted as \"a test provokes it\", and a refusal
+  whose only mention in `test/` was a comment was silently excused — invisible to
+  `unprovokable`'s staleness check too, since no entry names it.  Blanking is the
+  same lexer walk `delimiter-analysis` makes (`:code` / `:string` / `:comment`, char
+  literals and string escapes skipped), applied to the text instead of the stack."
+  ^String [^String src]
+  (let [n   (.length src)
+        out (char-array src)]
+    (loop [i 0, mode :code]
+      (when (< i n)
+        (let [c (.charAt src i)]
+          (case mode
+            :code
+            (cond
+              (= c \") (recur (inc i) :string)
+              (= c \;) (recur (inc i) :comment)
+              (= c \\) (recur (+ i 2) :code)
+              :else    (recur (inc i) :code))
+            :string
+            (cond
+              (= c \\) (do (aset out i \space)
+                           (when (< (inc i) n) (aset out (inc i) \space))
+                           (recur (+ i 2) :string))
+              (= c \") (recur (inc i) :code)
+              :else    (do (when-not (= c \newline) (aset out i \space))
+                           (recur (inc i) :string)))
+            :comment
+            (if (= c \newline)
+              (recur (inc i) :code)
+              (do (aset out i \space) (recur (inc i) :comment)))))))
+    (String. out)))
+
 (defn- asserted-in
   "Every keyword literal in one test source that sits inside a top-level form which reads
   a refusal's `:type` — directly, or through one of the file's own helpers.
@@ -126,7 +165,7 @@
     (into #{} (comp (filter (comp about-types? :pos)) (map (comp keyword :name))) lits)))
 
 (defn- asserted-types []
-  (transduce (map (comp asserted-in slurp)) into #{} (test-files)))
+  (transduce (map (comp asserted-in blank-prose slurp)) into #{} (test-files)))
 
 ;; ---- what the docs name --------------------------------------------------
 

--- a/test/vaelii/round_trip_test.clj
+++ b/test/vaelii/round_trip_test.clj
@@ -1004,3 +1004,21 @@
         (is (zero? (v/sentex-count kb)))
         (is (empty? (p/sentex-ids (:records kb)))))
       (finally (rm-rf! dump) (tu/clear-kb! kb)))))
+
+;;; ── the on-disk layout has one home ───────────────────────────────────
+
+(deftest the-dump-layout-is-stated-once-and-these-are-its-names
+  ;; The writer (`export`) and the reader (`import`) must agree on which streams a dump
+  ;; holds and what each is called — a rename on one side alone produces a dump the
+  ;; other reports as *missing* rather than misnamed, and the discovery moment is a
+  ;; restore.  So the names live once, in `frames` beside the framing they name, and
+  ;; this pins them to the literal on-disk spellings: the layout is a **frozen wire
+  ;; contract** (existing dumps must stay readable), so a change here is a format
+  ;; version, never a refactor.
+  (is (= "meta.edn"                     frames/meta-file))
+  (is (= "sentexes.nippy.stream"        frames/sentex-file))
+  (is (= "justifications.nippy.stream"  frames/justification-file))
+  (is (= "provenance.nippy.stream"      frames/provenance-file))
+  (is (= "index"                        frames/index-dir))
+  (is (= "entries.nippy.stream"         frames/index-entry-file))
+  (is (= "index.edn"                    frames/index-meta-file)))


### PR DESCRIPTION
Four independent fixes out of a five-lens review of the engine, each probe-first — every new test was run red against the unfixed code before the fix landed:

- **quality.clj** — `rule-line-order`'s same-signature tie-break used a bare `pr-str` key, the exact hazard naming.clj documents: an ambient `*print-length*` collapses two long rules to one key and the tie falls back to assertion order. The source-scanning guard missed it because the `pr-str` sits one line below the `sort-by` it scans. Now routed through `nm/sort-by-content-key` + `nm/print-key`, which also stops re-reading the record store once per comparison.
- **koinii/deref.clj** — `sorted-leaves` sorted digests by a hex key rebuilt inside the comparator (~2·n·log₂n builds, 32 Formatter allocations each) on the path `commit-id` folds every believed sentex through. Equal-width digests order identically under `Arrays/compareUnsigned`, so no key is built at all. (koinii can't reach `nm/sort-by-content-key` by design.)
- **io/frames.clj** — export and import each held a private, byte-identical copy of the dump's seven stream names; a rename on one side alone turns a restore into "stream missing", discovered at restore time. The names now live once in `frames.clj`, and `round_trip_test` pins the literal spellings as the frozen wire contract. Test literals elsewhere intentionally kept as independent pins.
- **refusal_roster_test** — the coverage scan counted refusal keywords in docstrings and `;;` comments as "a test provokes it". Blanking prose (same lexer walk as `delimiter-analysis`) revealed three refusals nothing had ever executed — `:damaged-dictionary`, `:malformed-record`, `:labeling-inconsistent` — now provoked by real tests instead of excused; the codec pair also pins the tombstone-vs-rethrow discrimination `rebuild-premises!` relies on.

Deliberately excluded: confirmed-but-cosmetic items with no possible failing-first test, and everything needing a design call — those arrive separately as issues.

Per-commit receipts (probe red pre-fix, green post-fix, affected namespaces green) are in the commit messages.

https://claude.ai/code/session_01FwF6txKpruJwsyfhimNyWj
