### PR TITLE
feat(curation): seeAlso/conceptuallyRelated + in-KB example vocab

### DIFF
--- a/docs/kbs.md
+++ b/docs/kbs.md
@@ -18,7 +18,7 @@ OpenCyc reader is in this repo. This page is the **sequence**, and what each ste
 | KB | comes from | to first load | once loaded |
 |---|---|---|---|
 | Starter ontology | the classpath | seconds | ~1,879 sentexes |
-| Core vocabulary | the classpath | seconds | 420 sentexes |
+| Core vocabulary | the classpath | seconds | 455 sentexes |
 | cyc-tiny | a test fixture in the plugin | one dependency, then seconds | 8,181 sentexes |
 | OpenCyc 4.0 | a distribution you supply | a conversion, then ~10 minutes | ~1.2M sentexes |
 

--- a/resources/kb/CxCore.txt
+++ b/resources/kb/CxCore.txt
@@ -621,3 +621,65 @@
 
 (comment unaryPredicate      "A predicate of one argument: every type (a snake_case unary predicate) and every one-place property such as flies.")
 (genl unaryPredicate predicate)
+
+;; ---- curation cross-reference --------------------------------------------
+;; Documentation vocabulary beside `comment`: relations a KB curator writes to point a
+;; reader from one term to others.  Read like `comment` — by a browser rendering a term
+;; page, and by nobody for inference — so they are `:inert` in the vocabulary roster.
+;; They earn a place here for the reason `comment` does: the grammar documents itself in
+;; its own representation, and a cross-reference is queried and retracted like any fact.
+
+(comment termsRelated
+         "(termsRelated ?term1 ?term2 …) means that the named terms form a related cluster — a curation grouping among vocabulary terms, so a reader meeting one is pointed at the rest. Variable arity, like lessThan: (termsRelated positiveExample negativeExample borderlineExample) groups the three example predicates as one family. Documentation only — nothing in the engine reads it and it draws no inference, the grouping being for a reader as comment's prose is.")
+(binaryPredicate termsRelated)
+(instanceRelationPredicate termsRelated)
+(arg termsRelated 1 thing)
+(arg termsRelated 2 thing)
+(variableArity termsRelated)
+
+(comment seeAlso
+         "(seeAlso ?term1 ?term2) means that ?term1 and ?term2 are worth reading together — an editorial 'see also' cross-reference between two terms. Directional: (seeAlso a b) points a reader from a to b, and the reverse is a separate assertion, not implied. Documentation only, like comment: nothing in the engine reads it and it draws no inference.")
+(binaryPredicate seeAlso)
+(instanceRelationPredicate seeAlso)
+(arg seeAlso 1 thing)
+(arg seeAlso 2 thing)
+
+;; ---- in-KB worked examples -----------------------------------------------
+;; Meta-sentexes that name an example sentex by handle (sentexHandle), annotating a term
+;; with a true / false / borderline example of its usage — the (sentexHandle H) +
+;; targetFollowingPredicate pointing pattern koinii's reply acts use (kb/koinii/
+;; CxSpeechActs.txt).  Documentation (`:inert`): no engine path reads them.
+;; positiveExample / negativeExample carry an integrity obligation held by a TEST rather
+;; than the engine — the named sentex is provable, or provable as its negation — while
+;; borderlineExample is truth-agnostic and carries none.
+;;
+;; @todo once we have `termMentioned`, enforce `(termMentioned ?term ?sentex)`: that the
+;;   ?term an example annotates is actually mentioned in the ?sentex it names.  A
+;;   cyclistNotes analogue — recorded here for the reader, implemented by nobody yet, and
+;;   NOT to be invented in passing.
+
+(comment positiveExample
+         "(positiveExample ?term (sentexHandle ?sentex)) means that ?sentex is a TRUE example of ?term's usage — a meta-sentex naming ?sentex by handle. Declared targetFollowingPredicate, so retracting the example sentex tears this annotation down with it; and the named sentex must be provable, an obligation curation_test holds over every believed positiveExample. ?term is the term being exemplified; the handle arg is typed `thing` via quotedArg — a quoted mention, with no narrower sentex type yet — the target being any sentex.")
+(binaryPredicate positiveExample)
+(instanceRelationPredicate positiveExample)
+(arg positiveExample 1 thing)
+(quotedArg positiveExample 2 thing)
+(targetFollowingPredicate positiveExample)
+
+(comment negativeExample
+         "(negativeExample ?term (sentexHandle ?sentex)) means that ?sentex is a FALSE example of ?term's usage — a meta-sentex naming ?sentex by handle. Same pointing shape and targetFollowingPredicate mark as positiveExample; the obligation is the mirror, that the named sentex is provable AS ITS NEGATION — the example genuinely does not hold as stated — which curation_test holds. ?term is the term being exemplified; the handle arg is typed `thing` via quotedArg — a quoted mention, no narrower sentex type yet.")
+(binaryPredicate negativeExample)
+(instanceRelationPredicate negativeExample)
+(arg negativeExample 1 thing)
+(quotedArg negativeExample 2 thing)
+(targetFollowingPredicate negativeExample)
+
+(comment borderlineExample
+         "(borderlineExample ?term (sentexHandle ?sentex)) means that ?sentex is a BORDERLINE example of ?term's usage — a meta-sentex naming ?sentex by handle. Truth-agnostic by design: the named sentex is neither asserted true nor false, so it carries no provability obligation and NO regression reads its target. Same pointing shape, quotedArg mark, and targetFollowingPredicate mark as the other two.")
+(binaryPredicate borderlineExample)
+(instanceRelationPredicate borderlineExample)
+(arg borderlineExample 1 thing)
+(quotedArg borderlineExample 2 thing)
+(targetFollowingPredicate borderlineExample)
+
+(termsRelated positiveExample negativeExample borderlineExample)

--- a/src/vaelii/impl/vocabulary.clj
+++ b/src/vaelii/impl/vocabulary.clj
@@ -172,7 +172,21 @@
 
     ;; ---- declared and read by nothing, on purpose -------------------------
     contradicts {:inert "a report form the engine *writes*: conflicts and contradictions compose it per settle. Nothing reads it as input, and asserting one would put a stale claim under truth maintenance."}
-    typeToInstancePred {:inert "a link, not a rule. Moving a claim between the type and instance levels needs a quantifier reading nothing here fixes, so the pairing is recorded for a reader and inferred from by nobody."}})
+    typeToInstancePred {:inert "a link, not a rule. Moving a claim between the type and instance levels needs a quantifier reading nothing here fixes, so the pairing is recorded for a reader and inferred from by nobody."}
+
+    ;; ---- curation vocabulary: documentation, read like comment ------------
+    ;; Cross-reference a curator writes for a reader.  Read by a browser rendering a term
+    ;; page and by nobody for inference.
+    termsRelated {:inert "a curation grouping of related vocabulary terms (variable arity), for a reader. Nothing infers from it — the grouping is documentation, as comment's prose is."}
+    seeAlso {:inert "a documentation 'see also' cross-reference between two terms; read like comment and by nobody for inference. Directional — (seeAlso a b) does not imply (seeAlso b a); the reverse is a separate assertion."}
+
+    ;; in-KB worked examples: meta-sentexes naming an example sentex by handle.  The
+    ;; targetFollowingPredicate mark is what tears one down with the sentex it names —
+    ;; that mark's enforcement, not an arm keyed on these functors.  Their integrity
+    ;; obligation (provable / provable-as-negation) is a test's, read by no engine path.
+    positiveExample {:inert "a curation meta-sentex naming, by handle, a sentex that is a true example of a term's usage. Nothing reads the annotation for inference; its integrity (the named sentex is provable) is held by curation_test. Belief-following via the targetFollowingPredicate mark, so it does not outlive the example it names."}
+    negativeExample {:inert "the same, for a sentex whose negation is provable — a false example of a term's usage. Read by no check; its integrity is a test's, and it cascades with its target like positiveExample."}
+    borderlineExample {:inert "the same pointing shape, truth-agnostic: it names a sentex neither asserted true nor false, so it carries no provability obligation and no regression reads its target. Documentation only."}})
 
 (defn classify
   "What the engine does with vocabulary term `term`: `{:enforced \"where\"}`,

--- a/test/vaelii/core_context_test.clj
+++ b/test/vaelii/core_context_test.clj
@@ -56,8 +56,7 @@
                  (v/assert kb (list 'arity rel 7) 'CxCore)))))
 
 (tu/deftest-kb the-core-vocabulary-is-the-size-docs-kbs-says
-  ;; docs/kbs.md's shipped-KB table quotes this number, and nothing else pins it —
-  ;; the figure went stale once already (a 62% shortfall against the doc).  The
-  ;; fixture loads CxCore alone, which is exactly the row's claim.
-  (is (= 420 (v/sentex-count kb))
+  ;; docs/kbs.md's shipped-KB table quotes this number, and nothing else pins it.
+  ;; The fixture loads CxCore alone, which is exactly the row's claim.
+  (is (= 455 (v/sentex-count kb))
       "the Core vocabulary row of docs/kbs.md quotes this count — update both together"))

--- a/test/vaelii/curation_test.clj
+++ b/test/vaelii/curation_test.clj
@@ -1,0 +1,231 @@
+;; SPDX-License-Identifier: SSPL-1.0
+;; Copyright © 2026 Vaelii LLC and the Vaelii contributors.
+(ns vaelii.curation-test
+  "KB-curation vocabulary.
+
+  Two families, both declared in CxCore beside `comment`:
+
+    * cross-reference — `seeAlso`, a directional binary predicate relating two terms,
+      alongside `termsRelated`, a symmetric variable-arity grouping for a reader.
+    * in-KB worked examples — `positiveExample` / `negativeExample` / `borderlineExample`,
+      meta-sentexes that name an example sentex by handle, the same
+      `(sentexHandle H)` + `targetFollowingPredicate` pointing pattern koinii's reply acts
+      use (`target_following_meta_test`, `koinii_speech_acts_test`).
+
+  The load-bearing check is the examples' integrity: every `positiveExample` names a
+  sentex the KB can prove, and every `negativeExample` names one whose negation it can
+  prove — so a card that states a verdict the ontology no longer gives turns a test red.
+  `borderlineExample` is truth-agnostic and carries no such obligation."
+  (:require [clojure.test :refer [is use-fixtures]]
+            [vaelii.core :as v]
+            [vaelii.impl.core-context :as core-context]
+            [vaelii.impl.sentex :as sx]
+            [vaelii.test-util :as tu]))
+
+(use-fixtures :each (tu/neutral-fresh #(doto (tu/fresh) (core-context/load-into))))
+
+;; ---- Piece 1: seeAlso, a directional cross-reference ----------------------
+
+(tu/deftest-kb cross-reference-vocab-is-documented
+  (doseq [term '[seeAlso termsRelated]]
+    (is (= 1 (count (core-context/comment-of kb term))) (str "comment for " term))
+    (is (string? (first (core-context/comment-of kb term))))))
+
+(tu/deftest-kb see-also-is-a-directional-binary-predicate
+  (is (v/ask? kb '(binaryPredicate seeAlso) 'CxCore) "seeAlso is a binary predicate")
+  (is (not (v/has-prop? kb :symmetric 'seeAlso))
+      "and NOT symmetric — a 'see also' points one way; the reverse is a separate assertion"))
+
+(tu/deftest-kb see-also-relates-two-terms-directionally
+  (tu/with-terms [parentOf childOf]
+    (v/assert kb (list 'seeAlso parentOf childOf) 'CxUniverse)
+    (is (v/ask? kb (list 'seeAlso parentOf childOf) 'CxUniverse)
+        "the asserted direction is retrievable")
+    (is (not (v/ask? kb (list 'seeAlso childOf parentOf) 'CxUniverse))
+        "and the converse is NOT implied — seeAlso is directional, unlike a symmetric relation")))
+
+;; ---- Piece 2: positiveExample / negativeExample / borderlineExample -------
+;; Meta-sentexes naming an example sentex by handle (sx/sentex-handle), the same
+;; pointing pattern koinii's reply acts use.  positiveExample names a provable sentex;
+;; negativeExample names one whose negation is provable; borderlineExample is
+;; truth-agnostic and carries no such obligation.
+
+(defn- scratch
+  "A context below CxUniverse (which sees CxCore in a core-only KB), taken away by the
+  neutral fixture."
+  [kb]
+  (let [c (tu/fresh-term :context :Curation)]
+    (v/assert kb (list 'genlCx c 'CxUniverse) 'CxUniverse)
+    c))
+
+;; ---- the vocabulary loads and carries the pointing mark -------------------
+
+(tu/deftest-kb example-vocab-is-documented-and-target-following
+  (doseq [term '[positiveExample negativeExample borderlineExample]]
+    (is (= 1 (count (core-context/comment-of kb term))) (str "comment for " term))
+    (is (v/ask? kb (list 'binaryPredicate term) 'CxCore) (str term " is binary"))
+    (is (v/has-prop? kb :target-following term)
+        (str term " names its target sentex by handle and does not outlive it"))))
+
+(tu/deftest-kb the-example-family-is-grouped-by-termsRelated
+  (is (seq (v/sentexes-matching
+            kb '(termsRelated positiveExample negativeExample borderlineExample) 'CxCore))
+      "the three example predicates are asserted one termsRelated family in CxCore"))
+
+;; ---- a positive example names a provable sentex --------------------------
+
+(tu/deftest-kb a-positive-example-names-a-sentex-the-kb-proves
+  (let [ctx (scratch kb)]
+    (tu/with-terms [parentOf Abe Homer]
+      (let [p (v/assert kb (list parentOf Abe Homer) ctx)]
+        (v/assert kb (list 'positiveExample parentOf (sx/sentex-handle p)) ctx)
+        (is (v/ask? kb (list parentOf Abe Homer) ctx)
+            "the named sentex holds, so it is a true example of parentOf")))))
+
+;; ---- a negative example names a sentex whose negation the KB proves -------
+
+(tu/deftest-kb a-negative-example-names-a-sentex-whose-negation-the-kb-proves
+  (let [ctx (scratch kb)]
+    (tu/with-terms [parentOf Abe Homer]
+      ;; the false-direction sentence is stored (default) and then defeated by the
+      ;; monotonic negation, so it keeps a handle to name while (not C) is what holds.
+      (let [c (list parentOf Homer Abe)
+            neg (v/assert kb c ctx {:strength :default})]
+        (v/assert kb (list 'not c) ctx {:strength :monotonic})
+        (v/assert kb (list 'negativeExample parentOf (sx/sentex-handle neg)) ctx)
+        (is (some? (v/sentex kb neg)) "the named sentex is stored, so its handle resolves")
+        (is (not (v/ask? kb c ctx)) "it does not hold — a false example")
+        (is (v/ask? kb (list 'not c) ctx) "and its negation is what the KB proves")))))
+
+;; ---- the KB-integrity sweep: every asserted example checks out -----------
+
+(defn- handle-content
+  "The stored content of the sentex a `(pred term (sentexHandle H))` meta names."
+  [kb sentex]
+  (let [target (sx/handle-id (nth (:sentence sentex) 2))]
+    (:sentence (v/sentex kb target))))
+
+(defn- examples-of
+  "Every *believed* `pred` meta-sentex in the KB, wherever it lives — asserted or deduced,
+  and excepted ones excluded, because `sentexes-matching` returns believed sentexes."
+  [kb pred]
+  (v/sentexes-matching kb (list pred '?term '?h) '?ctx))
+
+(tu/deftest-kb every-believed-example-holds-as-stated
+  ;; The generative gate, data-driven over whatever examples the KB *believes* — asserted
+  ;; OR deduced, with excepted ones excluded, because `examples-of` reads believed sentexes.
+  ;; A positive example's target is provable, a negative example's target is provable as
+  ;; its negation.  borderlineExample is deliberately NOT swept — it is truth-agnostic.
+  (let [ctx (scratch kb)]
+    (tu/with-terms [parentOf Abe Homer sibling Bea]
+      ;; a positive example
+      (let [p (v/assert kb (list parentOf Abe Homer) ctx)]
+        (v/assert kb (list 'positiveExample parentOf (sx/sentex-handle p)) ctx))
+      ;; a second positive example on a different predicate
+      (let [s (v/assert kb (list sibling Homer Bea) ctx)]
+        (v/assert kb (list 'positiveExample sibling (sx/sentex-handle s)) ctx))
+      ;; a negative example (stored-then-defeated)
+      (let [c (list parentOf Homer Abe)
+            neg (v/assert kb c ctx {:strength :default})]
+        (v/assert kb (list 'not c) ctx {:strength :monotonic})
+        (v/assert kb (list 'negativeExample parentOf (sx/sentex-handle neg)) ctx))
+      ;; a borderlineExample pointing at a sentex with no provability guarantee — it must
+      ;; be ignored by the sweep, not fail it
+      (let [c (list parentOf Bea Abe)
+            b (v/assert kb c ctx {:strength :default})]
+        (v/assert kb (list 'not c) ctx {:strength :monotonic})       ; b is in fact defeated
+        (v/assert kb (list 'borderlineExample parentOf (sx/sentex-handle b)) ctx))
+
+      (let [pos (examples-of kb 'positiveExample)
+            neg (examples-of kb 'negativeExample)]
+        (is (= 2 (count pos)) "the sweep found both positive examples")
+        (is (= 1 (count neg)) "and the negative one")
+        (doseq [e pos]
+          (is (v/ask? kb (handle-content kb e) ctx)
+              (str "positive example must prove its target: " (pr-str (:sentence e)))))
+        (doseq [e neg]
+          (is (v/ask? kb (list 'not (handle-content kb e)) ctx)
+              (str "negative example must prove its target's negation: "
+                   (pr-str (:sentence e)))))))))
+
+;; ---- believed, not merely asserted: deduced in, excepted out -------------
+
+(tu/deftest-kb a-deduced-example-meta-is-swept
+  ;; An example meta the KB *derives* (never directly asserted) is believed, so the sweep
+  ;; sees and checks it.  This is why the terminology is "believed", not "asserted".
+  (let [ctx (scratch kb)]
+    (tu/with-terms [parentOf Abe Homer marksExample]
+      (v/assert kb (list 'unaryPredicate marksExample) 'CxUniverse)
+      (let [p (v/assert kb (list parentOf Abe Homer) ctx)
+            h (sx/sentex-handle p)]
+        ;; a rule concluding the positiveExample meta from a trigger — the meta is DEDUCED
+        (v/assert kb (list 'implies (list 'marksExample '?t)
+                           (list 'positiveExample '?t h)) ctx)
+        (v/assert kb (list 'marksExample parentOf) ctx)
+        (let [found (examples-of kb 'positiveExample)]
+          (is (= 1 (count found)) "the deduced example meta is believed and swept")
+          (doseq [e found]
+            (is (v/ask? kb (handle-content kb e) ctx)
+                "and its target proves, exactly as an asserted example's would")))))))
+
+(tu/deftest-kb a-negated-example-meta-is-not-swept
+  ;; A negated example meta — one whose negation is what the KB believes — is not itself
+  ;; believed, so the sweep must not see it.  The "excepted examples should not be
+  ;; checked" half, realized by asserting the meta's negation.
+  (let [ctx (scratch kb)]
+    (tu/with-terms [parentOf Abe Homer]
+      (let [p    (v/assert kb (list parentOf Abe Homer) ctx)
+            meta (list 'positiveExample parentOf (sx/sentex-handle p))]
+        (v/assert kb meta ctx {:strength :default})
+        (is (= 1 (count (examples-of kb 'positiveExample))) "believed while unnegated")
+        (v/assert kb (list 'not meta) ctx {:strength :monotonic})   ; negate the meta itself
+        (is (empty? (examples-of kb 'positiveExample))
+            "a negated example meta is not believed, so the sweep skips it")))))
+
+(tu/deftest-kb an-excepted-example-meta-is-not-swept
+  ;; An example meta defeated by an (except (sentexHandle H)) — the targeted except
+  ;; machinery, NOT a (not …) assertion — is not believed, so the sweep skips it.
+  ;; (except P) is not (not P): the except retracts the meta's own support rather than
+  ;; asserting a contrary proposition.
+  (let [ctx (scratch kb)]
+    (tu/with-terms [parentOf Abe Homer]
+      (let [p  (v/assert kb (list parentOf Abe Homer) ctx)
+            mh (v/assert kb (list 'positiveExample parentOf (sx/sentex-handle p)) ctx)]
+        (is (= 1 (count (examples-of kb 'positiveExample))) "believed before the except")
+        (v/assert kb (list 'except (sx/sentex-handle mh)) ctx {:strength :monotonic})
+        (is (empty? (examples-of kb 'positiveExample))
+            "an excepted example meta is not believed, so the sweep skips it")))))
+
+;; ---- kb-has-integrity: the umbrella the scope card checks against ---------
+
+(tu/deftest-kb kb-has-integrity
+  ;; The KB-integrity umbrella.  Currently just the believed-example sweep; two more
+  ;; integrity checks are planned to join it, so the namespace is staked out now.
+  (every-believed-example-holds-as-stated))
+
+;; ---- borderline carries no obligation ------------------------------------
+
+(tu/deftest-kb a-borderline-example-is-truth-agnostic
+  ;; It names a sentex that is neither believed true nor its negation proven, and nothing
+  ;; refuses it — no regression reads its target.
+  (let [ctx (scratch kb)]
+    (tu/with-terms [likes Cara Dora]
+      (let [c (list likes Cara Dora)
+            h (v/assert kb c ctx {:strength :default})]
+        (v/assert kb (list 'borderlineExample likes (sx/sentex-handle h)) ctx)
+        (is (seq (v/sentexes-matching
+                  kb (list 'borderlineExample likes (sx/sentex-handle h)) ctx))
+            "the borderline annotation is stored, whatever the truth of its target")))))
+
+;; ---- the pointing pattern cascades: retract the target, the example goes -
+
+(tu/deftest-kb an-example-does-not-outlive-the-sentex-it-names
+  (let [ctx (scratch kb)]
+    (tu/with-terms [parentOf Abe Homer]
+      (let [p (v/assert kb (list parentOf Abe Homer) ctx)
+            e (v/assert kb (list 'positiveExample parentOf (sx/sentex-handle p)) ctx)]
+        (is (some? (v/sentex kb e)))
+        (v/retract! kb p)
+        (is (nil? (v/sentex kb p)) "the example sentex is gone")
+        (is (nil? (v/sentex kb e))
+            "and the positiveExample naming it cascaded — targetFollowingPredicate")))))

--- a/test/vaelii/meta_test.clj
+++ b/test/vaelii/meta_test.clj
@@ -133,6 +133,10 @@
     (is (v/ask? kb '(functional birthYearOf)))
     (is (not (v/ask? kb '(symmetric parentOf)))))
   (testing "and enumerated"
+    ;; the domain relations and siblingDisjointException are the symmetric marks,
+    ;; decontextualized like the other algebraic marks, so they answer the enumeration
+    ;; wherever CxUniverse is seen.  seeAlso is NOT among them — it is a directional
+    ;; cross-reference, not symmetric.
     (is (= '#{siblingOf marriedTo friendOf siblingDisjointException}
            (set (map #(get % '?p) (v/ask kb '(symmetric ?p) '?ctx)))))
     ;; `genl` and `genlCx` are in the enumeration because CxCore asserts (transitive genl)


### PR DESCRIPTION
Part of the vaelii-lacuna-direct-blocker set (Pace-authorized). **Draft — @paceheart holds the draft→ready latch.**

## `seeAlso`
Directional binary curation cross-reference vocab, classified `:inert` (documentation only — nothing in the engine reads it). `(seeAlso a b)` points a reader from a to b; the reverse is a separate assertion, not implied.

## `positiveExample` / `negativeExample` / `borderlineExample`
Meta-sentexes naming an example sentex by handle, using the existing `(sentexHandle H)` + `targetFollowingPredicate` pattern (grounded in koinii's `CxSpeechActs`, nothing invented). The handle arg is typed `(quotedArg <pred> 2 thing)` — a quoted mention. `(termsRelated positiveExample negativeExample borderlineExample)` groups the family. `@todo` records future `(termMentioned ?term ?sentex)` enforcement.

## KB-integrity
A generative sweep proves every **believed** `positiveExample`/`negativeExample` arg2 sentex holds as stated — *believed* meaning asserted **or deduced**, with **negated** metas excluded (`sentexes-matching` returns believed sentexes). `borderlineExample` is truth-agnostic and excluded from the sweep. The sweep runs under a `kb-has-integrity` umbrella test, staking the namespace for two further integrity checks planned to join it. Tests cover: deduced example swept, negated example not swept, borderline ignored.

## Verification
Curation namespace **14 tests / 79 assertions, 0 failures** after review; curation + ontology + meta green. Full suite runs on CI.

No CONFLICT — the pointing pattern was grounded in the existing codebase.
