### PR TITLE
refactor(sentex): rename AtomicSentex record → LiteralSentex (it holds signed literals)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The unit of knowledge is a **sentex**: a sentence — a Clojure s-expression, gr
 pattern with `?x` variables — plus the one **context** it holds in.
 
 A sentex canonicalizes into one of two records, split so a fact does not carry the
-rule-only slots: an `AtomicSentex` holds `[sentence context id truth strength]`, and a
+rule-only slots: a `LiteralSentex` holds `[sentence context id truth strength]`, and a
 `RuleSentex` adds `[antecedent consequent varmap direction defeasible assumption
 constraint]`. **A rule is a sentex too**, indexed additionally by its antecedent and
 consequent predicates, so it gets a handle, truth maintenance and retraction for free.

--- a/bench/vaelii/bench/profile.clj
+++ b/bench/vaelii/bench/profile.clj
@@ -920,7 +920,7 @@
   [kb ^long limit ^long pair-ms]
   (banner "the churn arm — what retracting and re-asserting costs the index (REAL)")
   (let [tms      (:tms kb)
-        ;; **premises only.**  A derived conclusion is an ordinary atomic sentex with no
+        ;; **premises only.**  A derived conclusion is an ordinary literal sentex with no
         ;; antecedent, so filtering on that alone churns the rule engine's own output —
         ;; and a conclusion a rule drew past an argument constraint does not go back in
         ;; as a premise, which the `lost` counter below reports as a KB no longer the one

--- a/bench/vaelii/bench/survey.clj
+++ b/bench/vaelii/bench/survey.clj
@@ -66,7 +66,7 @@
 ;; ---- rule audit (are there rules, and what predicates do they introduce?) ----
 ;; The front-of-log fact sample can miss rules loaded elsewhere, so classify EVERY
 ;; record: a Rule carries :antecedent (the discriminant), an exceptWhen meta is
-;; an Atomic whose :sentence starts with `exceptWhen`, everything else is a fact.  Two
+;; a Literal whose :sentence starts with `exceptWhen`, everything else is a fact.  Two
 ;; modes: a uniform sample by handle via the .idx (fast, unbiased across the whole store),
 ;; and a full sequential scan (definitive).
 

--- a/bench/vaelii/bench/survey.clj
+++ b/bench/vaelii/bench/survey.clj
@@ -66,7 +66,8 @@
 ;; ---- rule audit (are there rules, and what predicates do they introduce?) ----
 ;; The front-of-log fact sample can miss rules loaded elsewhere, so classify EVERY
 ;; record: a Rule carries :antecedent (the discriminant), an exceptWhen meta is
-;; a Literal whose :sentence starts with `exceptWhen`, everything else is a fact.  Two
+;; an atomic sentex (a positive `(exceptWhen …)` application — never negated) whose
+;; :sentence starts with `exceptWhen`, everything else is a fact.  Two
 ;; modes: a uniform sample by handle via the .idx (fast, unbiased across the whole store),
 ;; and a full sequential scan (definitive).
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -529,7 +529,7 @@ their bindings, so there is no per-literal context to honor; ask the whole conju
 A **sentex map** has the stable keys `:id` (the handle), `:sentence`, `:context`,
 `:truth`, and for a rule `:antecedent` / `:consequent` / `:direction` / `:defeasible`.
 Key into it.
-The concrete record class behind it (`vaelii.impl.sentex/AtomicSentex` / `RuleSentex`) is an
+The concrete record class behind it (`vaelii.impl.sentex/LiteralSentex` / `RuleSentex`) is an
 `impl` detail and not part of the contract — never `instance?`-test it.
 
 **The sentex-map readers are lazy, over live state.**  `sentexes-matching` and the three

--- a/docs/canonicalization.md
+++ b/docs/canonicalization.md
@@ -268,4 +268,4 @@ twin somebody writes out by hand.
 ## See also
 
 - [docs/indexing.md](indexing.md) — how the canonical form reaches the trie key.
-- [docs/storage.md](storage.md) — the `AtomicSentex` / `RuleSentex` record shapes.
+- [docs/storage.md](storage.md) — the `LiteralSentex` / `RuleSentex` record shapes.

--- a/docs/density.md
+++ b/docs/density.md
@@ -13,7 +13,7 @@
 `vaelii.impl.disk.*`.
 
 These exist because of a gap between the engine's *seams* and its data structures at
-corpus scale. The seams carry a large KB — the `AtomicSentex`/`RuleSentex` split, symbol interning,
+corpus scale. The seams carry a large KB — the `LiteralSentex`/`RuleSentex` split, symbol interning,
 an index derived from the records and rebuildable by `reindex` — while the default
 structures are persistent Clojure collections holding boxed values, which measure
 ~1,973 B/fact of index (591.9 MB over 300k real facts, measured below). Each backend

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -90,11 +90,6 @@ fallback. See [asp.md](asp.md).
 `Program` is emitted to before a clingo/clasp solve. Contested assumptions
 become choice atoms and nogoods become weak constraints. See [asp.md](asp.md).
 
-**AtomicSentex** ![kb](../.github/badges/cat-kb.svg): The sentex record for an
-atomic sentence — a fact, a metadata declaration, or a query pattern — holding only
-`[sentence context id truth strength]`. Split from `RuleSentex` so a fact does not
-carry the rule-only slots. See [canonicalization.md](canonicalization.md).
-
 ## B
 
 **Backward chaining** ![inference](../.github/badges/cat-inference.svg): Proving
@@ -468,6 +463,14 @@ Evaluable arithmetic comparators, variable-arity — a ground chain
 stack — eight levels (`lookup`), each adding exactly one mechanism to the one
 below, from raw index handles to full backchaining. `escalate` finds the
 cheapest level that answers. See [levels.md](levels.md).
+
+**LiteralSentex** ![kb](../.github/badges/cat-kb.svg): The sentex record for a
+literal — a fact or its negation, a metadata declaration, or a query pattern —
+holding only `[sentence context id truth strength]`. Split from `RuleSentex` so a
+fact does not carry the rule-only slots. A *literal* is a signed predicate
+application (an atomic sentence or its negation); the record admits either polarity
+via its `truth` slot, so the name is `Literal`, not `Atomic`. See
+[canonicalization.md](canonicalization.md).
 
 **Locality** ![tms](../.github/badges/cat-tms.svg): The JTMS invariant that no
 operation recomputes the whole graph — every relabel is scoped to the affected

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -1089,9 +1089,9 @@ two KBs over one directory share the durable store — the restart contract the 
 tests rely on — and the lock, file handles, and durability registration are taken once;
 closing either KB closes both.
 
-## The sentex records — `AtomicSentex` and `RuleSentex`
+## The sentex records — `LiteralSentex` and `RuleSentex`
 
-A sentex is stored as one of **two records**, split so an atomic sentex does not carry
+A sentex is stored as one of **two records**, split so a literal sentex does not carry
 the seven rule-only slots — there are 100M+ facts, and each dropped reference field is
 ~4 bytes across all of them (measured: the record shell falls from ~80 to ~48
 bytes/instance, ~3.2 GB at 100M). Both share a scalar **core**; `RuleSentex` adds the rule
@@ -1099,7 +1099,7 @@ decomposition. The `sentex/sentex` constructor canonicalizes the structural conn
 and `set/*` wrappers into these fields rather than leaving them as sentence data, and
 emits the right record.
 
-The **core** (`AtomicSentex` and `RuleSentex` alike):
+The **core** (`LiteralSentex` and `RuleSentex` alike):
 
 - `:sentence` — the readable, normalized form (`(not (flies Tweety))`,
   `(implies (and A B) C)`), kept for display and matching.
@@ -1113,10 +1113,10 @@ The **core** (`AtomicSentex` and `RuleSentex` alike):
   lives **on the record** — with the rank mirrored into the disk idx slot (above), so
   `premise-strength` answers off the slot rather than paging the record on every open.
 
-**`AtomicSentex`** is an atomic sentence — a fact, a metadata declaration, or a query
-pattern: one signed predicate application, ground or holding variables. It adds nothing
-to the core. Reading any rule-only key off an `AtomicSentex` returns `nil`, so
-`(some? (:antecedent sx))` is the atomic-vs-rule discriminant everywhere — no consumer
+**`LiteralSentex`** is a literal — a fact or its negation, a metadata declaration, or a
+query pattern: one signed predicate application, ground or holding variables. It adds
+nothing to the core. Reading any rule-only key off a `LiteralSentex` returns `nil`, so
+`(some? (:antecedent sx))` is the literal-vs-rule discriminant everywhere — no consumer
 needs to know which record it holds.
 
 **`RuleSentex`** is an implication, and adds the decomposition:
@@ -1158,14 +1158,14 @@ connective-free (heads stripped even nested in a rule), and the **trie key** dro
 the `implies` / `and` rule frame — a negative literal keeps its `not` there as its
 polarity (see [indexing.md](indexing.md)). `or` reaches neither, having no slot here at
 all: a rule whose antecedent disjoins is stored as one rule per alternative before a
-record is built ([canonicalization.md](canonicalization.md)). `AtomicSentex` and `RuleSentex` are records (not bare
+record is built ([canonicalization.md](canonicalization.md)). `LiteralSentex` and `RuleSentex` are records (not bare
 maps) so each round-trips through nippy (the on-disk backend) with its type intact.
 
 ## Provenance — a side map, not record fields
 
 Bookkeeping about *who* asserted a sentex and *when* lives in a **per-handle
 provenance entry** keyed by the record handle, deliberately **beside** the record
-rather than as fields on an `AtomicSentex` / `RuleSentex` / `Justification`. Two reasons the shape
+rather than as fields on a `LiteralSentex` / `RuleSentex` / `Justification`. Two reasons the shape
 is a side map:
 
 - The record shapes stay fixed. Adding `:who` / `:when` / `:confidence` / `:source`
@@ -1192,13 +1192,13 @@ who/when); only asserted sentexes are stamped.
 
 The engine stores Clojure data — records, symbols, keywords, numbers — and every
 backend must preserve it type-faithfully (a keyword read back as a keyword, `1970` as
-a number, an `AtomicSentex`/`RuleSentex` back as itself), or `lookup`'s wildcard descent silently
+a number, a `LiteralSentex`/`RuleSentex` back as itself), or `lookup`'s wildcard descent silently
 matches nothing (`kv_backend_test` and `index_edge_test` guard exactly this).
 
 - **In memory** there is nothing to serialize: records sit in the map directly and
   the structured key vectors are the map keys (equal vectors are equal keys).
 - **On disk** values are **nippy**-frozen into the log frames and thawed on read, so
-  an `AtomicSentex` round-trips as an `AtomicSentex` and a `RuleSentex` as a `RuleSentex`; the in-RAM index map
+  a `LiteralSentex` round-trips as a `LiteralSentex` and a `RuleSentex` as a `RuleSentex`; the in-RAM index map
   is rebuilt from the WAL frames the same way. nippy freeze is a pure function of its
   value, so equal values freeze to equal bytes.
 

--- a/src/vaelii/core.clj
+++ b/src/vaelii/core.clj
@@ -3154,7 +3154,7 @@
   Returns a seq of **sentex maps**.  The stable contract is the map keys — `:id`
   (the handle), `:sentence`, `:context`, `:truth`, and for a rule `:antecedent` /
   `:consequent` / `:direction` — so key into the result.  The concrete record type
-  (`vaelii.impl.sentex/AtomicSentex` / `RuleSentex`) is an internal detail: do not `instance?`-
+  (`vaelii.impl.sentex/LiteralSentex` / `RuleSentex`) is an internal detail: do not `instance?`-
   test it or rely on it, only its keys.
 
   **The seq is lazy, over live state.**  Matches are fetched as it is walked, which is
@@ -5536,7 +5536,7 @@
   "The sentex for a handle as a **map**, or nil.  Same shape contract as `sentexes-matching`'s
   elements: `:id` (the handle), `:sentence`, `:context`, `:truth`, and for a rule
   `:antecedent` / `:consequent` / `:direction` / `:defeasible`.  Key into it; the
-  concrete `vaelii.impl.sentex/AtomicSentex` / `RuleSentex` record class is internal and not
+  concrete `vaelii.impl.sentex/LiteralSentex` / `RuleSentex` record class is internal and not
   part of the contract.  nil (`handle-of` of an absent sentence) answers nil; a
   non-handle (a vector of handles included) is refused (`:bad-handle`)."
   [kb handle]

--- a/src/vaelii/impl/disk/codec.clj
+++ b/src/vaelii/impl/disk/codec.clj
@@ -4,7 +4,7 @@
   "How a record is shaped on its way into a log frame, and back.
 
   nippy freezes a Clojure record by writing its **type tag and every field name** into
-  the frame — so a store of 100M sentexes writes `vaelii.impl.sentex.AtomicSentex` and
+  the frame — so a store of 100M sentexes writes `vaelii.impl.sentex.LiteralSentex` and
   `:sentence :context :id :truth :strength` 100M times.  Measured on the real corpus,
   that scaffolding is **56% of the store** (87 of 155 B/record) and it says nothing a
   frame needs to carry: the field layout is a property of the code, identical in every
@@ -13,14 +13,14 @@
   So a frame holds the fields **positionally** — a plain vector, the shape known here —
   which is 1.85× smaller and needs no dictionary, no id allocation, and no new durable
   ground truth (`lein bench-records`).  The codec is per *kind*, because each kind has
-  one known set of shapes: a sentex frame is tagged `atomic`/`rule`, a justification frame
+  one known set of shapes: a sentex frame is tagged `literal`/`rule`, a justification frame
   is a bare vector (there is only one shape), and provenance is an open application map
   that passes through untouched.
 
   **Reading is backward-compatible in both directions.**  `decode` dispatches on the
   thawed frame: a vector is positional, anything else is returned as it thawed.  So a
   store written before this codec reads exactly as it did (its frames are records), and
-  a plain map handed to `put-sentex` — which the tests do, and which is not an `AtomicSentex`
+  a plain map handed to `put-sentex` — which the tests do, and which is not a `LiteralSentex`
   — round-trips as the map it is.
 
   Decoding also **interns** the symbols it rebuilds (`sentex/intern-deep`), so a record
@@ -41,19 +41,19 @@
             [vaelii.impl.sentex :as sx])
   (:import [java.io ByteArrayOutputStream]))
 
-(def ^:private atomic-tag 0)
+(def ^:private literal-tag 0)
 (def ^:private rule-tag   1)
-(def ^:private atomic-tok-tag 2)
+(def ^:private literal-tok-tag 2)
 (def ^:private rule-tok-tag   3)
 
 ;; ---- sentexes -----------------------------------------------------------
 
 (defn encode-sentex
-  "An `AtomicSentex` or `RuleSentex` as a positional vector; anything else unchanged."
+  "An `LiteralSentex` or `RuleSentex` as a positional vector; anything else unchanged."
   [sx]
   (condp instance? sx
-    vaelii.impl.sentex.AtomicSentex
-    [atomic-tag (:sentence sx) (:context sx) (:id sx) (:truth sx) (:strength sx)]
+    vaelii.impl.sentex.LiteralSentex
+    [literal-tag (:sentence sx) (:context sx) (:id sx) (:truth sx) (:strength sx)]
 
     vaelii.impl.sentex.RuleSentex
     [rule-tag (:sentence sx) (:context sx) (:id sx) (:truth sx) (:antecedent sx)
@@ -74,14 +74,14 @@
         (= rule-tag tag)
         (sx/->RuleSentex (f 1) (f 2) (nth v 3) (nth v 4) (f 5) (f 6) (nth v 7) (f 8)
                          (nth v 9) (nth v 10) (nth v 11) (nth v 12))
-        (= atomic-tag tag)
-        (sx/->AtomicSentex (f 1) (f 2) (nth v 3) (nth v 4) (nth v 5))
+        (= literal-tag tag)
+        (sx/->LiteralSentex (f 1) (f 2) (nth v 3) (nth v 4) (nth v 5))
         ;; a tag this build does not read is a frame from some other build — refused
-        ;; by name, never misread as an atomic record whose fields land in the wrong
+        ;; by name, never misread as a literal record whose fields land in the wrong
         ;; slots (the tokenized tags decode on their own path, dictionary in hand)
         :else
         (throw (ex-info (str "unknown sentex frame tag " (pr-str tag) " — this path reads"
-                             " tag " atomic-tag " (atomic) and " rule-tag " (rule), and"
+                             " tag " literal-tag " (literal) and " rule-tag " (rule), and"
                              " the two tokenized twins decode with the dictionary in"
                              " hand; a tag outside those four is a frame some other build"
                              " wrote")
@@ -225,9 +225,9 @@
 
 (defn- encode-sentex-tok [dict sx]
   (condp instance? sx
-    vaelii.impl.sentex.AtomicSentex
+    vaelii.impl.sentex.LiteralSentex
     (let [[bs lits] (encode-body dict [(:sentence sx) (:context sx) (:truth sx) (:strength sx)])]
-      [atomic-tok-tag bs lits (:id sx)])
+      [literal-tok-tag bs lits (:id sx)])
 
     vaelii.impl.sentex.RuleSentex
     (let [[bs lits] (encode-body dict [(:sentence sx) (:context sx) (:truth sx)
@@ -251,7 +251,7 @@
         (sx/->RuleSentex sentence context id truth antecedent consequent strength varmap
                          direction defeasible assumption constraint))
       (let [sentence (rd) context (rd) truth (rd) strength (rd)]
-        (sx/->AtomicSentex sentence context id truth strength)))))
+        (sx/->LiteralSentex sentence context id truth strength)))))
 
 ;; ---- the per-kind table -------------------------------------------------
 
@@ -260,7 +260,7 @@
    ;; reading is never conditional: the frame's own tag says which shape it is, so a
    ;; store holding plain, tokenized and pre-codec frames at once reads all three
    :dec (fn [v]
-          (if (and (vector? v) (#{atomic-tok-tag rule-tok-tag} (nth v 0)))
+          (if (and (vector? v) (#{literal-tok-tag rule-tok-tag} (nth v 0)))
             (decode-sentex-tok dict v)
             (decode-sentex v)))})
 
@@ -268,7 +268,7 @@
   "Whether a thawed frame spells its body as dictionary ids — what a store must have a
   dictionary to read."
   [v]
-  (boolean (and (vector? v) (#{atomic-tok-tag rule-tok-tag} (nth v 0)))))
+  (boolean (and (vector? v) (#{literal-tok-tag rule-tok-tag} (nth v 0)))))
 
 (defn by-kind
   "`kind-name -> {:enc :dec}` for a store.  `dict` is its durable token dictionary, which

--- a/src/vaelii/impl/kb.clj
+++ b/src/vaelii/impl/kb.clj
@@ -1786,7 +1786,7 @@
   so its leaf can still hold sentexes of the same *shape* naming other variables (two
   `exceptWhen` exceptions on one rule differing in which rule variable they name, a
   `defn*` condition with its variables transposed); for those the stored sentence decides,
-  one record read per sentex at that leaf.  Only a non-ground Atomic pays it: a rule's key
+  one record read per sentex at that leaf.  Only a non-ground Literal pays it: a rule's key
   is its canonical form whole — α-renamed literals, never a bare variable token — so the
   trie answers it exactly."
   [kb built handles]

--- a/src/vaelii/impl/resolution.clj
+++ b/src/vaelii/impl/resolution.clj
@@ -982,7 +982,7 @@
                   (let [stored (p/get-sentex recs h)]
                     ;; an exceptWhen meta-sentex is internal bookkeeping (a rule's
                     ;; exception), not a domain fact, and it is the one *non-ground*
-                    ;; stored Atomic — so it is skipped here, keeping the trie and
+                    ;; stored Literal — so it is skipped here, keeping the trie and
                     ;; argument-root retrieval paths in agreement and ordinary queries
                     ;; clear of it.  A rule's exceptions are read through
                     ;; `provers/rule-exceptions`.
@@ -1454,7 +1454,7 @@
             ;; predicate-hierarchy filter (the sub-predicate closure) and the
             ;; context-hierarchy filter (the genlCx up-closure), in memory.  An
             ;; exceptWhen meta-sentex is internal bookkeeping and skipped, as in
-            ;; `match-one` (the one non-ground stored Atomic).  Both branches below
+            ;; `match-one` (the one non-ground stored Literal).  Both branches below
             ;; admit a candidate exactly here, and differ only in how many answers one
             ;; admitted record may yield.
             blind? (belief-blind?)

--- a/src/vaelii/impl/rete.clj
+++ b/src/vaelii/impl/rete.clj
@@ -208,7 +208,7 @@
   (let [pat (res/kb-sentex kb sentence context)]
     (keep (fn [stored]
             ;; the exceptWhen guard is the reference's too (`res/match-one`): a rule's
-            ;; exception meta-sentex is internal bookkeeping, stored Atomic and so
+            ;; exception meta-sentex is internal bookkeeping, stored Literal and so
             ;; admitted into the alpha memories, and must never surface as a fact
             (when (and (jtms/in? (:tms kb) (:id stored))
                        (not (sx/exceptWhen-meta? (:sentence stored))))

--- a/src/vaelii/impl/sentex.clj
+++ b/src/vaelii/impl/sentex.clj
@@ -42,15 +42,15 @@
 
   `:sentence` holds the canonical, readable form for display and matching.
 
-  A sentex is one of two records — `AtomicSentex` (an atomic sentence: a fact, a metadata
-  declaration, a query pattern) or `RuleSentex` (an implication) — so an atomic sentex does
-  not carry the rule-only slots (there are 100M+ of them), and each still round-trips
-  through nippy with its type intact."
+  A sentex is one of two records — `LiteralSentex` (a literal: a signed predicate
+  application — a fact or its negation, a metadata declaration, a query pattern) or
+  `RuleSentex` (an implication) — so a literal sentex does not carry the rule-only slots
+  (there are 100M+ of them), and each still round-trips through nippy with its type intact."
   (:refer-clojure :exclude [name])
   (:require [vaelii.impl.caches :as caches])
   (:import [java.util.concurrent ConcurrentHashMap]))
 
-;; Two records, split so an atomic sentex does not carry the seven rule-only slots
+;; Two records, split so a literal sentex does not carry the seven rule-only slots
 ;; (facts are the 100M+ case).  Both share the scalar core:
 ;;   sentence    the canonical, readable form — `(not S)` for a negative literal,
 ;;               `(implies (and …) …)` for a rule; display and matching read it
@@ -73,11 +73,11 @@
 ;;   strength    :monotonic | :default | nil    (the assumption strength when the
 ;;               sentex is asserted as a premise; nil for a purely-derived one)
 ;;
-;; An `AtomicSentex` is an atomic sentence — a fact, a metadata declaration, or a query
-;; pattern: one signed predicate application, ground or holding variables.  It adds
+;; A `LiteralSentex` is a literal — a fact or its negation, a metadata declaration, or a
+;; query pattern: one signed predicate application, ground or holding variables.  It adds
 ;; nothing to the core, and reading any rule-only key off it returns nil, so
-;; `(some? (:antecedent sx))` is the atomic-vs-rule discriminant everywhere.
-(defrecord AtomicSentex [sentence context id truth strength])
+;; `(some? (:antecedent sx))` is the literal-vs-rule discriminant everywhere.
+(defrecord LiteralSentex [sentence context id truth strength])
 ;;
 ;; A `RuleSentex` is an implication.  Beyond the core it carries the decomposition the
 ;; connectives and `set/*` wrappers canonicalize into:
@@ -1882,10 +1882,10 @@
       (let [b      (normalize-literal body symmetric?)
             stored (if (= truth :false) (list not-functor b) b)]
         ;; a wrapper on a non-rule is meaningless; it is stripped and ignored
-        (->AtomicSentex stored ctx nil truth nil)))))
+        (->LiteralSentex stored ctx nil truth nil)))))
 
 (defn sentex
-  "Construct a sentex — an `AtomicSentex` or a `RuleSentex` — canonicalizing the structural
+  "Construct a sentex — a `LiteralSentex` or a `RuleSentex` — canonicalizing the structural
   connectives into the record and the sentence into canonical form (see the namespace
   docstring).  Context defaults to 'default; id defaults to nil until the record store
   assigns a handle.
@@ -1896,14 +1896,14 @@
   ([sentence] (sentex sentence 'default))
   ([sentence context] (sentex sentence context nil))
   ([sentence context {:keys [symmetric?] :or {symmetric? (constantly false)}}]
-   ;; A `(exceptWhen <query> (sentexHandle H))` meta-sentex is stored **verbatim** as an
-   ;; Atomic — `peel-rule-wrapper` would otherwise strip the exceptWhen and drop the
+   ;; A `(exceptWhen <query> (sentexHandle H))` meta-sentex is stored **verbatim** as a
+   ;; Literal — `peel-rule-wrapper` would otherwise strip the exceptWhen and drop the
    ;; query, since it cannot tell the stored meta form from the surface wrapper.  This is
    ;; the one point that can: the wrapper's second argument is a rule, the meta's is a
    ;; handle.  Its query holds the rule's canonical variables, so it is a non-ground
-   ;; Atomic — exempt from the ground-fact check by the assert layer.
+   ;; Literal — exempt from the ground-fact check by the assert layer.
    (if (exceptWhen-meta? sentence)
-     (->AtomicSentex (canon sentence) (intern-sym context) nil :true nil)
+     (->LiteralSentex (canon sentence) (intern-sym context) nil :true nil)
      (constructed-sentex sentence context symmetric?))))
 
 (defn body

--- a/src/vaelii/impl/spec.clj
+++ b/src/vaelii/impl/spec.clj
@@ -131,7 +131,7 @@
 ;; The *stable* contract is the map shape below — `:id`, `:sentence`, `:context`
 ;; are always present; a rule adds `:antecedent` / `:consequent` / `:direction`.
 ;; Treat the result as a map: callers should key into it, never depend on the
-;; concrete `vaelii.impl.sentex/AtomicSentex` / `RuleSentex` record class, which is an internal
+;; concrete `vaelii.impl.sentex/LiteralSentex` / `RuleSentex` record class, which is an internal
 ;; detail free to change.
 (s/def ::sentex-map (s/keys :req-un [::id ::sentence ::context]
                             :opt-un [::truth ::strength]))

--- a/src/vaelii/impl/web.clj
+++ b/src/vaelii/impl/web.clj
@@ -8,7 +8,7 @@
     /find?q=<pattern> the terms whose name matches, from the index's term roster
     /term?q=<term>    every sentex containing the term, grouped by the index root that
                       reaches it (functor / argument-position / context / term-index)
-    /sentex/:id       a sentex (atomic or rule): its belief state (IN, or the why-not
+    /sentex/:id       a sentex (literal or rule): its belief state (IN, or the why-not
                       reason — superseded / defeated / unsupported), supports, dependents
     /justification/:id    a justification: its supports (arguments) and dependent sentex
     /levels?q=<goal>  the lookup-to-query stack: what each of the 8 levels answers

--- a/test/vaelii/catalog_test.clj
+++ b/test/vaelii/catalog_test.clj
@@ -507,7 +507,7 @@
             (sentex-ids [_] (p/sentex-ids real))
             (get-sentex [_ _id]
               {:nippy/unthawable {:type :record
-                                  :class-name "vaelii.impl.sentex.AtomicSentex"}}))
+                                  :class-name "vaelii.impl.sentex.LiteralSentex"}}))
           nothing-stored #_{:clj-kondo/ignore [:missing-protocol-method]}
           (reify p/RecordStore
             (sentex-ids [_] #{})

--- a/test/vaelii/disk_codec_test.clj
+++ b/test/vaelii/disk_codec_test.clj
@@ -23,17 +23,17 @@
 (def ^:private sx-trip #(round-trip codec/encode-sentex codec/decode-sentex %))
 (def ^:private d-trip  #(round-trip codec/encode-justification codec/decode-justification %))
 
-(deftest atomic-round-trips
-  (doseq [a [(sx/->AtomicSentex '(dog Muffet) 'C 7 :true :monotonic)
-             (sx/->AtomicSentex '(bornIn Tom 1970) 'CxWell 12 :true nil)
-             (sx/->AtomicSentex '(likes Ann (mother (father Bob))) 'C 3 :false :default)
-             (sx/->AtomicSentex '(exceptWhen (penguin ?var0) (sentexHandle 9)) 'C 4 :true nil)
+(deftest literal-round-trips
+  (doseq [a [(sx/->LiteralSentex '(dog Muffet) 'C 7 :true :monotonic)
+             (sx/->LiteralSentex '(bornIn Tom 1970) 'CxWell 12 :true nil)
+             (sx/->LiteralSentex '(likes Ann (mother (father Bob))) 'C 3 :false :default)
+             (sx/->LiteralSentex '(exceptWhen (penguin ?var0) (sentexHandle 9)) 'C 4 :true nil)
              ;; every nil-able field nil at once — the shape a bare derived fact has
-             (sx/->AtomicSentex '(p A) 'C nil :true nil)]]
-    (testing (str "atomic " (:sentence a))
+             (sx/->LiteralSentex '(p A) 'C nil :true nil)]]
+    (testing (str "literal " (:sentence a))
       (let [r (sx-trip a)]
         (is (= a r) "equal")
-        (is (instance? vaelii.impl.sentex.AtomicSentex r) "and still an Atomic")
+        (is (instance? vaelii.impl.sentex.LiteralSentex r) "and still a Literal")
         (is (nil? (:antecedent r)) "a rule-only key still reads nil off it")))))
 
 (deftest rule-round-trips
@@ -68,14 +68,14 @@
 (deftest decoding-interns-the-vocabulary
   ;; a record paged off disk must share the one pooled object per name, or every fetch
   ;; mints its own copies and the hot cache retains them
-  (let [a (sx/->AtomicSentex (list 'parentOf 'Tom 'Ann) 'CxWell 1 :true nil)
+  (let [a (sx/->LiteralSentex (list 'parentOf 'Tom 'Ann) 'CxWell 1 :true nil)
         r (sx-trip a)]
     (is (identical? (sx/intern-sym 'parentOf) (first (:sentence r))))
     (is (identical? (sx/intern-sym 'Tom) (second (:sentence r))))
     (is (identical? (sx/intern-sym 'CxWell) (:context r)))))
 
 (deftest non-record-values-pass-through
-  (testing "a plain map is not an Atomic and must round-trip as the map it is"
+  (testing "a plain map is not a Literal and must round-trip as the map it is"
     (is (= {:sentence '(dog Muffet) :context 'C} (sx-trip {:sentence '(dog Muffet) :context 'C}))))
   (testing "provenance is an open application map, stored as it comes"
     (let [p {:creator "agent" :created 1700000000 :nested {:review :pending}}]
@@ -85,7 +85,7 @@
   ;; the durable stores hold nippy-frozen RECORDS.  `decode` dispatches on the thawed
   ;; frame's shape, so those frames must come back unchanged — this is what keeps an
   ;; existing store readable rather than needing a rewrite.
-  (let [a      (sx/->AtomicSentex '(dog Muffet) 'C 7 :true :monotonic)
+  (let [a      (sx/->LiteralSentex '(dog Muffet) 'C 7 :true :monotonic)
         r      (sx/->RuleSentex '(implies (and (p ?var0)) (q ?var0)) 'C 8 :true
                                 '[(p ?var0)] '(q ?var0) nil nil :forward nil nil nil)
         d      (jtms/->Justification 20 :rule [1 2] 3 nil :monotonic #{})
@@ -96,7 +96,7 @@
 
 (deftest a-frame-tag-this-build-does-not-read-is-refused-by-name
   ;; The other direction of the same compatibility question: a positional frame whose tag
-  ;; is not one of this codec's must be refused rather than read as an atomic whose fields
+  ;; is not one of this codec's must be refused rather than read as a literal whose fields
   ;; land in the wrong slots.  Refused *by name*, because `rebuild-premises!`
   ;; discriminates on the type: `:damaged-dictionary` and `:malformed-record` are crash
   ;; damage and tombstone the record, while this one rethrows — a build that cannot read a
@@ -109,7 +109,7 @@
 (deftest the-codec-is-what-shrinks-the-frame
   ;; the point of the codec, asserted rather than assumed: a positional frame is
   ;; materially smaller than the record frame it replaces
-  (let [a     (sx/->AtomicSentex '(parentOf Tom Ann) 'CxNaturalWorld 7 :true :monotonic)
+  (let [a     (sx/->LiteralSentex '(parentOf Tom Ann) 'CxNaturalWorld 7 :true :monotonic)
         rec-b (alength ^bytes (nippy/freeze a))
         pos-b (alength ^bytes (nippy/freeze (codec/encode-sentex a)))]
     (is (< pos-b rec-b)
@@ -130,12 +130,12 @@
                   (doseq [x (reverse (file-seq (java.io.File. dir)))] (.delete ^java.io.File x))))))
 
 (def ^:private shapes
-  [(sx/->AtomicSentex '(dog Muffet) 'C 7 :true :monotonic)
-   (sx/->AtomicSentex '(bornIn Tom 1970) 'CxWell 12 :true nil)
-   (sx/->AtomicSentex '(comment dog "a domestic canine") 'CxCore 13 :true :default)
-   (sx/->AtomicSentex '(likes Ann (mother (father Bob))) 'C 3 :false :default)
-   (sx/->AtomicSentex '(measures Rod 1.5) 'C 14 :true nil)
-   (sx/->AtomicSentex '(p A) 'C nil :true nil)
+  [(sx/->LiteralSentex '(dog Muffet) 'C 7 :true :monotonic)
+   (sx/->LiteralSentex '(bornIn Tom 1970) 'CxWell 12 :true nil)
+   (sx/->LiteralSentex '(comment dog "a domestic canine") 'CxCore 13 :true :default)
+   (sx/->LiteralSentex '(likes Ann (mother (father Bob))) 'C 3 :false :default)
+   (sx/->LiteralSentex '(measures Rod 1.5) 'C 14 :true nil)
+   (sx/->LiteralSentex '(p A) 'C nil :true nil)
    (sx/->RuleSentex '(implies (and (dog ?var0)) (mammal ?var0)) 'C 8 :true
                     '[(dog ?var0)] '(mammal ?var0) :monotonic '{?var0 ?x} :forward true nil nil)
    (sx/->RuleSentex '(implies (and (parentOf ?var0 ?var1) (parentOf ?var1 ?var2))
@@ -165,7 +165,7 @@
   (with-dict
     (fn [d _]
       (let [tok  (get (codec/by-kind d true) "sentexes")
-            a    (sx/->AtomicSentex '(parentOf Tom Ann) 'CxNaturalWorld 7 :true :monotonic)
+            a    (sx/->LiteralSentex '(parentOf Tom Ann) 'CxNaturalWorld 7 :true :monotonic)
             rec-b (alength ^bytes (nippy/freeze a))
             pos-b (alength ^bytes (nippy/freeze (codec/encode-sentex a)))
             tok-b (alength ^bytes (nippy/freeze ((:enc tok) a)))]
@@ -180,11 +180,11 @@
       (let [{:keys [enc dec]} (get (codec/by-kind d true) "sentexes")
             before (dtok/token-count d)]
         (doseq [i (range 50)]
-          (enc (sx/->AtomicSentex (list 'measured 'Rod (+ 1000 i) (str "run-" i)) 'C i :true nil)))
+          (enc (sx/->LiteralSentex (list 'measured 'Rod (+ 1000 i) (str "run-" i)) 'C i :true nil)))
         (is (= (+ before 4) (dtok/token-count d))
             "only measured / Rod / C / :true entered the dictionary — not the 100 literals")
         ;; and they still come back
-        (let [s (sx/->AtomicSentex '(measured Rod 1042 "run-42") 'C 42 :true nil)]
+        (let [s (sx/->LiteralSentex '(measured Rod 1042 "run-42") 'C 42 :true nil)]
           (is (= s (dec (nippy/thaw (nippy/freeze (enc s)))))))))))
 
 (deftest the-dictionary-keys-by-clojure-equality
@@ -233,7 +233,7 @@
     (fn [d _]
       (let [on  (get (codec/by-kind d true) "sentexes")
             off (get (codec/by-kind d false) "sentexes")
-            a   (sx/->AtomicSentex '(dog Muffet) 'C 7 :true :monotonic)
+            a   (sx/->LiteralSentex '(dog Muffet) 'C 7 :true :monotonic)
             plain (nippy/freeze ((:enc off) a))
             toked (nippy/freeze ((:enc on) a))]
         (is (= a ((:dec on) (nippy/thaw plain))) "tokenizing store reads a plain frame")
@@ -245,7 +245,7 @@
   (with-dict
     (fn [d _]
       (let [{:keys [enc dec]} (get (codec/by-kind d true) "sentexes")
-            frame (nippy/thaw (nippy/freeze (enc (sx/->AtomicSentex '(dog Muffet) 'C 7 :true nil))))]
+            frame (nippy/thaw (nippy/freeze (enc (sx/->LiteralSentex '(dog Muffet) 'C 7 :true nil))))]
         (is (codec/tokenized-frame? frame))
         ;; a dictionary that never saw those tokens cannot decode the frame
         (with-dict
@@ -273,7 +273,7 @@
   (with-dict
     (fn [d _]
       (let [{:keys [enc dec]} (get (codec/by-kind d true) "sentexes")
-            frame   (enc (sx/->AtomicSentex '(dog Muffet) 'C 7 :true nil))
+            frame   (enc (sx/->LiteralSentex '(dog Muffet) 'C 7 :true nil))
             ;; -11 is one past the codec's lowest control code; its zigzag varint is
             ;; the single byte 21 — a body no writer of this format produces
             corrupt (assoc frame 1 (byte-array [(byte 21)]))

--- a/test/vaelii/disk_record_store_test.clj
+++ b/test/vaelii/disk_record_store_test.clj
@@ -886,7 +886,7 @@
     (fn [dir]
       (let [s1 (drs/open-record-store dir {:tokenize? true})
             a  (p/put-sentex s1 {:sentence '(dog Muffet) :context 'C})
-            b  (p/put-sentex s1 (sx/->AtomicSentex '(bornIn Tom 1970) 'CxWell nil :true :monotonic))
+            b  (p/put-sentex s1 (sx/->LiteralSentex '(bornIn Tom 1970) 'CxWell nil :true :monotonic))
             r  (p/put-sentex s1 (sx/->RuleSentex '(implies (and (dog ?var0)) (mammal ?var0)) 'C nil
                                                  :true '[(dog ?var0)] '(mammal ?var0) :monotonic
                                                  '{?var0 ?x} :forward true nil nil))
@@ -917,7 +917,7 @@
             (try
               (is (= '(bornIn Tom 1970) (:sentence (p/get-sentex s3 b))))
               ;; and what it writes from here is a plain positional frame, beside them
-              (let [c (p/put-sentex s3 (sx/->AtomicSentex '(cat Tom) 'C nil :true nil))]
+              (let [c (p/put-sentex s3 (sx/->LiteralSentex '(cat Tom) 'C nil :true nil))]
                 (is (= '(cat Tom) (:sentence (p/get-sentex s3 c))))
                 (is (= '(dog Muffet) (:sentence (p/get-sentex s3 a))) "the tokenized ones keep reading"))
               (finally (drs/close! s3)))))))))
@@ -927,13 +927,13 @@
     (fn [dir]
       (let [s (drs/open-record-store dir {:tokenize? true})]
         (try
-          (p/put-sentex s (sx/->AtomicSentex '(dog Muffet) 'C nil :true nil))
+          (p/put-sentex s (sx/->LiteralSentex '(dog Muffet) 'C nil :true nil))
           (is (pos? (dtok/token-count (:dict s))))
           (p/clear-records! s)
           (is (zero? (dtok/token-count (:dict s)))
               "a wiped store must not carry its predecessor's vocabulary")
           ;; and it still works afterwards — ids restart from 0 against an empty log
-          (let [h (p/put-sentex s (sx/->AtomicSentex '(cat Tom) 'C nil :true nil))]
+          (let [h (p/put-sentex s (sx/->LiteralSentex '(cat Tom) 'C nil :true nil))]
             (is (= '(cat Tom) (:sentence (p/get-sentex s h)))))
           (finally (drs/close! s)))))))
 
@@ -946,10 +946,10 @@
     (fn [dir]
       (let [tl (str dir "/records/tokens.log")
             s1 (drs/open-record-store dir {:tokenize? true})
-            a  (p/put-sentex s1 (sx/->AtomicSentex '(dog Muffet) 'C nil :true nil))
+            a  (p/put-sentex s1 (sx/->LiteralSentex '(dog Muffet) 'C nil :true nil))
             ;; the dictionary exactly as of `a` — every later token is `b`'s
             after-a (do (drs/fsync s1) (.length (java.io.File. tl)))
-            b  (p/put-sentex s1 (sx/->AtomicSentex '(elephant Jumbo) 'CxZoo nil :true nil))]
+            b  (p/put-sentex s1 (sx/->LiteralSentex '(elephant Jumbo) 'CxZoo nil :true nil))]
         (drs/close! s1)
         (is (> (.length (java.io.File. tl)) after-a) "b introduced new vocabulary")
         ;; roll the dictionary back to that point: b's frame now cites ids that are gone
@@ -964,7 +964,7 @@
             (is (nil? (p/get-sentex s2 b)))
             ;; and the store is usable afterwards — new tokens continue from where the
             ;; rolled-back dictionary now ends
-            (let [c (p/put-sentex s2 (sx/->AtomicSentex '(cat Tom) 'C nil :true nil))]
+            (let [c (p/put-sentex s2 (sx/->LiteralSentex '(cat Tom) 'C nil :true nil))]
               (is (= '(cat Tom) (:sentence (p/get-sentex s2 c)))))
             (finally (drs/close! s2))))))))
 

--- a/test/vaelii/export_test.clj
+++ b/test/vaelii/export_test.clj
@@ -401,7 +401,7 @@
     (justification-ids [_] #{})
     (get-sentex [_ id]
       (vswap! fetches inc)
-      (sx/->AtomicSentex (list 'synthetic (symbol (str "Ind" id))) 'CxSynthetic
+      (sx/->LiteralSentex (list 'synthetic (symbol (str "Ind" id))) 'CxSynthetic
                          id :true nil))
     (get-provenance [_ _] nil)))
 

--- a/test/vaelii/export_test.clj
+++ b/test/vaelii/export_test.clj
@@ -402,7 +402,7 @@
     (get-sentex [_ id]
       (vswap! fetches inc)
       (sx/->LiteralSentex (list 'synthetic (symbol (str "Ind" id))) 'CxSynthetic
-                         id :true nil))
+                          id :true nil))
     (get-provenance [_ _] nil)))
 
 (deftest ^:slow the-writer-never-runs-more-than-a-chunk-ahead-of-what-it-has-written

--- a/test/vaelii/public_api_test.clj
+++ b/test/vaelii/public_api_test.clj
@@ -334,7 +334,7 @@
   docstrings do, legitimately, eight times), and it misses every spelling that is a
   dependency but not the shape it matched: the plain-symbol libspec
   `(:require vaelii.impl.naming)`, the prefix list `(:require [vaelii.impl [naming :as
-  nm]])`, an `(:import (vaelii.impl.sentex AtomicSentex))`, a `requiring-resolve` on a
+  nm]])`, an `(:import (vaelii.impl.sentex LiteralSentex))`, a `requiring-resolve` on a
   quoted symbol, and — the one that needs no require at all — a bare
   `(vaelii.impl.naming/sort-by-content-key …)` call, which resolves at runtime because
   `vaelii.core` has already loaded the namespace.  Reading the file and walking the forms


### PR DESCRIPTION
Part of the vaelii-lacuna-direct-blocker set (Pace-authorized). **Draft — @paceheart holds the draft→ready latch.**

⚠️ **Stacks on #64** (curation vocab) — the first two commits are #64's; review/merge #64 first, then this rebases onto develop. Only the third commit (`Rename AtomicSentex record → LiteralSentex`) is this PR's own work.

## What this does (the mechanical rename — Step 3 of Pace's 8-step spec)
The `AtomicSentex` record held **one signed predicate application** — a fact *or its negation* — which by the convention is a **literal**, not atomic. Renamed the record and all its references `AtomicSentex → LiteralSentex` pervasively (code, docs, tests). **Wire format unchanged** (the durable frame uses numeric tags, never the class name). Grep receipt: **0 stray `AtomicSentex`**, 60 `LiteralSentex`. Full suite green (**4410 tests, 0 failures**).

## ⚠️ CONFLICT flagged for @paceheart — the type-taxonomy (Steps 2, 4, 5, 6, 8) is NOT in this PR
Steps 5–6 want `(disjoint AtomicSentex NegatedAtomicSentex)` + genl edges making these KB **types**. But vaelii's naming invariant reads **PascalCase as individuals, lowercase as types** — so `AtomicSentex`/`LiteralSentex`/`NegatedAtomicSentex` parse as individuals, and `(genl AtomicSentex …)` / `(AtomicSentex H)` are rejected/inert. **The taxonomy as spelled cannot be expressed.** Needs a ruling:

1. **Spelling:** snake_case KB types `literal_sentex` / `atomic_sentex` / `negated_atomic_sentex` (KB-idiomatic), keeping PascalCase `LiteralSentex` only as the record/glossary name? (my recommendation)
2. **Placement:** CxCore, or another context?
3. **Parent:** there's no `sentence`/`sentex` collection to hang `literal_sentex` under — genl to `thing`, or introduce a supertype?
4. **Classifier:** `:inert`/documentary (like the example vocab), or an engine classifier?

Also: vaelii has **no** `partitionedInto`/coverage-partition vocab (only `siblingDisjoint`/`disjointMetatype`, neither asserting exhaustive coverage) — so Atomic/Negated exhaustively partitioning Literal can only be expressed as disjoint + two genl edges.

**Recommended (not applied):** snake_case types `literal_sentex ⊐ atomic_sentex, negated_atomic_sentex`, disjoint, `genl … thing`, `:inert`, examples in `curation_test`; glossary maps record `LiteralSentex` ↔ KB type `literal_sentex`. Idiomatic + expressible — but it's an ontology-design call, so surfaced rather than guessed.
