### PR TITLE
test: pin the exact represented dilemma (functionalInArg row 3)

### DIFF
--- a/test/vaelii/functional_in_arg_test.clj
+++ b/test/vaelii/functional_in_arg_test.clj
@@ -360,17 +360,24 @@
         (when-not difference-first?
           (v/assert kb (list 'not (list 'equals ThingOne ThingTwo)) U))
         (testing label
-          (is (merged? kb ThingOne ThingTwo)
-              "the tie leaves the derived equality believed — the merge is not undone")
-          (is (equality-in? kb ThingOne ThingTwo CxBottom)
-              "and its sentex stored in the context that sees both")
           (let [pos (v/handle-of kb (list 'equals ThingOne ThingTwo) CxBottom)
-                neg (v/handle-of kb (list 'not (list 'equals ThingOne ThingTwo)) U)]
+                neg (v/handle-of kb (list 'not (list 'equals ThingOne ThingTwo)) U)
+                dilemmas (v/contradictions kb)]
+            (is (true? (v/in? kb pos))
+                "the derived equality remains believed — the merge is not undone")
+            (is (merged? kb ThingOne ThingTwo)
+                "and the believed equality still joins the two fillers")
+            (is (true? (v/in? kb neg))
+                "the asserted difference remains believed — neither side wins")
             (is (= [:default :default]
                    [(v/defeat-class kb pos) (v/defeat-class kb neg)])
-                "neither side was defeated — the dilemma is represented, not decided"))
-          (is (= 1 (count (v/contradictions kb)))
-              "the pair is reported exactly once")
+                "neither side was defeated — the dilemma is represented, not decided")
+            (is (= 1 (count dilemmas))
+                "the pair is reported exactly once")
+            (is (= #{pos neg} (:nogood (first dilemmas)))
+                "the reported dilemma is this exact positive/negative pair")
+            (is (= 'contradicts (first (:sentence (first dilemmas))))
+                "and it is reported as a contradiction"))
           (is (zero? (count (v/conflicts kb)))
               "as a dilemma, not a conflict"))))))
 


### PR DESCRIPTION
Tightens the row-3 oracle in `functional_in_arg_test.clj` so it asserts the **represented dilemma**, not storage-strength:

- both the derived equality (`pos`) and the asserted difference (`neg`) remain believed (`in?`) — the clash is not lost, neither side wins
- `merged?` — the believed equality actually joins the two fillers (semantic effect, not just belief)
- `[:default :default]` defeat classes — the dilemma is represented, not decided
- the reported nogood is exactly `#{pos neg}` with functor `contradicts` — it is *this* dilemma, not merely 'a contradiction exists'
- zero conflicts — a dilemma, not a conflict

Test-only, +15/-8. Full suite green (4353 tests / 154362 assertions, 0 failures); multi-lens review clean. Supersedes #57 (same change, reauthored per the upstream authorship protocol).