### PR TITLE
feat(kb): the bijection mark — vocab-only, one-to-one declared once

### DIFF
--- a/resources/kb/CxCore.txt
+++ b/resources/kb/CxCore.txt
@@ -479,6 +479,18 @@
 (decontextualized_predicate functional)
 (genl functional binary_predicate)
 
+(comment bijection
+         "(bijection ?predicate) means that ?predicate is functional in both directions: each first argument fixes its second and each second argument fixes its first, so the relation is one-to-one. Declared once, it stands in for the two: forward rules derive (functional ?predicate) and (functionalInArg ?predicate 1), each a real mark the engine enforces in turn — the merge/refuse rule over a shared first argument, and the same rule mirrored over a shared second — materialized as stored marks rather than claimed by subsumption edges, for the reason equivalence_relation's entry gives: the rule's stored conclusion both classifies and enforces, where a genl-inherited membership never reaches the mark ingestion. So a second symbol filler on either side derives (equals V1 V2) and merges, while two non-symbols such as 1980 and 1990 are refused outright, exactly as under a directly written mark. Also a type: (genl bijection functional) states the subsumption outright — inferentially inert for the mark machinery (the rules below do the enforcing) but true, and it classifies P as functional and so binary_predicate. Declared of a one-to-one relation such as capitalCityOf, for instance.")
+(unary_predicate bijection)
+(arg bijection 1 predicate)
+(decontextualized_predicate bijection)
+(genl bijection functional)
+
+;; the two marks a bijection stands in for, derived so each is a real property the
+;; engine enforces exactly as a directly written one is
+(implies (and (bijection ?p)) (functional ?p))
+(implies (and (bijection ?p)) (functionalInArg ?p 1))
+
 (comment functionCorrespondingPredicate
          "(functionCorrespondingPredicate ?function ?predicate ?position) means that ?function and ?predicate state the same relationship: ?function maps some arguments to a value exactly when ?predicate holds of those same arguments with the value at ?position. So (functionCorrespondingPredicate MotherFn motherOf 2) makes (MotherFn Muffet) resolve to the Mary of a believed (motherOf Muffet Mary), and, where no mother is known, projects the placeholder constant it mints back onto motherOf so the placeholder still answers questions about who Muffet's mother is. Reading it both ways is what stops the function and the predicate from being one claim the KB can reason with only half of, and a value arriving after its application is equated with the placeholder, so the order the two are asserted in does not decide the answer. ?position is 1-based over ?predicate's arguments and may be omitted, which puts the value last — the shape nearly every correspondence has. Read only for a reifiable_function, an undeclared function having no application to reify. See docs/nat.md.")
 (binary_predicate functionCorrespondingPredicate)

--- a/src/vaelii/impl/predicates.clj
+++ b/src/vaelii/impl/predicates.clj
@@ -876,6 +876,14 @@
                 (str "generic forward chaining: the three CxCore rules derive (symmetric P),"
                      " (transitive P) and (reflexive P), each enforced in turn; also a"
                      " binary_predicate type"))]
+     ['bijection
+      (enforced (collection :notes (str "two CxCore rules derive (functional P) and"
+                                        " (functionalInArg P 1) from it, each enforced in turn —"
+                                        " so it is enforced by generic forward chaining and by"
+                                        " nothing keyed on its name, like equivalence_relation."))
+                (str "generic forward chaining: the two CxCore rules derive (functional P)"
+                     " and (functionalInArg P 1), each enforced in turn; also a"
+                     " binary_predicate type"))]
 
      ;; ---- the connectives and rule wrappers -------------------------------
      ['implies (enforced (structural {:args [:sentence :sentence]}

--- a/test/vaelii/bijection_test.clj
+++ b/test/vaelii/bijection_test.clj
@@ -1,0 +1,94 @@
+;; SPDX-License-Identifier: SSPL-1.0
+;; Copyright © 2026 Vaelii LLC and the Vaelii contributors.
+(ns vaelii.bijection-test
+  "`bijection`, the two-directions composite mark shipped in CxCore: no engine code,
+  two CxCore forward rules derive `(functional P)` and `(functionalInArg P 1)`, each a
+  real mark the engine enforces in turn — `equivalence_relation`'s pattern, over the
+  functional family.
+
+  Behaviourally that is one-to-one: a shared first argument merges-or-refuses its two
+  second-argument fillers (the `functional` half), and a shared second argument does
+  the same to its two first-argument fillers (the `functionalInArg 1` half).  The
+  merge/refuse rule itself is `functional`'s and is tested exhaustively in
+  `functional-in-arg-test`; what is tested here is that the SHIPPED declaration wires
+  both directions, and that the wiring is belief-following — retracting the one
+  declaration drops both derived marks.
+
+  A CxCore-loaded KB throughout, like `relation-properties-test`: the shipped
+  declarations are what is tested, not a hand-built fixture that could drift from the
+  file."
+  (:require [clojure.test :refer [is testing use-fixtures]]
+            [vaelii.core :as v]
+            [vaelii.impl.core-context :as core-context]
+            [vaelii.test-util :as tu]))
+
+(use-fixtures :each (tu/neutral-fresh #(doto (tu/fresh) (core-context/load-into))))
+
+(defn- ex-type
+  "The `:type` on the ex-info a thunk throws, or nil if it does not throw."
+  [f]
+  (try (f) nil (catch clojure.lang.ExceptionInfo e (:type (ex-data e)))))
+
+(def ^:private U 'CxUniverse)
+
+;;; ── the shipped declaration ───────────────────────────────────────────
+
+(tu/deftest-kb cxcore-declares-bijection
+  (testing "the term carries its comment sentex like any other CxCore entry"
+    (is (= 1 (count (core-context/comment-of kb 'bijection))))
+    (is (string? (first (core-context/comment-of kb 'bijection)))))
+  (testing "and the classification half: a bijection is a binary_predicate"
+    (tu/with-terms [capitalCityOf]
+      (v/assert kb (list 'bijection capitalCityOf) U)
+      (is (v/ask? kb (list 'binary_predicate capitalCityOf) U)))))
+
+;;; ── the two marks, derived — no engine code ───────────────────────────
+
+(tu/deftest-kb a-bijection-derives-functional-and-functional-in-arg-1
+  (tu/with-terms [capitalCityOf]
+    (v/assert kb (list 'bijection capitalCityOf) U)
+    (testing "the two marks are derived"
+      (is (v/ask? kb (list 'functional capitalCityOf) U))
+      (is (v/ask? kb (list 'functionalInArg capitalCityOf 1) U)))))
+
+(tu/deftest-kb retracting-the-bijection-declaration-drops-the-two-marks
+  (tu/with-terms [capitalCityOf]
+    (let [decl (v/assert kb (list 'bijection capitalCityOf) U)]
+      (is (v/ask? kb (list 'functional capitalCityOf) U))
+      (v/retract! kb decl)
+      (testing "the derived marks rested on the declaration and go with it"
+        (is (not (v/ask? kb (list 'functional capitalCityOf) U)))
+        (is (not (v/ask? kb (list 'functionalInArg capitalCityOf 1) U)))))))
+
+;;; ── each derived mark is enforced in turn, behaviourally ──────────────
+
+(tu/deftest-kb a-bijection-merges-two-symbol-fillers-in-either-direction
+  (tu/with-terms [capitalCityOf]
+    (v/assert kb (list 'bijection capitalCityOf) U)
+    (testing "a shared first argument merges its two symbol fillers — the functional half"
+      (tu/with-terms [Freedonia]
+        (let [[lo hi] (sort [(tu/tmp-ind "Fredville") (tu/tmp-ind "Fredville")])]
+          (v/assert kb (list capitalCityOf Freedonia lo) U)
+          (v/assert kb (list capitalCityOf Freedonia hi) U)
+          (is (v/same-class? kb lo hi)
+              "two names for one capital are one thing, as under (functional P)"))))
+    (testing "a shared second argument merges its two — the functionalInArg 1 half"
+      (tu/with-terms [Fredopolis]
+        (let [[lo hi] (sort [(tu/tmp-ind "Sylvania") (tu/tmp-ind "Sylvania")])]
+          (v/assert kb (list capitalCityOf lo Fredopolis) U)
+          (v/assert kb (list capitalCityOf hi Fredopolis) U)
+          (is (v/same-class? kb lo hi)
+              "two names for one country are one thing, via (functionalInArg P 1)"))))))
+
+(tu/deftest-kb a-bijection-refuses-two-unmergeable-fillers-in-either-direction
+  (tu/with-terms [pRel Ruritania]
+    (v/assert kb (list 'bijection pRel) U)
+    (testing "a second number at argument 2 for one argument 1 is refused"
+      (v/assert kb (list pRel Ruritania 1980) U)
+      (is (some? (ex-type #(v/assert kb (list pRel Ruritania 1990) U)))
+          "no merge can make 1980 and 1990 one thing"))
+    (testing "and a second number at argument 1 for one argument 2 is refused the same"
+      (tu/with-terms [Zenda]
+        (v/assert kb (list pRel 7 Zenda) U)
+        (is (some? (ex-type #(v/assert kb (list pRel 8 Zenda) U)))
+            "the mirrored refusal, via the derived (functionalInArg P 1)")))))

--- a/test/vaelii/meta_test.clj
+++ b/test/vaelii/meta_test.clj
@@ -216,7 +216,8 @@
   ;; context every data context sees, decontextualizing a predicate nothing declared.
   (testing "the roster is the algebraic marks, the inverse declaration, and genlCx"
     (is (= '#{functional inverse reflexive symmetric asymmetric transitive
-              irreflexive anti_symmetric anti_transitive equivalence_relation}
+              irreflexive anti_symmetric anti_transitive equivalence_relation
+              bijection}
            (v/props kb :decontextualized)))
     (is (= '#{genlCx} (v/props kb :forced-decontextualized))))
   (testing "so a social fact stays in the theory that states it"


### PR DESCRIPTION
`(bijection ?predicate)` classifies a binary predicate as functional in both directions — one-to-one, declared once.

**Vocabulary only, no engine code.** Two CxCore rules derive `(functional P)` and `(functionalInArg P 1)` — each a real mark the existing machinery enforces (symbol merge, unmergeable refusal, both directions), on `equivalence_relation`'s exact pattern. The `predicates.clj` entry is the classification record `vocabulary-audit-test` requires (`:storage [:none] :checked false`, no arms); `meta_test`'s decontextualized roster pin gains the member deliberately.

**Why rules rather than `(genl bijection functional)`** — tested, not assumed: under the genl edge the classification query still answers (membership inherits), but enforcement dies — the `:functional` prop installs only when a stored `functional`-functor sentex integrates (`special.clj` prop-entry `:integrate`; rule-derived conclusions install via `integrate-transitive`), and `props-over` reads only the props roster, never genl memberships. Two behavioral tests go red under the genl form. This is the same split `equivalence_relation`'s own docstring documents.

**Extent sweep:** all 7 shipped `(functional X)` declarations audited for promotion; every one is genuinely many-to-one (`arity`, `displayNameOf`, `trustLevel`, `heightOf`, `weightOf`, `birthYearOf`, `fatherOf`, `motherOf`) — zero promotions, so the starter KB ships no bijection exemplar yet; the docstring's `capitalCityOf` stays illustrative.

**Receipts:** red-first — the five `bijection_test.clj` tests fail 10/27 assertions against unmodified CxCore. Focused 106/1770/0. Full suite 4491/156057/0 after the roster-pin companion edit.