### PR TITLE
feat(predall): the predAll quantifier-family matrix (8 of 8 cells)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,11 +14,14 @@ name: test
 # 317s; deferring them here is only honest because deep.yml runs `:all`. If
 # that job is ever removed, this one has to become `:all`.
 #
-# No sharding, deliberately. The retired engine sharded a 162-namespace suite
-# four ways behind a `vaelii.tools.test-shard` runner and a `.test-timings.edn`
-# cache; none of that machinery exists here and the suite it was built for does
-# not either. Measure a real run before importing it — the whole `:default` pass
-# is ~2 minutes locally, and four shards of that is four JVM boots to save one.
+# The disk leg alone is sharded, across two RUNNER VMs, because a real run
+# measured it into its own timeout: ~21 minutes on develop and ~30 against the
+# 30-minute cap once the predall suite landed. This is not the same-host JVM
+# sharding scripts/test-parallel.sh refuses for durable backends — separate VMs
+# share neither a disk nor a registry, the same reason deep.yml runs nine
+# backends in parallel. The memory leg stays whole: ~2 minutes locally, and
+# shards of that is JVM boots to save nothing. Shards are whole namespaces
+# (a `:once` fixture is what tests in one file share), split alphabetically.
 #
 # Hermetic: no external service, no network call, and no LLM. `^:llm` is the one
 # mark `:all` does not select, and reaching a provider additionally needs
@@ -73,12 +76,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
-      # Run both to completion. A durability bug that shows up only under `disk`
-      # is exactly what this matrix is for, and cancelling it because the memory
-      # run went red first would hide it until the next push.
+      # A one-value matrix, kept as a matrix so the job's check name stays the
+      # bare `memory` (see the naming note above). The disk end of the axis runs
+      # in the sharded `disk-shard` legs below, reporting through the `disk`
+      # gate job so branch protection's required context is unchanged.
       fail-fast: false
       matrix:
-        backend: [memory, disk]
+        backend: [memory]
     steps:
       # No credentials left in .git/config: nothing here pushes, and a token
       # sitting in the workspace is reachable by anything the build runs.
@@ -130,16 +134,11 @@ jobs:
           # The matrix value is the CHECK name, and branch protection stores that:
           # `memory` and `disk` are required on `develop`, so a leg that changes
           # name stops reporting under the required one and leaves every pull
-          # request unmergeable. The name therefore says which END of the storage
-          # axis this leg is, and the `:backend` it selects is named here —
-          # `disk-log`, durable records under the write-ahead-logged index
-          # (docs/storage.md).
-          VAELII_TEST_BACKEND: ${{ matrix.backend == 'disk' && 'disk-log' || matrix.backend }}
+          # request unmergeable. The matrix value is the CHECK name; the disk
+          # end of the axis reports through the `disk` gate below.
+          VAELII_TEST_BACKEND: ${{ matrix.backend }}
         run: |
           set -o pipefail
-          if [ "${{ matrix.backend }}" = "disk" ]; then
-            export JVM_OPTS="-Dvaelii.disk.dir=$RUNNER_TEMP/vaelii-disk"
-          fi
           mkdir -p target/ci
           lein test 2>&1 | tee "target/ci/test-${{ matrix.backend }}.log"
 
@@ -160,6 +159,103 @@ jobs:
           path: target/ci/
           if-no-files-found: error
           retention-days: 7
+
+  # The disk end of the durability axis, split across two runner VMs. The leg
+  # grew into its 30-minute timeout (~21m on develop, ~30m with the predall
+  # suite); halving the namespaces halves the long pole, and separate VMs make
+  # it safe where scripts/test-parallel.sh's same-host durable-sharding refusal
+  # applies — no shared directory, no shared registry, no single-writer lock in
+  # common (deep.yml's matrix is the standing precedent). Shards are whole
+  # namespaces (a `:once` fixture is what tests in one file share), split
+  # alphabetically; `:default` pins the same selector the memory leg runs.
+  disk-shard:
+    name: disk-shard-${{ matrix.shard }}
+    if: github.event_name != 'schedule' || github.repository_owner == 'vaelii'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      # Run both to completion: a durability bug living in one alphabetical half
+      # should not be hidden by the other half going red first.
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5.7.0
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Leiningen
+        uses: DeLaGuardo/setup-clojure@4c7a6f613e5089821bb3bb2a33a3ee115578580d  # 13.6.1
+        with:
+          lein: 2.12.0  # 2.13.0's launcher self-installs an unpublished snapshot jar
+
+      - name: Cache Maven deps
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.m2
+          key: m2-${{ runner.os }}-jdk21-${{ hashFiles('project.clj') }}
+          restore-keys: |
+            m2-${{ runner.os }}-jdk21-
+
+      - name: Run the suite (disk-log, shard ${{ matrix.shard }} of 2)
+        id: suite
+        env:
+          # `disk-log`: durable records under the write-ahead-logged index
+          # (docs/storage.md) — the same end of the axis the retired single
+          # `disk` leg ran.
+          VAELII_TEST_BACKEND: disk-log
+        run: |
+          set -o pipefail
+          export JVM_OPTS="-Dvaelii.disk.dir=$RUNNER_TEMP/vaelii-disk"
+          mkdir -p target/ci
+          mapfile -t files < <(find test -name '*_test.clj' | sort)
+          half=$(( (${#files[@]} + 1) / 2 ))
+          if [ "${{ matrix.shard }}" = "1" ]; then
+            sel=("${files[@]:0:$half}")
+          else
+            sel=("${files[@]:$half}")
+          fi
+          nss=()
+          for f in "${sel[@]}"; do
+            ns=${f#test/}; ns=${ns%.clj}; ns=${ns//\//.}; ns=${ns//_/-}
+            nss+=("$ns")
+          done
+          echo "shard ${{ matrix.shard }}: ${#nss[@]} of ${#files[@]} test namespaces"
+          # Bare namespace args: the `:default` selector still applies (verified:
+          # a ^:slow test in a named namespace is excluded), while spelling the
+          # selector out alongside namespace args makes lein ignore the namespace
+          # filter and run the whole suite (verified the hard way).
+          lein test "${nss[@]}" 2>&1 | tee "target/ci/test-disk-shard-${{ matrix.shard }}.log"
+
+      - name: Upload failure logs
+        if: failure() && steps.suite.outcome == 'failure'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: test-disk-shard-${{ matrix.shard }}-logs
+          path: target/ci/
+          if-no-files-found: error
+          retention-days: 7
+
+  # Branch protection on `develop` requires the bare `disk` context, so the two
+  # shard legs report through this gate rather than under their own names —
+  # renaming it strands every pull request (the naming note on `suite` says
+  # why). `always()` because a skipped job never reports, which a required
+  # check reads as missing, not as passed.
+  disk:
+    name: disk
+    needs: disk-shard
+    if: ${{ always() && (github.event_name != 'schedule' || github.repository_owner == 'vaelii') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: All disk shards green
+        run: |
+          [ "${{ needs.disk-shard.result }}" = "success" ]
 
   # The suite again, with an ANSWER SET SOLVER on the box. Without one, eight
   # test namespaces skip their bodies and still report as passing — every solver

--- a/docs/equality.md
+++ b/docs/equality.md
@@ -71,6 +71,13 @@ OWL drops UNA. We do not. `(different X Y)` is **provable exactly when the
 arguments lie in no shared equivalence class** — so distinct symbols denote
 distinct individuals until an equality sentex says otherwise.
 
+One carve-out: an **unpinned indeterminate term** — a skolem constant, or a
+believed member of the extensible `indeterminate_term` category — suspends the
+UNA for itself. It stands for some object without pinning down which, so
+neither `equals` nor `different` is provable between it and a determinate term
+until a `rewriteOf` or merge pins it, at which point its representative moves
+off it and the exemption lifts (`provers.clj`, `pairwise-distinct?`).
+
 This is negation as failure over the equality closure, and it is what keeps
 counting meaningful: counting distinct symbols stays correct except for terms
 somebody explicitly merged, so `count-with-arg` and friends do not acquire a

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -976,8 +976,9 @@ subtype fact satisfies the antecedent. See [inference.md](inference.md).
 
 **Unique-name assumption (UNA)** ![kb](../.github/badges/cat-kb.svg): Distinct
 symbols denote distinct things until an equality sentex says otherwise —
-preserved even under the equality closure and made provable by `different`. See
-[equality.md](equality.md).
+preserved even under the equality closure and made provable by `different`.
+Suspended for an unpinned indeterminate term (skolems and `indeterminate_term`
+members) until a `rewriteOf`/merge pins it. See [equality.md](equality.md).
 
 **`unknown`** ![inference](../.github/badges/cat-inference.svg): The negation-as-
 failure prover — `(unknown S)` holds iff `S` is not derivable over the level-6

--- a/docs/kbs.md
+++ b/docs/kbs.md
@@ -18,7 +18,7 @@ OpenCyc reader is in this repo. This page is the **sequence**, and what each ste
 | KB | comes from | to first load | once loaded |
 |---|---|---|---|
 | Starter ontology | the classpath | seconds | ~1,879 sentexes |
-| Core vocabulary | the classpath | seconds | ~475 sentexes |
+| Core vocabulary | the classpath | seconds | ~535 sentexes |
 | cyc-tiny | a test fixture in the plugin | one dependency, then seconds | 8,181 sentexes |
 | OpenCyc 4.0 | a distribution you supply | a conversion, then ~10 minutes | ~1.2M sentexes |
 

--- a/docs/namespaces.md
+++ b/docs/namespaces.md
@@ -91,6 +91,7 @@ src/vaelii/impl/
   abduce.clj        abduction: the scratch-context lifecycle, the gate on what may be assumed, and the mint/re-prove loop over the dead ends `prove` reports
   wff.clj           well-formedness of genl / genlCx / disjoint / arg / the equality relations (symbols only, no rewriteOf cycle, `different` not assertible); stratification (no rule-graph cycle through negation)
   provers.clj       Prover protocol (est-bindings + cost tier + completeness) + fact/transitivity/disjointness/metadata/evaluable/quantity/NAF/aggregate/arg/belief-projection + the `ask` engine; the completeness contract and what may shadow what; exceptWhen evaluation + rule guards; `candidate-rules` and `parse-rule`, which the two backward chainers read.  **No member of it expands a rule**, so `ask` never opens a proof search
+  predall.clj       the predAll / predExists / predSpecified quantifier matrix's on-demand half: `specified-violations` (the *Specified* integrity audit — instances of the universal collection with no determinate filler, `indeterminate_term` members exempt) and `indeterminate-term?` (the extensible determinacy read the audit and the equality exemption share).  The *Instance* cells are CxCore rule generators and the *Exists* cells inert records — neither needs code here
   budget.clj        resource-bounded / anytime: bound a lazy answer stream (:max-ms/:max-results), the partial-result contract, the resumable tail
   plan.clj          conjunctive query planning: selectivity cost model + sideways information passing, with the cartesian factors (literals sharing no variable with the rest, and matching more than once, so they multiply it) held to the back on structure rather than on an estimate
   literal_cache.clj per-KB cache of matches-visible answers, keyed by the α-renamed (repetition-preserving) literal + context + retrieval strategy, stamped with the change clock; stores only what ran dry, so a bounded run leaves no prefix behind
@@ -172,7 +173,7 @@ resources/
 
 ## Not glossed above
 
-The map covers 112 of the 152 namespaces under `src/`. The other 40 are listed here by
+The map covers 113 of the 153 namespaces under `src/`. The other 40 are listed here by
 name rather than left out, and the two lists together are every one of them — `lein
 lint`'s **E18** fails on a file in neither and on a count that disagrees with them, so
 the number above stays a measurement. Named here: the engine's write path (`integrate`,

--- a/resources/kb/CxCore.txt
+++ b/resources/kb/CxCore.txt
@@ -312,6 +312,150 @@
 (genlArg defnIff 1 thing)
 (arg defnIff 2 thing)
 
+;; ---- the predAll / predExists / predInstance / predSpecified matrix -------
+;; A family of ternary relations that quantify one binary ?pred's two argument positions
+;; against a collection or an individual, and fix the other.  Each name reads its two
+;; positions in order — predAllInstance quantifies position 1 (All) and fixes position 2
+;; (Instance); predInstanceAll fixes 1 and quantifies 2 — so the four *Instance* / *All*
+;; combinations, the four *Exists* ones, and the *Specified* audit are one matrix.
+;;
+;; Unlike the defn* relations, these are NOT expanded into a single rule at assert: they
+;; are **rule generators** (docs/generators.md — a rule whose consequent is a rule).  The
+;; generator's antecedent grounds the predicate and the collection, and its firing stamps
+;; a concrete rule with those holes filled, so one generator ranges over a whole family of
+;; predicates while every rule the index keys carries a concrete functor.
+
+;; --- Instance class: rule generators, real inference ----------------------
+;; The quantified position ranges over a collection's members; the fixed position is a
+;; given filler.  Stamping (implies (?coll ?x) (?pred …)) is ordinary forward inference,
+;; so a member of the collection is concluded to bear ?pred to the fixed filler.
+
+(comment predAllInstance
+         "(predAllInstance ?pred ?indep ?fixed) means that every instance of collection ?indep bears ?pred to the fixed filler ?fixed at ?pred's first position: for all x in ?indep, (?pred x ?fixed). A rule generator (docs/generators.md), not a defn: it stamps the rule (implies (?indep ?x) (?pred ?x ?fixed)) — a defaultRule, bidirectional — with ?pred/?indep/?fixed ground, so a member arriving later fires it and the conclusion retracts and belief-follows like any derived fact. Forward, the stamped rule fires when membership is believed; backward, its antecedent is discharged inside a query/prove proof — including a bare literal's membership via the evaluative defnSufficient prover, so (predAllInstance sign negative_integer \"negative\") proves (sign -212 \"negative\") from the bare literal under query. Under ask the goal answers false by contract: the registry expands no rule (docs/levels.md).")
+(ternary_predicate predAllInstance)
+(arg predAllInstance 1 binary_predicate)
+(genlArg predAllInstance 2 thing)
+(arg predAllInstance 3 thing)
+(implies (predAllInstance ?pred ?indep ?fixed)
+         (set/defaultRule (implies (?indep ?x) (?pred ?x ?fixed))))
+
+(comment predInstanceAll
+         "(predInstanceAll ?pred ?fixed ?dep) means that the fixed filler ?fixed bears ?pred to every instance of collection ?dep at ?pred's second position: for all y in ?dep, (?pred ?fixed y). The argument-swapped twin of predAllInstance. A rule generator that stamps the bidirectional defaultRule (implies (?dep ?y) (?pred ?fixed ?y)) with the holes ground, so the descent to members is ordinary chain inference (docs/generators.md).")
+(ternary_predicate predInstanceAll)
+(arg predInstanceAll 1 binary_predicate)
+(arg predInstanceAll 2 thing)
+(genlArg predInstanceAll 3 thing)
+(implies (predInstanceAll ?pred ?fixed ?dep)
+         (set/defaultRule (implies (?dep ?y) (?pred ?fixed ?y))))
+
+;; --- Exists class: pure record, inferentially inert -----------------------
+;; Everything with "exist" in the name is INERT (Pace's ruling): the declaration is
+;; stored and queryable like any fact, and the engine draws no inference from it — no
+;; stamped rule, no skolemized witness, no defn ("skolems suck"), no materialized facts.
+;; What each cell contributes beyond the record is a sanctioned PLACEHOLDER functor an
+;; author MAY use to name the required-but-unnamed filler: a PER-CELL functor carrying
+;; that cell's FULL argument list — "kinda like a named skolem" (Pace) — deliberately
+;; DISTINCT per cell, because the markers are ontology now and eventually it will matter
+;; that they are different.  Asserting a placeholder into a sentence (its collection
+;; membership, its relation to a subject) is the author's act, not the engine's; when
+;; asserted, the placeholder is determinate — it satisfies a predAllSpecified audit —
+;; where a skolem witness would not be.  Each functor is unreifiable_function so its
+;; ground application stays a structural NAT, readable inside the sentence.
+;;
+;; Inertness is also what makes all FOUR cells expressible.  An earlier design stamped a
+;; rule per declaration via a generator; the two pure-existential cross-cells
+;; (predExistsInstance / predInstanceExists) have no universal to range over, so the
+;; generator form failed range restriction there, and the plain-rule form — a
+;; variable-functor consequent — filed in the concluding-rule catch-all and made the
+;; planner see a phantom rule for EVERY predicate (broke aggregate / STP / QCN /
+;; interval / distance reasoning KB-wide, verified).  An inert record stamps nothing,
+;; so there is nothing to fail and nothing to pollute: the asymmetry between the
+;; straight cells and the cross-cells dissolves with the inference.
+
+(comment PredAllExistsFn
+         "(PredAllExistsFn ?pred ?indep ?dep) denotes the sanctioned ontological placeholder for the required but unnamed ?dep filler of ?pred over ?indep — the term an author may use to speak of the filler a predAllExists declaration requires, without naming it. An unreifiable_function, so a ground application stays a structural NAT the reader keeps readable inside the sentence; per-cell and full-arg (\"kinda like a named skolem\"), distinct from the other Exists cells' placeholders. An ontological marker, deliberately NOT a skolem witness: the engine never asserts it anywhere — its uses are the author's — and when used it is determinate, so it satisfies a predAllSpecified audit. See docs/nat.md.")
+(unreifiable_function PredAllExistsFn)
+
+(comment PredExistsAllFn
+         "(PredExistsAllFn ?pred ?dep ?indep) denotes the sanctioned placeholder for the ?dep filler predExistsAll requires at ?pred's first position. An unreifiable_function; per-cell and full-arg, distinct from the other Exists cells' placeholders; never asserted by the engine. See docs/nat.md.")
+(unreifiable_function PredExistsAllFn)
+
+(comment PredExistsInstanceFn
+         "(PredExistsInstanceFn ?pred ?indep ?fixed) denotes the sanctioned placeholder for the ?indep member predExistsInstance requires at ?pred's first position, against the fixed filler ?fixed. An unreifiable_function; per-cell and full-arg, distinct from the other Exists cells' placeholders; never asserted by the engine. See docs/nat.md.")
+(unreifiable_function PredExistsInstanceFn)
+
+(comment PredInstanceExistsFn
+         "(PredInstanceExistsFn ?pred ?fixed ?dep) denotes the sanctioned placeholder for the ?dep member predInstanceExists requires at ?pred's second position, borne by the fixed subject ?fixed. An unreifiable_function; per-cell and full-arg, distinct from the other Exists cells' placeholders; never asserted by the engine. See docs/nat.md.")
+(unreifiable_function PredInstanceExistsFn)
+
+(comment predAllExists
+         "(predAllExists ?pred ?indep ?dep) means that every instance of collection ?indep bears ?pred, at position 1, to some member of collection ?dep: for all x in ?indep, exists y in ?dep, (?pred x y). Inferentially inert (see the Exists header): the declaration is a stored, queryable record and the engine derives nothing from it — no rule, no witness, no membership. (PredAllExistsFn ?pred ?indep ?dep) is the sanctioned placeholder an author may use to name the required filler.")
+(ternary_predicate predAllExists)
+(arg predAllExists 1 binary_predicate)
+(genlArg predAllExists 2 thing)
+(genlArg predAllExists 3 thing)
+
+(comment predExistsAll
+         "(predExistsAll ?pred ?dep ?indep) means that some member of collection ?dep bears ?pred, at position 1, to every instance of collection ?indep: exists y in ?dep such that for all x in ?indep, (?pred y x). The argument-swapped twin of predAllExists — the existential filler sits in ?pred's first position and the universal in its second. Inferentially inert like the whole Exists class; (PredExistsAllFn ?pred ?dep ?indep) is its sanctioned placeholder.")
+(ternary_predicate predExistsAll)
+(arg predExistsAll 1 binary_predicate)
+(genlArg predExistsAll 2 thing)
+(genlArg predExistsAll 3 thing)
+
+(comment predExistsInstance
+         "(predExistsInstance ?pred ?indep ?fixed) means that some member of collection ?indep bears ?pred, at position 1, to the fixed filler ?fixed: exists x in ?indep, (?pred x ?fixed). A pure existential — no universal to range over — expressible precisely because the Exists class is inert: a stored record, nothing derived. (PredExistsInstanceFn ?pred ?indep ?fixed) is its sanctioned placeholder.")
+(ternary_predicate predExistsInstance)
+(arg predExistsInstance 1 binary_predicate)
+(genlArg predExistsInstance 2 thing)
+(arg predExistsInstance 3 thing)
+
+(comment predInstanceExists
+         "(predInstanceExists ?pred ?fixed ?dep) means that the fixed subject ?fixed bears ?pred, at position 1, to some member of collection ?dep: exists y in ?dep, (?pred ?fixed y). The argument-swapped twin of predExistsInstance, inert like the whole class; (PredInstanceExistsFn ?pred ?fixed ?dep) is its sanctioned placeholder.")
+(ternary_predicate predInstanceExists)
+(arg predInstanceExists 1 binary_predicate)
+(arg predInstanceExists 2 thing)
+(genlArg predInstanceExists 3 thing)
+
+;; --- indeterminate_term: the determinacy category the Specified audit reads ---
+;; An EXTENSIBLE category of terms whose identity is not pinned down: a term that stands
+;; for some object without pinning down which.  It is what the *Specified* audit excludes
+;; (an indeterminate filler does not satisfy the requirement) and, in the same spirit, the
+;; category the unique-name assumption is suspended for — neither `equals` nor `different`
+;; is provable of a member against a determinate term until a `rewriteOf` pins it.  Skolem
+;; constants are the built-in first member: their membership is never a stored fact (they
+;; are minted dynamically), so it is read off their `SkolemFn` minting expression rather
+;; than through a collection query, while a further kind of indeterminate term is added
+;; with (genl NewKind indeterminate_term) and picked up through ordinary membership by both
+;; the audit (vaelii.impl.predall/indeterminate-term?) and the `different` prover.
+
+(comment indeterminate_term
+         "(indeterminate_term ?term) means that ?term is an indeterminate filler: it stands for some object without pinning down which, so it is not a determinate filler for a predAllSpecified audit, and the unique-name assumption is suspended for it — neither (equals ?term x) nor (different ?term x) is provable against a determinate term x until a rewriteOf pins it. An extensible category read by vaelii.impl.predall/indeterminate-term? and the different prover. Skolem constants are the built-in first member, detected by their SkolemFn minting expression rather than a stored membership; a further kind is added with (genl NewKind indeterminate_term). See docs/skolem.md.")
+(genl indeterminate_term thing)
+
+;; --- Specified class: integrity audit, no inference -----------------------
+;; The antagonist of the *Exists* class.  Where *Exists* mints a placeholder to stand for
+;; an unnamed filler, *Specified* asks whether every quantified instance has a DETERMINATE
+;; filler already — a believed (?pred x y) whose y is not an indeterminate term.  It is an
+;; audit that reports the instances with no determinate filler, run by the reader in
+;; vaelii.impl.predall (not a stored rule).  Indeterminate terms are skolems plus any declared indeterminate_term kind (none ships by default); skolem
+;; terms; a non-skolem NAT (a *Exists* placeholder among them) is treated as determinate,
+;; so the two classes are exact antagonists.  The declaration is a plain stored fact the
+;; audit reads; it stamps no rule and concludes nothing on its own.
+
+(comment predAllSpecified
+         "(predAllSpecified ?pred ?indep ?dep) declares the integrity requirement that every instance of collection ?indep have a determinate ?dep filler at ?pred's second position: for all x in ?indep there is a believed (?pred x y) with y in ?dep and y determinate. An audit, not an inference — vaelii.impl.predall/specified-violations reads the declaration and returns the instances of ?indep with no determinate filler. Indeterminate terms are skolems plus any declared indeterminate_term kind (none ships by default); an author-asserted *Exists* placeholder is a determinate filler, so predAllSpecified is the antagonist of predAllExists. The declaration stamps no rule and concludes nothing.")
+(ternary_predicate predAllSpecified)
+(arg predAllSpecified 1 binary_predicate)
+(genlArg predAllSpecified 2 thing)
+(genlArg predAllSpecified 3 thing)
+
+(comment predSpecifiedAll
+         "(predSpecifiedAll ?pred ?dep ?indep) is the argument-swapped twin of predAllSpecified: it requires that every instance of collection ?indep have a determinate ?dep filler at ?pred's FIRST position — for all x in ?indep there is a believed (?pred y x) with y in ?dep and y determinate. An audit read by vaelii.impl.predall/specified-violations, not a stored rule (docs above).")
+(ternary_predicate predSpecifiedAll)
+(arg predSpecifiedAll 1 binary_predicate)
+(genlArg predSpecifiedAll 2 thing)
+(genlArg predSpecifiedAll 3 thing)
+
 (comment evaluate
          "(evaluate ?result ?expression) means that ?result is the value of the symbolic ?expression. So (evaluate ?sum (+ 1 2)) binds ?sum to 3. A safe whitelist over +, -, *, /, mod, min, max, abs and expt rather than clojure eval, computed on demand and never stored.")
 (binary_predicate evaluate)

--- a/src/vaelii/impl/predall.clj
+++ b/src/vaelii/impl/predall.clj
@@ -1,0 +1,111 @@
+;; SPDX-License-Identifier: SSPL-1.0
+;; Copyright © 2026 Vaelii LLC and the Vaelii contributors.
+(ns vaelii.impl.predall
+  "The *Specified* half of the predAll / predExists / predInstance / predSpecified matrix
+  (docs/generators.md, resources/kb/CxCore.txt).
+
+  Where the *Instance* relations stamp real inference and the *Exists* relations are
+  inert records beside a sanctioned placeholder functor, `predAllSpecified` / `predSpecifiedAll` are an **integrity
+  audit**: given a declaration that every instance of a collection ought to have a
+  *determinate* filler, the reader here returns the instances that do not.  It is not a
+  stored rule and concludes nothing — it reads the declaration and the beliefs and hands
+  back the violations, the way a solve-time report does.
+
+  **Indeterminate = the `indeterminate_term` category.**  A filler counts as determinate
+  unless it is a member of the extensible `indeterminate_term` collection (CxCore.txt).
+  Skolem constants are its built-in first member — a reified NAT whose expression is a
+  `SkolemFn` application (docs/skolem.md), detected structurally because a skolem's
+  membership is never a stored fact — and a further kind is added with
+  `(genl NewKind indeterminate_term)`.  Whether a non-skolem NAT is determinate by default
+  is punted (Pace): a plain individual, a literal and an *Exists* placeholder alike are
+  all treated as determinate here, which is what makes `predAllSpecified` the exact
+  antagonist of `predAllExists`."
+  (:require [vaelii.core :as v]
+            [vaelii.impl.skolem :as skolem]))
+
+(defn- skolem-term?
+  "Is `term` a skolem constant — a reified NAT whose `termOfUnit` expression heads with
+  `SkolemFn` (docs/skolem.md)?  Skolems are the built-in first member of `indeterminate_term`:
+  their membership is never a stored fact (they are minted dynamically), so it is read off
+  the minting expression rather than through a collection query."
+  [kb term]
+  (boolean
+   (and (v/reified-term? term)
+        (let [e (v/term-expression kb term)]
+          (and (sequential? e) (= skolem/skolem-function (first e)))))))
+
+(defn indeterminate-term?
+  "Is `term` an **indeterminate** filler — a member of the extensible `indeterminate_term`
+  category (CxCore.txt)?  A term is indeterminate when it is either a
+  skolem constant (the built-in first member, detected structurally by `skolem-term?`) or a
+  believed member of `indeterminate_term` in `ctx` — so a future kind added with
+  `(genl NewKind indeterminate_term)` is picked up through ordinary collection membership,
+  by this reader and by the `different` prover's UNA identity exemption alike.
+
+  A non-skolem NAT that is not declared an `indeterminate_term`, a bare individual and a
+  literal are all determinate; the blanket non-skolem-NAT determinacy question is punted
+  (Pace).  The `ctx`-free arity checks only the skolem membership."
+  ([kb term] (indeterminate-term? kb term nil))
+  ([kb term ctx]
+   (or (skolem-term? kb term)
+       (boolean (and ctx (v/ask? kb (list 'indeterminate_term term) ctx))))))
+
+(defn- determinate-filler?
+  "Does the collection `dep` (or, when `dep` is nil, no collection at all) admit at least
+  one determinate filler `y` believed at position `arg-pos` of `(pred … x …)` in `ctx`?
+  `arg-pos` is `:second` for a `predAllSpecified` (x at position 1, filler at 2) or
+  `:first` for a `predSpecifiedAll` (x at position 2, filler at 1)."
+  [kb pred x dep arg-pos ctx]
+  (let [goal    (case arg-pos
+                  :second (list pred x '?y)
+                  :first  (list pred '?y x))
+        answers (v/ask kb goal ctx)]
+    (boolean
+     (some (fn [b]
+             (let [y (get b '?y)]
+               (and (not (indeterminate-term? kb y ctx))
+                    (or (nil? dep) (v/ask? kb (list dep y) ctx)))))
+           answers))))
+
+(defn specified-violations
+  "The instances of `indep` that violate the `(predAllSpecified pred indep dep)` integrity
+  requirement in `ctx`: every member x of `indep` for which no believed `(pred x y)` has a
+  *determinate* filler y in `dep`.  Returns a set of such x (empty when the requirement
+  holds).
+
+  `arg-pos` selects the twin: `:second` for `predAllSpecified` (the audited filler sits at
+  `pred`'s second position), `:first` for `predSpecifiedAll` (the filler sits first and
+  the quantified instance second).  Defaults to `:second`.
+
+  A filler is indeterminate exactly when it is an `indeterminate_term` — a skolem (the
+  built-in first member) or an extension declared with `(genl NewKind indeterminate_term)`
+  — so an *Exists* placeholder passes and a skolemised witness does not, which is what
+  makes this the antagonist of the *Exists* class."
+  ([kb pred indep dep ctx] (specified-violations kb pred indep dep ctx :second))
+  ([kb pred indep dep ctx arg-pos]
+   (into #{}
+         (comp (map #(get % '?x))
+               (remove #(determinate-filler? kb pred % dep arg-pos ctx)))
+         (v/ask kb (list indep '?x) ctx))))
+
+(defn- declaration-args
+  "Read the stored `(functor pred a b)` declarations in `ctx` as `[pred a b]` tuples."
+  [kb functor ctx]
+  (for [b (v/ask kb (list functor '?pred '?a '?b) ctx)]
+    [(get b '?pred) (get b '?a) (get b '?b)]))
+
+(defn all-specified-violations
+  "Audit every `predAllSpecified` and `predSpecifiedAll` declaration visible in `ctx` and
+  return a map `{[functor pred indep dep] #{violating-instances…}}`, omitting the
+  declarations that hold.  The one call an integrity sweep makes; `specified-violations`
+  is the per-declaration reader it is built from."
+  [kb ctx]
+  (into {}
+        (for [[functor arg-pos indep-at] [['predAllSpecified :second :a]
+                                          ['predSpecifiedAll :first :b]]
+              [pred a b] (declaration-args kb functor ctx)
+              :let [indep (if (= indep-at :a) a b)
+                    dep   (if (= indep-at :a) b a)
+                    vs    (specified-violations kb pred indep dep ctx arg-pos)]
+              :when (seq vs)]
+          [[functor pred indep dep] vs])))

--- a/src/vaelii/impl/predicates.clj
+++ b/src/vaelii/impl/predicates.clj
@@ -892,7 +892,108 @@
                           " design, so no regression reads its target.")}
              (str "the same pointing shape, truth-agnostic: it names a sentex neither"
                   " asserted true nor false, so it carries no provability obligation and no"
-                  " regression reads its target. Documentation only."))]])))
+                  " regression reads its target. Documentation only."))]
+
+     ;; ---- the predAll / predExists / predSpecified matrix ------------------
+     ;;
+     ;; Quantifier-family declarations (docs/generators.md).  The
+     ;; *Instance* and *Exists* relations are each declared beside a CxCore **rule
+     ;; generator** — a rule whose consequent is a rule — so their enforcement is generic
+     ;; forward chaining, keyed on nothing; like `equivalence_relation`, no arm reads the
+     ;; functor.  The *Specified* pair is an on-demand integrity audit in
+     ;; `vaelii.impl.predall`, which also owns the `indeterminate_term` membership read.
+     ['predAllInstance
+      (enforced {:shape {:args [:predicate :type :term]} :storage [:none] :checked false
+                 :family nil :facets #{}
+                 :notes (str "enforced by the generic chain, not by name: the CxCore"
+                             " generator beside the declaration stamps the concrete rule"
+                             " when the holes ground.")}
+                (str "generic rule generator (docs/generators.md): the CxCore generator"
+                     " beside it stamps (implies (?indep ?x) (?pred ?x ?fixed)) — chain"
+                     " inference concludes the fixed filler for every member"))]
+     ['predInstanceAll
+      (enforced {:shape {:args [:predicate :term :type]} :storage [:none] :checked false
+                 :family nil :facets #{}
+                 :notes "the argument-swapped twin of predAllInstance, same generic chain."}
+                (str "generic rule generator: the CxCore generator stamps (implies (?dep ?y)"
+                     " (?pred ?fixed ?y)), the argument-swapped twin"))]
+     ['predAllExists
+      (inert {:shape {:args [:predicate :type :type]} :storage [:none] :checked false
+              :family nil :facets #{}
+              :notes (str "the whole Exists class is inferentially inert by ruling —"
+                          " a stored record plus a sanctioned per-cell placeholder"
+                          " functor for authors, nothing derived.")}
+             (str "an inert record: every ?indep member bears ?pred to some ?dep member,"
+                  " stated and stored, inferred from by nothing. (PredAllExistsFn ?pred"
+                  " ?indep ?dep) is the sanctioned placeholder an author may use for the"
+                  " unnamed filler."))]
+     ['predExistsAll
+      (inert {:shape {:args [:predicate :type :type]} :storage [:none] :checked false
+              :family nil :facets #{}
+              :notes "the argument-swapped twin of predAllExists, inert like the class."}
+             (str "an inert record, the argument-swapped twin: some ?dep member bears"
+                  " ?pred to every ?indep member. (PredExistsAllFn ?pred ?dep ?indep) is"
+                  " its sanctioned placeholder."))]
+     ['predExistsInstance
+      (inert {:shape {:args [:predicate :type :term]} :storage [:none] :checked false
+              :family nil :facets #{}
+              :notes (str "a pure existential — no universal to range over — expressible"
+                          " precisely because the class stamps nothing.")}
+             (str "an inert record: some ?indep member bears ?pred to the fixed filler."
+                  " (PredExistsInstanceFn ?pred ?indep ?fixed) is its sanctioned"
+                  " placeholder."))]
+     ['predInstanceExists
+      (inert {:shape {:args [:predicate :term :type]} :storage [:none] :checked false
+              :family nil :facets #{}
+              :notes "the argument-swapped twin of predExistsInstance."}
+             (str "an inert record: the fixed subject bears ?pred to some ?dep member."
+                  " (PredInstanceExistsFn ?pred ?fixed ?dep) is its sanctioned"
+                  " placeholder."))]
+     ['predAllSpecified
+      (enforced {:shape {:args [:predicate :type :type]} :storage [:none] :checked false
+                 :family nil :facets #{}
+                 :notes (str "an on-demand audit, not a stored constraint: nothing fires on"
+                             " assert, and the read is a function a caller invokes.")}
+                (str "vaelii.impl.predall/specified-violations — the on-demand integrity"
+                     " audit reads the declaration and returns the instances of ?indep with"
+                     " no determinate filler; stamps no rule"))]
+     ['predSpecifiedAll
+      (enforced {:shape {:args [:predicate :type :type]} :storage [:none] :checked false
+                 :family nil :facets #{}
+                 :notes "the argument-swapped twin, auditing ?pred's first position."}
+                (str "vaelii.impl.predall/specified-violations with :first — audits ?pred's"
+                     " first position, the argument-swapped twin"))]
+     ['PredAllExistsFn
+      (enforced (collection :notes (str "a function constant, never a sentence functor; its"
+                                        " unreifiable_function mark keeps a ground"
+                                        " application a structural NAT. The engine never"
+                                        " asserts it — uses are the author's."))
+                (str "the predAllExists placeholder function; unreifiable_function keeps its"
+                     " application a structural NAT — per-cell and full-arg, an ontological"
+                     " marker rather than a skolem witness, and determinate for the"
+                     " predAllSpecified audit when an author uses it"))]
+     ['PredExistsAllFn
+      (enforced (collection :notes "the predExistsAll twin of PredAllExistsFn.")
+                (str "the predExistsAll placeholder function; unreifiable_function,"
+                     " per-cell and full-arg, distinct from the other Exists cells'"
+                     " placeholders"))]
+     ['PredExistsInstanceFn
+      (enforced (collection :notes "the predExistsInstance twin of PredAllExistsFn.")
+                (str "the predExistsInstance placeholder function; unreifiable_function,"
+                     " per-cell and full-arg, distinct from the other Exists cells'"
+                     " placeholders"))]
+     ['PredInstanceExistsFn
+      (enforced (collection :notes "the predInstanceExists twin of PredAllExistsFn.")
+                (str "the predInstanceExists placeholder function; unreifiable_function,"
+                     " per-cell and full-arg, distinct from the other Exists cells'"
+                     " placeholders"))]
+     ['indeterminate_term
+      (enforced (collection :notes (str "an extensible determinacy category: skolem is the"
+                                        " built-in first member, a future kind joins by"
+                                        " genl."))
+                (str "vaelii.impl.predall/indeterminate-term? and the different prover's"
+                     " identity exemption — a filler that is a member is not determinate"
+                     " and is exempt from the unique-name assumption"))]])))
 
 (defn- check-families
   "Refuse at load a declaration whose family or whose sweep is half-written, which is the

--- a/src/vaelii/impl/provers.clj
+++ b/src/vaelii/impl/provers.clj
@@ -989,6 +989,56 @@
 
 ;; ---- different: the unique-name assumption over the equality closure ----
 
+(declare believed-sentexes-with)                 ; defined below, beside ArgTypeProver
+
+;; The identity exemption for `indeterminate_term` members: the UNA is
+;; suspended for an indeterminate term — a term that stands for some object without pinning
+;; down which — so `(different indeterminate X)` is NOT provable against a determinate `X`
+;; until a `rewriteOf`/merge pins it (at which point `rep` lifts the exemption).  Gated on
+;; the extensible category, with the skolem constant its built-in first member: a skolem's
+;; membership is never a stored fact, so it is read off its `SkolemFn` `termOfUnit`
+;; expression, while a further kind added with `(genl NewKind indeterminate_term)` is picked
+;; up through ordinary membership.  `vaelii.impl.predall/indeterminate-term?` is the audit's
+;; twin of this; the two cannot share code (predall sits above the prover registry), so both
+;; read the one category.
+(defn- reified-nat-symbol? [term]
+  ;; a reified constant — a symbol in a reserved reified namespace; the cheap gate before
+  ;; the skolem `termOfUnit` read.  Master: `nat/reified-namespaces` (#{"nat" "cx"}) —
+  ;; copied because the provers layer cannot require nat without a cycle through kb; if
+  ;; the reserved set ever grows, this copy must move with it.
+  (and (symbol? term) (contains? #{"nat" "cx"} (namespace term))))
+
+(defn- skolem-indeterminate? [kb term context]
+  (and (reified-nat-symbol? term)
+       (boolean
+        ;; 'SkolemFn is skolem/skolem-function's value, copied for the same cycle reason
+        (some (fn [[_ b]] (let [e (get b '?e)]
+                            (and (sequential? e) (= 'SkolemFn (first e)))))
+              (res/matches-visible kb (list 'termOfUnit term '?e) context)))))
+
+(defn- category-indeterminate? [kb term context]
+  ;; a believed member of `indeterminate_term` or of a collection that genl-reaches it.
+  ;; The direct membership is one indexed point-read and is consulted unconditionally —
+  ;; gating it on declared subkinds made a direct member's exemption depend on an
+  ;; unrelated (genl _ indeterminate_term) declaration.  The membership SCAN stays
+  ;; gated: only walk the term's memberships when the category actually has extensions,
+  ;; so a KB that never uses subkinds pays one point-read plus one taxonomy read per
+  ;; `different` and no index scan.
+  (let [tax (:taxonomy kb)]
+    (or (boolean (seq (res/matches-visible kb (list 'indeterminate_term term) context)))
+        (and (> (count (tax/specs tax 'indeterminate_term context)) 1)
+             (boolean
+              (some (fn [s]
+                      (let [sen (:sentence s)]
+                        (and (sequential? sen) (= 2 (count sen)) (= term (nth sen 1))
+                             (symbol? (nth sen 0))
+                             (contains? (tax/genls tax (nth sen 0) context) 'indeterminate_term))))
+                    (believed-sentexes-with kb term context)))))))
+
+(defn- indeterminate-term-arg? [kb term context]
+  (or (skolem-indeterminate? kb term context)
+      (category-indeterminate? kb term context)))
+
 (defn- pairwise-distinct?
   "Do no two of `args` share an equivalence class?  A term is trivially in its own
   class, so `(different A A)` fails on the `=` arm without consulting the closure at
@@ -1001,14 +1051,21 @@
   Compound arguments normalize **recursively** (`res/representative-term`), which is what
   makes the answer congruence-consistent: the closure is keyed by symbol, so a flat
   lookup on `(QuantityFn 5 Kilogram)` returns it unchanged and would report it different
-  from `(QuantityFn 5 Kg)` with `(sameAs Kilogram Kg)` believed."
+  from `(QuantityFn 5 Kg)` with `(sameAs Kilogram Kg)` believed.
+
+  The UNA is **suspended** when any argument is an unpinned `indeterminate_term`: an
+  indeterminate term is not provably different from anything until a merge pins it, so the
+  whole difference goal is left unprovable (`rep` self-equal witnesses the unpinned state —
+  a `rewriteOf`/`equals` merge moves `rep` off the term and restores the UNA)."
   [kb context args]
-  (let [vis (res/visible-supporter-fn kb context)
-        rep #(res/representative-term kb vis %)
-        v   (vec args)]
-    (every? (fn [[a b]] (not (or (= a b) (= (rep a) (rep b)))))
-            (for [i (range (count v)), j (range (inc i) (count v))]
-              [(nth v i) (nth v j)]))))
+  (let [vis     (res/visible-supporter-fn kb context)
+        rep     #(res/representative-term kb vis %)
+        v       (vec args)
+        exempt? (fn [t] (and (= (rep t) t) (indeterminate-term-arg? kb t context)))]
+    (and (not-any? exempt? v)
+         (every? (fn [[a b]] (not (or (= a b) (= (rep a) (rep b)))))
+                 (for [i (range (count v)), j (range (inc i) (count v))]
+                   [(nth v i) (nth v j)])))))
 
 (defrecord DifferentProver []
   Prover

--- a/test/vaelii/common_sense_test.clj
+++ b/test/vaelii/common_sense_test.clj
@@ -519,6 +519,44 @@
     (is (v/ask? kb '(instantBefore ThreeOClock SixOClock) N)
         "the walk did, and that is the ordering the clipped facts joined over")))
 
+;; ---- known gap: functionality does not reach the event-calculus lane ------
+;; `functional` is enforced by the equality closure over stored bare literals of the
+;; marked predicate.  A fact carried the Davidsonian way — a fluent under initiates /
+;; holdsAt — stores no bare literal of that predicate: the value lives inside a fluent
+;; NAT, the mark has nothing to attach to, and per-instant functionality ("at most one
+;; value at ?t") is enforced by nothing.  The control/gap pair below records both
+;; halves as executable fact; the gap test is the future per-instant repair's red test.
+
+(tu/deftest-kb control-two-bare-values-of-a-functional-predicate-merge
+  (tu/with-terms [primaryHostOf Svc BoxA BoxB]
+    (v/assert kb (list 'binary_predicate primaryHostOf) N)
+    (v/assert kb (list 'functional primaryHostOf) N)
+    (v/assert kb (list primaryHostOf Svc BoxA) N)
+    (v/assert kb (list primaryHostOf Svc BoxB) N)
+    (is (v/same-class? kb BoxA BoxB)
+        "two co-believed bare fillers of a functional predicate are one thing under two names")))
+
+(tu/deftest-kb known-gap-fluent-carried-values-of-a-functional-predicate-escape-the-closure
+  ;; the same two values, Davidsonian: each observation initiates a fluent carrying its
+  ;; value, neither clips the other, so BOTH hold at the later moment — and the fillers
+  ;; stay distinct, because no bare literal of the marked predicate was ever stored for
+  ;; the closure to see.  When a per-instant functionality check exists, the final
+  ;; assertion goes red: that is this test's purpose.
+  (tu/with-terms [primaryHostOf HostStateFn Svc BoxA BoxB SwapA SwapB]
+    (v/assert kb (list 'binary_predicate primaryHostOf) N)
+    (v/assert kb (list 'functional primaryHostOf) N)
+    (v/assert kb (list 'reifiable_function HostStateFn) N)
+    (v/assert kb (list 'result HostStateFn 'fluent) N)
+    (v/assert kb (list 'happens SwapA 'ThreeOClock) N)
+    (v/assert kb (list 'initiates SwapA (list HostStateFn Svc BoxA) 'ThreeOClock) N)
+    (v/assert kb (list 'happens SwapB 'FourOClock) N)
+    (v/assert kb (list 'initiates SwapB (list HostStateFn Svc BoxB) 'FourOClock) N)
+    (testing "both values hold at five — truthfully observed, never mutually clipped"
+      (is (holds-at? kb (list HostStateFn Svc BoxA) 'FiveOClock))
+      (is (holds-at? kb (list HostStateFn Svc BoxB) 'FiveOClock)))
+    (is (not (v/same-class? kb BoxA BoxB))
+        "and the fillers stay distinct — per-instant functionality is unenforced (known gap)")))
+
 (tu/deftest-kb a-fluent-nobody-terminated-still-holds
   ;; The cat was indoors before the afternoon began and nothing ever put it out, so it
   ;; is indoors at every moment of the afternoon — the whole of what inertia says, with

--- a/test/vaelii/core_context_test.clj
+++ b/test/vaelii/core_context_test.clj
@@ -56,7 +56,7 @@
                  (v/assert kb (list 'arity rel 7) 'CxCore)))))
 
 (tu/deftest-kb the-core-vocabulary-is-the-size-docs-kbs-says
-  ;; A bound, not a pin.  docs/kbs.md's row says "~475", and the exact number moves
+  ;; A bound, not a pin.  docs/kbs.md's row says "~535", and the exact number moves
   ;; whenever CxCore gains a term on purpose — which made an equality here pure churn:
   ;; it failed on every deliberate change and caught nothing else, because
   ;; `vocabulary-audit` already fails a functor nobody classified.  What a count *can*
@@ -64,6 +64,6 @@
   ;; that is what this asserts.
   (let [n (v/sentex-count kb)]
     (is (< 300 n 700)
-        (str "CxCore loaded " n " sentexes; docs/kbs.md's Core vocabulary row says ~475."
+        (str "CxCore loaded " n " sentexes; docs/kbs.md's Core vocabulary row says ~535."
              "  A number outside this band means the load is wrong, not that the"
              "  vocabulary grew — check the classpath before touching the row."))))

--- a/test/vaelii/predall_test.clj
+++ b/test/vaelii/predall_test.clj
@@ -1,0 +1,422 @@
+;; SPDX-License-Identifier: SSPL-1.0
+;; Copyright © 2026 Vaelii LLC and the Vaelii contributors.
+(ns vaelii.predall-test
+  "The predAll / predExists / predInstance / predSpecified matrix (docs/generators.md,
+  resources/kb/CxCore.txt).
+
+  The *Instance* relations (predAllInstance / predInstanceAll) are rule generators that do
+  REAL inference: every member of the quantified collection is concluded to bear the
+  predicate to the fixed filler, and the conclusion retracts and belief-follows like any
+  derived fact.
+
+  The *Exists* relations (predAllExists / predExistsAll / predExistsInstance /
+  predInstanceExists) are inferentially INERT: each declaration is a stored, queryable
+  record beside a sanctioned per-cell full-arg placeholder functor an author may use for
+  the unnamed filler.  The engine derives nothing — no skolem witness, no defn, no rule
+  (Pace, \"skolems suck\").
+
+  The *Specified* relations (predAllSpecified / predSpecifiedAll) are an integrity AUDIT
+  that reports the instances with no *determinate* filler.  Indeterminate = a member of the
+  extensible `indeterminate_term` category (skolem is its built-in first member), so an
+  author-asserted *Exists* placeholder passes and a skolemised witness does not — the
+  exact antagonist of the *Exists* class.  The same category drives the UNA identity
+  exemption: the unique-name assumption is suspended for an unpinned indeterminate term.
+
+  The tracer is predAllInstance on Pace's `sign` / `-212` example.  The generator's
+  stamped rule (defeasible, direction `:both` — `set/defaultRule`'s default) fires on a
+  believed membership, and its backward arm closes the keystone: bare-literal membership
+  derives (the evaluative defnSufficient provers, #59) and is discharged inside a
+  query/prove proof (`pred-all-instance-keystone-proves-from-the-bare-literal`).  `ask`
+  answers the same goal false by contract — the registry expands no rule."
+  (:require [clojure.test :refer [is use-fixtures]]
+            [vaelii.core :as v]
+            [vaelii.impl.core-context :as core-context]
+            [vaelii.impl.predall :as predall]
+            [vaelii.test-util :as tu]))
+
+(use-fixtures :each (tu/neutral-fresh #(doto (tu/fresh) (core-context/load-into))))
+
+(defn- believes?
+  "Is `sentence` a believed, stored sentex in `ctx`?  Read through `sentexes-matching`,
+  which is belief-sensitive, rather than through `ask`."
+  [kb sentence ctx]
+  (boolean (seq (v/sentexes-matching kb sentence ctx))))
+
+;; ==== the -212 subtlety, isolated ==========================================
+;; Pace named -212 the keystone: (sign -212 "negative") should be provable from the BARE
+;; literal, with membership DERIVED, not hand-asserted.  Both halves hold: membership
+;; derives via the evaluative defnSufficient prover (#59), and the stamped defaultRule's
+;; backward arm discharges that antecedent inside a query/prove proof — see
+;; pred-all-instance-keystone-proves-from-the-bare-literal.  The one instrument caveat:
+;; `ask` expands no rule by contract, so the ask-mode answer is false by design, not gap.
+
+(tu/deftest-kb minus-212-membership-is-derived
+  ;; #59 closed the membership half of the keystone: bare-literal membership now derives,
+  ;; no hand-assert needed.
+  (is (v/ask? kb '(negative_integer -212) 'CxUniverse)
+      "negative_integer membership of a bare literal derives via defnSufficient (#59)")
+  (is (v/ask? kb '(integer -212) 'CxUniverse)
+      "and integer membership too — now query-time evaluatable"))
+
+;; ==== Instance class: real inference =======================================
+
+(tu/deftest-kb pred-all-instance-mechanism-fires-on-a-believed-membership
+  ;; the generator's stamped defaultRule (bidirectional), on Pace's sign/-212 predicates:
+  ;; once (negative_integer -212) is believed — here asserted directly, exercising the
+  ;; forward arm on its own; the keystone test below covers the backward, query-time
+  ;; path — the rule concludes (sign -212 "negative") and binds the fixed position.
+  (v/assert kb '(binary_predicate sign) 'CxUniverse)
+  (v/assert kb '(predAllInstance sign negative_integer "negative") 'CxUniverse)
+  (v/assert kb '(negative_integer -212) 'CxUniverse)
+  (is (v/ask? kb '(sign -212 "negative") 'CxUniverse)
+      "every negative_integer is signed \"negative\", so -212 is")
+  (is (= #{"negative"} (into #{} (map '?x) (v/ask kb '(sign -212 ?x) 'CxUniverse)))
+      "and querying the fixed position binds it to the filler"))
+
+(tu/deftest-kb pred-all-instance-keystone-proves-from-the-bare-literal
+  ;; THE KEYSTONE, closed: with no hand-asserted membership, the stamped rule's backward
+  ;; arm discharges (negative_integer -212) through the evaluative defnSufficient prover
+  ;; at query time, so the acceptance criterion holds from the bare literal.  Under `ask`
+  ;; the same goal answers false BY CONTRACT — level 6 is the registry and expands no
+  ;; rule (docs/levels.md) — so the pair below pins both the capability and the
+  ;; instrument distinction that once hid it.
+  (v/assert kb '(binary_predicate sign) 'CxUniverse)
+  (v/assert kb '(predAllInstance sign negative_integer "negative") 'CxUniverse)
+  (is (v/query? kb '(sign -212 "negative") 'CxUniverse {:max-depth 5})
+      "provable from the bare literal — membership derives inside the proof")
+  (is (= [{'?x "negative"}] (vec (v/query kb '(sign -212 ?x) 'CxUniverse {:max-depth 5})))
+      "and querying the fixed position binds it")
+  (is (not (v/query? kb '(sign -212 "positive") 'CxUniverse {:max-depth 5}))
+      "negative control: the wrong filler is not provable")
+  (is (not (v/ask? kb '(sign -212 "negative") 'CxUniverse))
+      "ask answers false by contract — the registry expands no rule; use query/prove"))
+
+(tu/deftest-kb pred-all-instance-on-a-kind-without-a-defn
+  ;; Pace: also cover a kind whose membership is asserted directly, not derived through a
+  ;; defnNecessary/defnSufficient expansion.  A gensym'd type has no defn at all.
+  (tu/with-terms [color widget Blueish W1]
+    (v/assert kb (list 'binary_predicate color) 'CxUniverse)
+    (v/assert kb (list 'unary_predicate widget) 'CxUniverse)
+    (v/assert kb (list 'predAllInstance color widget Blueish) 'CxUniverse)
+    (is (not (believes? kb (list color W1 Blueish) 'CxUniverse))
+        "with no member yet, nothing is concluded")
+    (v/assert kb (list widget W1) 'CxUniverse)
+    (is (believes? kb (list color W1 Blueish) 'CxUniverse)
+        "a directly-asserted member fires the stamped rule")))
+
+(tu/deftest-kb pred-all-instance-retracts-and-belief-follows
+  (tu/with-terms [color widget Blueish W1]
+    (v/assert kb (list 'binary_predicate color) 'CxUniverse)
+    (v/assert kb (list 'unary_predicate widget) 'CxUniverse)
+    (let [dh (v/assert kb (list 'predAllInstance color widget Blueish) 'CxUniverse)]
+      (v/assert kb (list widget W1) 'CxUniverse)
+      (is (believes? kb (list color W1 Blueish) 'CxUniverse))
+      (v/retract! kb dh)
+      (is (not (believes? kb (list color W1 Blueish) 'CxUniverse))
+          "retracting the declaration withdraws the stamped rule and its conclusion"))))
+
+(tu/deftest-kb pred-instance-all-is-the-argument-swapped-twin
+  ;; the fixed filler bears ?pred to every member of the collection, at position 2
+  (tu/with-terms [enjoys Alice hobby Chess Sudoku]
+    (v/assert kb (list 'binary_predicate enjoys) 'CxUniverse)
+    (v/assert kb (list 'unary_predicate hobby) 'CxUniverse)
+    (v/assert kb (list 'predInstanceAll enjoys Alice hobby) 'CxUniverse)
+    (v/assert kb (list hobby Chess) 'CxUniverse)
+    (v/assert kb (list hobby Sudoku) 'CxUniverse)
+    (is (= #{Chess Sudoku} (into #{} (map '?y) (v/ask kb (list enjoys Alice '?y) 'CxUniverse)))
+        "Alice enjoys every hobby")))
+
+;; ==== Exists class: pure record, inferentially inert =======================
+;; Pace's ruling (2026-09-03): everything with "exist" in the name is inferentially
+;; inert — a stored, queryable record plus a sanctioned per-cell placeholder functor
+;; for authors, and the engine derives NOTHING.  This supersedes the earlier generator
+;; design that materialized (?pred ?x P) over the members; inertness is also what makes
+;; the two pure-existential cross-cells expressible (nothing to stamp, so no range
+;; restriction to fail and no variable-functor rule to pollute the planner with).
+
+(tu/deftest-kb an-exists-declaration-is-a-record-and-derives-nothing
+  (tu/with-terms [owns person dog Alice]
+    (v/assert kb (list 'binary_predicate owns) 'CxUniverse)
+    (v/assert kb (list 'unary_predicate person) 'CxUniverse)
+    (v/assert kb (list 'unary_predicate dog) 'CxUniverse)
+    (v/assert kb (list 'predAllExists owns person dog) 'CxUniverse)
+    (v/assert kb (list person Alice) 'CxUniverse)
+    (is (v/ask? kb (list 'predAllExists owns person dog) 'CxUniverse)
+        "the declaration is stored and queryable like any fact")
+    (is (empty? (into #{} (map '?y) (v/ask kb (list owns Alice '?y) 'CxUniverse)))
+        "and no filler is concluded for any member — inferentially inert")
+    (is (empty? (into #{} (map '?y) (v/ask kb (list dog '?y) 'CxUniverse)))
+        "no placeholder membership is materialized either")))
+
+(tu/deftest-kb all-four-exists-cells-are-inert-records
+  ;; the straight cells and the pure-existential cross-cells are uniform under inertness:
+  ;; four declarations stored, zero facts derived
+  (tu/with-terms [rel person dog Alice Rome]
+    (v/assert kb (list 'binary_predicate rel) 'CxUniverse)
+    (v/assert kb (list 'unary_predicate person) 'CxUniverse)
+    (v/assert kb (list 'unary_predicate dog) 'CxUniverse)
+    (v/assert kb (list 'predAllExists rel person dog) 'CxUniverse)
+    (v/assert kb (list 'predExistsAll rel dog person) 'CxUniverse)
+    (v/assert kb (list 'predExistsInstance rel person Rome) 'CxUniverse)
+    (v/assert kb (list 'predInstanceExists rel Rome dog) 'CxUniverse)
+    (v/assert kb (list person Alice) 'CxUniverse)
+    (is (v/ask? kb (list 'predExistsInstance rel person Rome) 'CxUniverse)
+        "a pure-existential cross-cell is storable and queryable")
+    (is (v/ask? kb (list 'predInstanceExists rel Rome dog) 'CxUniverse)
+        "and its argument-swapped twin")
+    (is (empty? (into [] (v/ask kb (list rel '?x '?y) 'CxUniverse)))
+        "none of the four declarations concludes a single fact of the subject predicate")))
+
+(tu/deftest-kb a-placeholder-is-sanctioned-vocabulary-the-author-asserts
+  ;; the per-cell full-arg functor is the author's term for the unnamed filler: usable in
+  ;; hand-asserted sentences, structural (unreifiable), and distinct per cell — the
+  ;; predAllExists and predExistsAll placeholders over the same (rel, dog) are two terms,
+  ;; not one shared filler (Pace, "eventually it will matter that they're distinct")
+  (tu/with-terms [rel person dog Alice]
+    (v/assert kb (list 'binary_predicate rel) 'CxUniverse)
+    (v/assert kb (list 'unary_predicate person) 'CxUniverse)
+    (v/assert kb (list 'unary_predicate dog) 'CxUniverse)
+    (v/assert kb (list 'predAllExists rel person dog) 'CxUniverse)
+    (v/assert kb (list 'predExistsAll rel dog person) 'CxUniverse)
+    (v/assert kb (list person Alice) 'CxUniverse)
+    (let [p1 (list 'PredAllExistsFn rel person dog)
+          p2 (list 'PredExistsAllFn rel dog person)]
+      (v/assert kb (list dog p1) 'CxUniverse)
+      (v/assert kb (list dog p2) 'CxUniverse)
+      (v/assert kb (list rel Alice p1) 'CxUniverse)
+      (is (v/ask? kb (list rel Alice p1) 'CxUniverse)
+          "an author-asserted sentence naming the placeholder is believed like any fact")
+      (let [fillers (into #{} (map '?y) (v/ask kb (list rel Alice '?y) 'CxUniverse))]
+        (is (= 1 (count fillers)) "and answers as a filler")
+        (is (not (v/reified-term? (first fillers)))
+            "staying a structural NAT — unreifiable, readable inside the sentence"))
+      (is (= 2 (count (into #{} (map '?y) (v/ask kb (list dog '?y) 'CxUniverse))))
+          "the two cells' placeholders are two distinct dog members, not one shared term"))))
+
+;; The aspirational existential-inference test (Pace, 2026-08-29 — KEEP, do NOT delete).
+;; Under pure-record inert semantics nothing at all is derivable from the declaration,
+;; so no existential filler for `(parts Lain ?x)` is provable.  That is the expected
+;; outcome and it is pinned here as a standing marker for future existential-inference
+;; work rather than as a passing feature.
+;;
+;; Cyc taught us that skolems suck, so we're not prioritizing this line of inference
+(tu/deftest-kb exists-inference-from-a-predAllExists-is-not-yet-supported
+  (tu/with-terms [parts construct llm Lain]
+    (v/assert kb (list 'binary_predicate parts) 'CxUniverse)
+    (v/assert kb (list 'unary_predicate construct) 'CxUniverse)
+    (v/assert kb (list 'unary_predicate llm) 'CxUniverse)
+    (v/assert kb (list 'predAllExists parts construct llm) 'CxUniverse)
+    (is (not (v/ask? kb (list 'thereExists '?x
+                              (list 'and (list llm '?x) (list parts Lain '?x)))
+                     'CxUniverse))
+        "no existential llm part of Lain is derivable from the inert record — pending")))
+
+;; ==== Specified class: an integrity audit ==================================
+
+(tu/deftest-kb pred-all-specified-reports-instances-with-no-determinate-filler
+  (tu/with-terms [hasPet person pet Alice Bob Carol Rex]
+    (v/assert kb (list 'binary_predicate hasPet) 'CxUniverse)
+    (v/assert kb (list 'unary_predicate person) 'CxUniverse)
+    (v/assert kb (list 'unary_predicate pet) 'CxUniverse)
+    (v/assert kb (list 'predAllSpecified hasPet person pet) 'CxUniverse)
+    (v/assert kb (list person Alice) 'CxUniverse)   ; a determinate filler
+    (v/assert kb (list person Bob) 'CxUniverse)     ; no filler at all
+    (v/assert kb (list person Carol) 'CxUniverse)   ; a filler, but not in the collection
+    (v/assert kb (list hasPet Alice Rex) 'CxUniverse)
+    (v/assert kb (list pet Rex) 'CxUniverse)
+    (tu/with-terms [NotAPet]
+      (v/assert kb (list hasPet Carol NotAPet) 'CxUniverse))
+    (let [vs (predall/specified-violations kb hasPet person pet 'CxUniverse)]
+      (is (not (contains? vs Alice)) "Alice has a determinate pet")
+      (is (contains? vs Bob) "Bob has no filler at all")
+      (is (contains? vs Carol) "Carol's filler is not a member of the required collection"))))
+
+(tu/deftest-kb pred-all-specified-treats-a-skolem-filler-as-indeterminate
+  ;; the crux: a filler minted by head-existential skolemization is INDETERMINATE, so the
+  ;; instance it fills still violates the requirement — Specified is the antagonist of the
+  ;; existential
+  (tu/with-terms [hasPet person pet Alice]
+    (v/assert kb (list 'binary_predicate hasPet) 'CxUniverse)
+    (v/assert kb (list 'unary_predicate person) 'CxUniverse)
+    (v/assert kb (list 'unary_predicate pet) 'CxUniverse)
+    ;; skolemize a pet witness for every person, so Alice HAS a filler — an indeterminate
+    ;; one
+    (v/assert kb (list 'implies (list person '?x)
+                       (list 'exists '?y (list 'and (list hasPet '?x '?y) (list pet '?y))))
+              'CxUniverse)
+    (v/assert kb (list 'predAllSpecified hasPet person pet) 'CxUniverse)
+    (v/assert kb (list person Alice) 'CxUniverse)
+    (let [filler (get (first (v/ask kb (list hasPet Alice '?y) 'CxUniverse)) '?y)]
+      (is (some? filler) "Alice does have a skolem filler")
+      (is (predall/indeterminate-term? kb filler) "which is an indeterminate (skolem) term"))
+    (is (contains? (predall/specified-violations kb hasPet person pet 'CxUniverse) Alice)
+        "so Alice still violates predAllSpecified — a skolem filler is not determinate")))
+
+(tu/deftest-kb pred-all-specified-honours-an-extensible-indeterminate-kind
+  ;; the category is extensible, not hard-wired to skolems: a filler that is a member of a
+  ;; NEW kind declared (genl NewKind indeterminate_term) is indeterminate too, so it does
+  ;; not satisfy the requirement — the audit reads the category, not the SkolemFn shape.
+  (tu/with-terms [hasPet person pet Alice Fuzzy vague_kind]
+    (v/assert kb (list 'binary_predicate hasPet) 'CxUniverse)
+    (v/assert kb (list 'unary_predicate person) 'CxUniverse)
+    (v/assert kb (list 'unary_predicate pet) 'CxUniverse)
+    (v/assert kb (list 'genl vague_kind 'indeterminate_term) 'CxUniverse)  ; a future indeterminate kind
+    (v/assert kb (list 'predAllSpecified hasPet person pet) 'CxUniverse)
+    (v/assert kb (list person Alice) 'CxUniverse)
+    (v/assert kb (list hasPet Alice Fuzzy) 'CxUniverse)
+    (v/assert kb (list pet Fuzzy) 'CxUniverse)     ; Fuzzy is in the required collection
+    (v/assert kb (list vague_kind Fuzzy) 'CxUniverse)   ; but it is an indeterminate_term member
+    (is (predall/indeterminate-term? kb Fuzzy 'CxUniverse)
+        "a member of a (genl _ indeterminate_term) kind is indeterminate")
+    (is (contains? (predall/specified-violations kb hasPet person pet 'CxUniverse) Alice)
+        "so Alice's only filler is indeterminate and she violates the requirement")))
+
+(tu/deftest-kb an-exists-placeholder-satisfies-the-specified-requirement
+  ;; the antagonism from the other side: the *Exists* placeholder is DETERMINATE — an
+  ;; author who asserts it as a filler passes the predAllSpecified audit, where a skolem
+  ;; witness (an indeterminate_term) would not.  Under pure-record semantics the
+  ;; assertion is the author's, so the test makes it by hand.
+  (tu/with-terms [owns person dog Alice]
+    (v/assert kb (list 'binary_predicate owns) 'CxUniverse)
+    (v/assert kb (list 'unary_predicate person) 'CxUniverse)
+    (v/assert kb (list 'unary_predicate dog) 'CxUniverse)
+    (v/assert kb (list 'predAllExists owns person dog) 'CxUniverse)
+    (v/assert kb (list 'predAllSpecified owns person dog) 'CxUniverse)
+    (v/assert kb (list person Alice) 'CxUniverse)
+    (let [p (list 'PredAllExistsFn owns person dog)]
+      (v/assert kb (list dog p) 'CxUniverse)
+      (v/assert kb (list owns Alice p) 'CxUniverse))
+    (is (empty? (predall/specified-violations kb owns person dog 'CxUniverse))
+        "the author-asserted placeholder is a determinate filler, so nothing violates")))
+
+(tu/deftest-kb pred-specified-all-audits-the-first-position
+  ;; the argument-swapped twin: the filler sits at ?pred's first position
+  (tu/with-terms [managedBy report manager Carol Dan Boss]
+    (v/assert kb (list 'binary_predicate managedBy) 'CxUniverse)
+    (v/assert kb (list 'unary_predicate report) 'CxUniverse)
+    (v/assert kb (list 'unary_predicate manager) 'CxUniverse)
+    ;; predSpecifiedAll ?pred ?dep ?indep : filler drawn from ?dep at position 1,
+    ;; quantified over ?indep at position 2
+    (v/assert kb (list 'predSpecifiedAll managedBy manager report) 'CxUniverse)
+    (v/assert kb (list report Carol) 'CxUniverse)
+    (v/assert kb (list report Dan) 'CxUniverse)
+    (v/assert kb (list managedBy Boss Carol) 'CxUniverse)  ; Boss manages Carol
+    (v/assert kb (list manager Boss) 'CxUniverse)
+    (let [vs (predall/specified-violations kb managedBy report manager 'CxUniverse :first)]
+      (is (not (contains? vs Carol)) "Carol has a determinate manager")
+      (is (contains? vs Dan) "Dan has none"))))
+
+(tu/deftest-kb all-specified-violations-sweeps-every-declaration
+  (tu/with-terms [hasPet person pet Bob]
+    (v/assert kb (list 'binary_predicate hasPet) 'CxUniverse)
+    (v/assert kb (list 'unary_predicate person) 'CxUniverse)
+    (v/assert kb (list 'unary_predicate pet) 'CxUniverse)
+    (v/assert kb (list 'predAllSpecified hasPet person pet) 'CxUniverse)
+    (v/assert kb (list person Bob) 'CxUniverse)
+    (let [report (predall/all-specified-violations kb 'CxUniverse)]
+      (is (contains? report ['predAllSpecified hasPet person pet])
+          "the sweep names the violated declaration")
+      (is (contains? (get report ['predAllSpecified hasPet person pet]) Bob)
+          "and carries its violating instances"))))
+
+;; ==== the IndeterminateTerm identity exemption + the UNA matrix ============
+;; The unique-name assumption applies to DETERMINATE terms (distinct names are provably
+;; different, a term is never different from itself) but is SUSPENDED for an unpinned
+;; indeterminate_term: neither equals nor different is provable of it against a determinate
+;; term until a merge pins it.  Built data-driven over the grid rather than N hand-written
+;; cases (Pace, "DRY it").
+;;
+;; FLAGGED for a future ruling: (1) the design notes also want a non-evaluatable
+;; *unreifiable* NAT (MotherFn JFK) treated as indeterminate; that rests on the
+;; NAT-determinacy question explicitly PUNTED ("for now only skolem is a
+;; member; flag the NAT call"), so the category here is skolem + whatever is declared
+;; (genl _ indeterminate_term), and the generic-NAT cell is left to that ruling.  (2)
+;; rewriteOf-pinning restores UNA for a skolem (below), but for an explicitly-declared
+;; indeterminate kind the equality merge MIGRATES the kind membership onto the winner, so
+;; the winner inherits the indeterminacy — pin-restoration for that row needs a
+;; merge-surviving pin signal (a Pace design call).
+
+(defn- a-skolem
+  "Skolemize a witness through a head-existential rule and return the minted skolem
+  constant — the built-in first member of indeterminate_term."
+  [kb]
+  (tu/with-terms [wk pk hasP T1]
+    (v/assert kb (list 'binary_predicate hasP) 'CxUniverse)
+    (v/assert kb (list 'unary_predicate wk) 'CxUniverse)
+    (v/assert kb (list 'unary_predicate pk) 'CxUniverse)
+    (v/assert kb (list 'implies (list wk '?x)
+                       (list 'exists '?y (list 'and (list hasP '?x '?y) (list pk '?y))))
+              'CxUniverse)
+    (v/assert kb (list wk T1) 'CxUniverse)
+    (get (first (v/ask kb (list hasP T1 '?y) 'CxUniverse)) '?y)))
+
+(tu/deftest-kb una-applies-to-distinct-determinate-terms
+  ;; every atomic determinate term-type pair is provably different; none is different from
+  ;; itself — the UNA baseline the exemption is carved out of.
+  (tu/with-terms [Alice Bob]
+    (doseq [[a b] [[Alice Bob]     ; symbol × symbol (individuals)
+                   [1 2]           ; number × number
+                   ["x" "y"]       ; string × string
+                   [1 "x"]         ; number × string (cross-kind)
+                   [Alice 1]]]     ; symbol × number
+      (is (v/ask? kb (list 'different a b) 'CxUniverse)
+          (str "UNA: " (pr-str a) " and " (pr-str b) " are provably different"))
+      (is (not (v/ask? kb (list 'different a a) 'CxUniverse))
+          (str "reflexive: " (pr-str a) " is not different from itself")))))
+
+(tu/deftest-kb una-is-suspended-for-unpinned-indeterminate-terms
+  ;; all three ways into the category — the built-in skolem, a declared kind, and a
+  ;; DIRECT membership — are exempt.  The direct case is the regression pin: the prover's
+  ;; cheap gate once required a declared subkind to exist before it would look, so a
+  ;; direct member's exemption appeared and disappeared with an unrelated (genl _
+  ;; indeterminate_term) declaration, and the audit and the prover disagreed about the
+  ;; same term.  Tested in ITS OWN kb-shape (no subkind declared) below.
+  (tu/with-terms [Other Foggy vague_kind]
+    (v/assert kb (list 'genl vague_kind 'indeterminate_term) 'CxUniverse)
+    (v/assert kb (list vague_kind Foggy) 'CxUniverse)
+    (doseq [[label t] [["skolem (built-in member)" (a-skolem kb)]
+                       ["declared (genl _ indeterminate_term) kind" Foggy]]]
+      (is (predall/indeterminate-term? kb t 'CxUniverse)
+          (str label " is an indeterminate term"))
+      (is (not (v/ask? kb (list 'different t Other) 'CxUniverse))
+          (str label ": UNA suspended — not provably different from a determinate term")))))
+
+(tu/deftest-kb a-direct-indeterminate-member-is-exempt-with-no-subkind-declared
+  ;; the regression shape: NO (genl _ indeterminate_term) declaration anywhere, only a
+  ;; direct membership.  The audit and the prover must agree.
+  (tu/with-terms [Other Hazy]
+    (v/assert kb (list 'indeterminate_term Hazy) 'CxUniverse)
+    (is (predall/indeterminate-term? kb Hazy 'CxUniverse)
+        "the audit sees the direct membership")
+    (is (not (v/ask? kb (list 'different Hazy Other) 'CxUniverse))
+        "and so does the different prover — no subkind declaration required")))
+
+(tu/deftest-kb a-rewriteOf-pins-a-skolem-and-restores-una
+  ;; a merge that gives the skolem a determinate identity lifts the exemption for it.
+  (tu/with-terms [Real Other]
+    (let [sk (a-skolem kb)]
+      (is (not (v/ask? kb (list 'different sk Other) 'CxUniverse)) "unpinned: exempt")
+      (v/assert kb (list 'rewriteOf Real sk) 'CxUniverse)          ; pin sk -> Real
+      (is (v/ask? kb (list 'different sk Other) 'CxUniverse)
+          (str "once pinned by rewriteOf, the SKOLEM itself obeys the UNA — its"
+               " representative has moved off it, which is the exemption's lifting"
+               " condition"))
+      (is (v/ask? kb (list 'different Real Other) 'CxUniverse)
+          "control: the determinate pin target was never exempt"))))
+
+(tu/deftest-kb negative-zero-permutations-are-canonicalized
+  ;; Pace's Cyc-canonicalizer check: -0.0 must not be a distinct term from 0.0 (the
+  ;; Allegro bug).  Honest scope note: (= 0.0 -0.0) is true in Clojure, so the -0.0 rows
+  ;; are settled by =-level canonicalization before the equality closure is ever
+  ;; consulted — this pins the reader-and-equality layer, not a closure read.  (An
+  ;; integer -0 literal reads as 0 and is pure reflexivity, so it is not a row.)
+  (doseq [[a b una?] [[0.0 -0.0 false]   ; same magnitude+kind: NOT different (no -0.0 bug)
+                      [0   0.0  true]    ; integer 0 vs float 0.0: distinct EDN kinds
+                      [0.0  1.0 true]]]  ; ordinary distinct floats
+    (is (= una? (v/ask? kb (list 'different a b) 'CxUniverse))
+        (str "(different " (pr-str a) " " (pr-str b) ") is " una?)))
+  (is (v/ask? kb '(different 0.0 1.0 2.0) 'CxUniverse)
+      "variable-arity control: three genuinely distinct floats are pairwise different")
+  (is (not (v/ask? kb '(different 0.0 -0.0 1.0) 'CxUniverse))
+      (str "-0.0 collapses onto 0.0, so this tuple carries a repeat and is NOT pairwise"
+           " different — the canonicalization visible through the variable-arity read")))


### PR DESCRIPTION
**Draft — @paceheart holds the draft→ready latch.**

## The predAll quantifier-family matrix (8 of 8 cells)

Three semantic classes over the pred/collection matrix, per the thread's scoping sessions:

- **Instance cells** (`predAllInstance` / `predInstanceAll`) — rule generators: the CxCore generator beside each declaration stamps a defeasible, bidirectional rule (`set/defaultRule`, direction `:both`) when the holes ground.
- **Exists cells** (`predAllExists` / `predExistsAll` / `predExistsInstance` / `predInstanceExists`) — **inferentially inert, by ruling**: each declaration is a stored, queryable record beside a sanctioned per-cell full-arg placeholder functor ("kinda like a named skolem") an author may use for the unnamed filler. The engine derives nothing — which is also what makes the two pure-existential cross-cells expressible (nothing to stamp → no range restriction to fail, no variable-functor rule polluting the concluding-rule index).
- **Specified cells** (`predAllSpecified` / `predSpecifiedAll`) — an on-demand integrity audit (`vaelii.impl.predall/specified-violations`) reporting instances with no determinate filler, gated on the extensible `indeterminate_term` category (skolem is its first member), which also carries the UNA identity exemption (neither `equals` nor `different` provable against an unpinned indeterminate term; documented in `docs/equality.md` + glossary).

## The keystone is CLOSED

`(sign -212 "negative")` proves from the bare literal under `query`/`prove`: the stamped rule's backward arm discharges `(negative_integer -212)` through the evaluative `defnSufficient` prover at query time (`pred-all-instance-keystone-proves-from-the-bare-literal`, with binding + negative control). Under `ask` the goal answers false **by contract** — the registry expands no rule — and the test pins that instrument distinction too. (#66 was filed on the ask-mode observation; the query-mode capability already works.)

## Also pinned

- **Functionality × event calculus (control/known-gap pair, `common_sense_test`):** the equality closure enforces `functional` over bare literals only — two values carried as fluents both hold at a later moment and never merge. The known-gap test is the future per-instant functionality repair's red test.
- **UNA regression:** a *direct* `indeterminate_term` member is exempt with no subkind declared (the prover's cheap gate once made that depend on an unrelated declaration; fixed, with the audit and prover now agreeing).

## CI

Second commit splits the `disk` leg into two runner-sharded jobs behind a gate that keeps the required `disk` context — the leg had grown into its 30-minute timeout (~21m on develop, ~30m with this suite). Whole-namespace alphabetical shards, same `:default` selector; safe across separate VMs where same-host durable sharding is refused.

## Verification

Three-model review (opus/sonnet/fable, six lenses each) run to convergence — all P1/P2 findings fixed or scoped out (the P1s: the false-pending keystone caught by opus, the UNA gate bug probe-confirmed by fable). Registry entries for all 13 new grammar terms; vocabulary audit, predicates, lint 10/10 all green; full suite green locally on each base. Deferred with notes: `all-specified-violations` key order (documented in its docstring), audit extent bound for computed collections.
