### PR TITLE
fix(equality): equate-existing learns the functionalInArg door

### DIFF
--- a/src/vaelii/impl/settle.clj
+++ b/src/vaelii/impl/settle.clj
@@ -2138,7 +2138,12 @@
 
 (def ^:private clash-declaration-functors
   "Sentence functors whose arrival implicates content already stored.  A membership or
-  a relation fact needs no entry here: it is its own candidate, found in the region."
+  a relation fact needs no entry here: it is its own candidate, found in the region.
+
+  **Clash exposure only.**  The *merge* half of a mark family lives in
+  `special.clj`'s `equate-*` lane, behind `functional-family-declaration` --
+  joining this vocabulary does not join that one, and a family wired into one
+  lane alone fails silently in the other (the lane map is on that door)."
   (into '#{disjoint disjointMetatype siblingDisjoint genl genlCx}
         definitional-mark-symbols))
 

--- a/src/vaelii/impl/special.clj
+++ b/src/vaelii/impl/special.clj
@@ -2903,7 +2903,8 @@
   `subtree-sentexes` reads it, snapshotted before the first merge, since migration writes
   twins to the roots the walk is reading."
   [kb sentence]
-  (when (and (= 'functional (nm/functor sentence)) (= 1 (nm/arity sentence)))
+  (when (or (and (= 'functional (nm/functor sentence)) (= 1 (nm/arity sentence)))
+            (and (= 'functionalInArg (nm/functor sentence)) (= 2 (nm/arity sentence))))
     (let [pred (first (nm/args sentence))]
       (when (symbol? pred)
         (reduce (fn [acc sx]

--- a/src/vaelii/impl/special.clj
+++ b/src/vaelii/impl/special.clj
@@ -2871,6 +2871,34 @@
                 (tax/context-down tax context))
         (derive-functional-equalities-in kb sentence context handle)))))
 
+(defn- functional-family-declaration
+  "The predicate `sentence` marks, when it is a functional-family declaration —
+  `(functional P)` or `(functionalInArg P n)` — else nil.  The one door the
+  declaration-arriving-last merge path opens through.
+
+  **The lane map, because this door has eaten a fix before.**  A mark family
+  lives in two lanes, and joining one vocabulary does not join the other:
+
+  * **Merges (this namespace):** fact-last → `derive-functional-equalities`;
+    declaration-last → `equate-existing`, through this door; `genl`-edge-last →
+    `equate-under-edge`; `genlCx`-edge-last → `equate-under-context-edge`.
+  * **Clash exposure (`settle.clj`):** `clash-declaration-functors`, the
+    discovery arms, the trigger case — reported via
+    `checks/arbitrable-violations`.
+
+  The 2026-08 `functionalInArg` gap sat exactly here: settle's lane was swept
+  thoroughly while an exact-functor test in `equate-existing` quietly excluded
+  the generalized declaration, and nothing named the exclusion.  A new mark
+  family joins this cond and settle's vocabularies **separately**."
+  [sentence]
+  (let [f (nm/functor sentence)]
+    (cond
+      (and (= 'functional f) (= 1 (nm/arity sentence)))
+      (first (nm/args sentence))
+      (and (= 'functionalInArg f) (= 2 (nm/arity sentence)))
+      (first (nm/args sentence))
+      :else nil)))
+
 (defn equate-existing
   "When a `(functional P)` declaration arrives, derive the equalities P's **already
   stored** facts license — the other direction of `derive-functional-equalities`, which
@@ -2903,16 +2931,14 @@
   `subtree-sentexes` reads it, snapshotted before the first merge, since migration writes
   twins to the roots the walk is reading."
   [kb sentence]
-  (when (or (and (= 'functional (nm/functor sentence)) (= 1 (nm/arity sentence)))
-            (and (= 'functionalInArg (nm/functor sentence)) (= 2 (nm/arity sentence))))
-    (let [pred (first (nm/args sentence))]
-      (when (symbol? pred)
-        (reduce (fn [acc sx]
-                  (merge-with into acc
-                              (derive-functional-equalities
-                               kb (:sentence sx) (:context sx) (:id sx))))
-                {:new [] :superseded [] :violations []}
-                (subtree-sentexes kb pred))))))
+  (when-let [pred (functional-family-declaration sentence)]
+    (when (symbol? pred)
+      (reduce (fn [acc sx]
+                (merge-with into acc
+                            (derive-functional-equalities
+                             kb (:sentence sx) (:context sx) (:id sx))))
+              {:new [] :superseded [] :violations []}
+              (subtree-sentexes kb pred)))))
 
 (defn equate-under-edge
   "When a `(genl sub super)` edge arrives, derive the equalities a `(functional …)` mark

--- a/test/vaelii/functional_in_arg_test.clj
+++ b/test/vaelii/functional_in_arg_test.clj
@@ -428,3 +428,53 @@
           (v/assert kb (wide-sentence wideP other  hi) U)
           (check (not (merged? kb lo hi))
                  "one position out of 211 differs, so these fill two slots and neither binds the other"))))))
+
+;; ---- declaration-last: the arrival order the settle sweep exists for ------
+
+;; `equate-existing`'s docstring states order-independence as an invariant, and vaelii#43
+;; found it holds for declaration-last and predicate-`genl`-edge-last while failing for
+;; context-`genlCx`-edge-last.  Declaration-last is the order `functional` gets RIGHT,
+;; and it gets it right through `settle`: `clash-declaration-functors` names the functors
+;; whose arrival implicates content already stored, and the dispatch beside it sweeps the
+;; marked predicate's subtree.
+;;
+;; `functionalInArg` was merged (#44) without reaching `settle.clj` at all, so it enforces
+;; at assert and is invisible to that sweep — a generalization weaker than the special
+;; case it generalizes, on the one axis the special case handles.  These two tests are
+;; the receipt for that, and the control is not optional: without it a red pair proves
+;; only that the fixture is wrong.
+
+(tu/deftest-kb control-declaring-functional-after-the-facts-convicts
+  ;; THE CONTROL.  Read this result first.  If this is red the fixture is broken and the
+  ;; test below measures nothing — the S175 lesson about a probe whose own known-good
+  ;; case never engaged the machinery it was aimed at.
+  (tu/with-terms [parentOf Tom]
+    (let [[lo hi] (sort [(tu/tmp-ind "Mary") (tu/tmp-ind "Mary")])]
+      (v/assert kb (list parentOf Tom lo) U)
+      (v/assert kb (list parentOf Tom hi) U)
+      (v/assert kb (list 'functional parentOf) U)          ; declaration LAST
+      (is (merged? kb lo hi)
+          "today's functional convicts a pair already stored when the mark arrives"))))
+
+(tu/deftest-kb declaring-functional-in-arg-after-the-facts-convicts
+  ;; Same fixture, same arrival order, spelled the generalized way.  Must behave exactly
+  ;; as the control does: the regression half of the generalization applies to arrival
+  ;; order as much as to verdict.
+  (tu/with-terms [parentOf Tom]
+    (let [[lo hi] (sort [(tu/tmp-ind "Mary") (tu/tmp-ind "Mary")])]
+      (v/assert kb (list parentOf Tom lo) U)
+      (v/assert kb (list parentOf Tom hi) U)
+      (v/assert kb (list 'functionalInArg parentOf 2) U)   ; declaration LAST
+      (is (merged? kb lo hi)
+          "(functionalInArg P 2) must convict retroactively exactly as (functional P) does"))))
+
+(tu/deftest-kb control-declaring-functional-in-arg-before-the-facts-still-convicts
+  ;; The already-passing order, restated here so a regression in the fix is visible
+  ;; beside the thing it fixes rather than in another test's file.
+  (tu/with-terms [parentOf Tom]
+    (let [[lo hi] (sort [(tu/tmp-ind "Mary") (tu/tmp-ind "Mary")])]
+      (v/assert kb (list 'functionalInArg parentOf 2) U)   ; declaration FIRST
+      (v/assert kb (list parentOf Tom lo) U)
+      (v/assert kb (list parentOf Tom hi) U)
+      (is (merged? kb lo hi)
+          "declaration-first was never broken and must stay unbroken"))))


### PR DESCRIPTION
The settle-side gap from the #43/#44 family, root-caused: `(functionalInArg P n)` declared **after** P's facts derived nothing, because `equate-existing`'s door reads functor=`functional` + arity 1 and the generalized mark fell through — while `derive-functional-equalities` beneath it already speaks the mark (`functional-in-arg-over`, wired in the genlCx work).

Two commits, probe-first:
1. tests — control (`functional`-after-the-facts) green, `functionalInArg` twin **red at develop**, before-the-facts control green
2. the three-line door widening — the red test goes green **with this change alone**

Deliberately excluded: the settle dispatch sites (`clash-declaration-functors`, the discovery arm, the trigger case) still omit `functionalInArg`. Those serve clash *exposure* — a functionalInArg pair surfacing as a represented dilemma — which is a distinct behavior with no failing-first probe here yet; it likely meets the still-pending asserted-difference test row. Wanted that lane to stay yours to prioritize rather than smuggling it in as passengers.

Verification: `lein test :only vaelii.functional-in-arg-test` — 12 tests / 83 assertions; the only remaining failures are the deliberately-red pending row from #43's close.