### PR TITLE
arityMin, fixed_arity, etc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,14 @@
 
 ## Unreleased
 
-- **Arity policy is vocabulary over every relation, not an overloaded exact-arity
-  flag.** `relation` is now the common parent of `predicate` and `function`.
-  `fixed_arity` / `variable_arity` each have predicate and function specializations;
-  `arityMin` states a variable relation's lower bound; exact `arity` entails the same
-  minimum; and generic `at_least_binary_relation` / `at_least_ternary_relation` classes
-  derive from it. `admitsArgnum` names the distinct positive-position question; no
-  WFF/query reader consumes it. The current four
-  variable-arity predicates are classified under `variable_arity_predicate`, including
-  `functionCorrespondingPredicate`'s explicitly modelled optional tail. This
-  slice does not declare fixed and variable disjoint or infer `fixed_arity` from exact
-  `arity`; those classifications remain independent. *Class:* **Additive**.
+- **Arity policy is vocabulary over every relation.** `relation` is now the common
+  parent of `predicate` and `function`. Unsuffixed `unary` / `binary` / `ternary` are
+  the relation-wide exact classes, with predicate and function specializations;
+  `relationTypeByArity` owns their shared numeric mapping. Exact `arity` is fixed-only,
+  while `arityMin` states a variable relation's lower bound and derives the generic
+  `at_least_binary_relation` / `at_least_ternary_relation` floors. `fixed_arity` and
+  `variable_arity` are disjoint, and every shipped relation is classified in exactly
+  one. `admitsArgnum` remains documentary. *Class:* **Additive**.
   *Migration:* none.
   [docs/taxonomy.md](docs/taxonomy.md#relations-and-arity-policy)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+- **Arity policy is vocabulary over every relation, not an overloaded exact-arity
+  flag.** `relation` is now the common parent of `predicate` and `function`.
+  `fixed_arity` / `variable_arity` each have predicate and function specializations;
+  `arityMin` states a variable relation's lower bound; exact `arity` entails the same
+  minimum; and generic `at_least_binary_relation` / `at_least_ternary_relation` classes
+  derive from it. `admitsArgnum` names the distinct positive-position question; no
+  WFF/query reader consumes it. The current four
+  variable-arity predicates are classified under `variable_arity_predicate`, including
+  `functionCorrespondingPredicate`'s explicitly modelled optional tail. This
+  slice does not declare fixed and variable disjoint or infer `fixed_arity` from exact
+  `arity`; those classifications remain independent. *Class:* **Additive**.
+  *Migration:* none.
+  [docs/taxonomy.md](docs/taxonomy.md#relations-and-arity-policy)
+
 - **`predAllSpecified` and `predSpecifiedAll` go binary: the filler type derives from
   the predicate's own slot contract.** The ternary forms restated in a third argument
   what `(arg P 2 R)` / `(genlArg P 2 R)` already say, and a restated type can disagree

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- **Starter loading preserves non-unary predicate specialization.** The starter
+  assigns `unary_predicate` only to the `thing` subtype hierarchy, not every `genl`
+  node. Binary mapping predicates retain their declared arity. Exact `arity` derives
+  `fixed_arity` even when argument-type entailment is disabled. Taxonomy coverage
+  excludes declared non-unary predicates without hiding unknown type islands.
+  Argument metadata (`arg` and its projections, `genlArg`, `quotedArg`, `interArg`)
+  accepts relations, including functions; `InstantFn` declares its six existing
+  integer-field contracts. Recursive function-input enforcement remains follow-up
+  work, documented in [docs/argtypes.md](docs/argtypes.md#relation-wide-declarations-and-the-runtime-boundary).
+  *Class:* **Fix**.
+  [docs/taxonomy.md](docs/taxonomy.md#relations-and-arity-policy)
+
 - **Arity policy is vocabulary over every relation.** `relation` is now the common
   parent of `predicate` and `function`. Unsuffixed `unary` / `binary` / `ternary` are
   the relation-wide exact classes, with predicate and function specializations;

--- a/docs/argtypes.md
+++ b/docs/argtypes.md
@@ -8,6 +8,21 @@
   [inherit.md](inherit.md).
 - **Assumes:** sentex, justification, context, `genl` → [glossary.md](glossary.md).
 
+## Relation-wide declarations and the runtime boundary
+
+`arg` (including `arg1` / `arg2` / `arg3`), `genlArg`, `quotedArg`, and `interArg`
+accept a `relation` as their subject: either a predicate or a function. Accepting and
+storing a function's declaration does **not** yet guarantee recursive enforcement of
+its input constraints inside a nested function application. The current checks read
+the asserted sentence's argument declarations. For `arg` / `genlArg`, a function
+application filling a constrained slot is checked through its `result` / `genlResult`,
+not by recursively checking every input against that function's declarations.
+`quotedArg` instead exempts compound arguments from its value-kind check.
+Recursive function-input enforcement is follow-up runtime work, not supplied by the
+vocabulary generalization.
+
+## Constraint and entailment readings
+
 `(arg parentOf 1 animal)` says the first argument of `parentOf` is an animal. Assert
 `(parentOf Fred Mary)` and the KB checks that claim against what it knows about `Fred` —
 and when it knows nothing, **passes and stores nothing**. The declaration is are indistinguishable from a

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -79,9 +79,10 @@ a `T` — and it reads open-world in *both* directions at once: an unestablished
 leaves it dormant, an unreachable target convicts. See [argtypes.md](argtypes.md).
 
 **Arity vocabulary** ![kb](../.github/badges/cat-kb.svg): `fixed_arity` and
-`variable_arity` classify relation-wide argument policy, each with predicate and
-function specializations. `arity` states one exact predicate arity; `arityMin` states a
-variable relation's lower bound, and exact arity entails the same minimum.
+`variable_arity` are disjoint relation-wide argument policies. Unsuffixed `unary`,
+`binary` and `ternary` are the exact relation classes, each with predicate and function
+specializations. `arity` states one exact relation arity; `arityMin` states a variable
+relation's lower bound.
 `at_least_binary_relation` / `at_least_ternary_relation` are derived minimum classes.
 `admitsArgnum` names whether one positive position exists; no WFF/query reader currently
 consumes it. See [taxonomy.md](taxonomy.md#relations-and-arity-policy).

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -78,6 +78,14 @@ a type whose genl closure reaches `type`. Open-world and context-scoped. See
 a `T` — and it reads open-world in *both* directions at once: an unestablished trigger
 leaves it dormant, an unreachable target convicts. See [argtypes.md](argtypes.md).
 
+**Arity vocabulary** ![kb](../.github/badges/cat-kb.svg): `fixed_arity` and
+`variable_arity` classify relation-wide argument policy, each with predicate and
+function specializations. `arity` states one exact predicate arity; `arityMin` states a
+variable relation's lower bound, and exact arity entails the same minimum.
+`at_least_binary_relation` / `at_least_ternary_relation` are derived minimum classes.
+`admitsArgnum` names whether one positive position exists; no WFF/query reader currently
+consumes it. See [taxonomy.md](taxonomy.md#relations-and-arity-policy).
+
 **Arm** ![kb](../.github/badges/cat-kb.svg): The function a table stores under a functor
 and a walk over that table invokes at one fixed point — `special/arms` holds an
 `:integrate`, a `:disintegrate`, a `:rebuild` and a `:wff` per interpreted predicate, and
@@ -827,6 +835,11 @@ nothing else. See [space.md](space.md).
 wholesale from the
 records, then recover — the repair for a stale on-disk index layout. See
 [indexing.md](indexing.md).
+
+**`relation`** ![kb](../.github/badges/cat-kb.svg): The common parent of
+`predicate` and `function` — every head that may be applied to arguments. The two
+specializations remain disjoint: a predicate holds or fails; a function denotes or
+evaluates to a value. See [taxonomy.md](taxonomy.md#relations-and-arity-policy).
 
 **Relation algebra** ![qr](../.github/badges/cat-qr.svg): `{:universe :identity
 :compose :converse}` — the base relations, the diagonal, the composition table

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -838,7 +838,7 @@ records, then recover — the repair for a stale on-disk index layout. See
 [indexing.md](indexing.md).
 
 **`relation`** ![kb](../.github/badges/cat-kb.svg): The common parent of
-`predicate` and `function` — every head that may be applied to arguments. The two
+`predicate` and `function` — every operator that may be applied to arguments. The two
 specializations remain disjoint: a predicate holds or fails; a function denotes or
 evaluates to a value. See [taxonomy.md](taxonomy.md#relations-and-arity-policy).
 

--- a/docs/kbs.md
+++ b/docs/kbs.md
@@ -18,7 +18,7 @@ OpenCyc reader is in this repo. This page is the **sequence**, and what each ste
 | KB | comes from | to first load | once loaded |
 |---|---|---|---|
 | Starter ontology | the classpath | seconds | ~1,879 sentexes |
-| Core vocabulary | the classpath | seconds | ~562 sentexes |
+| Core vocabulary | the classpath | seconds | ~920 sentexes |
 | cyc-tiny | a test fixture in the plugin | one dependency, then seconds | 8,181 sentexes |
 | OpenCyc 4.0 | a distribution you supply | a conversion, then ~10 minutes | ~1.2M sentexes |
 

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -169,9 +169,10 @@ the reading means the same on a corpus that never heard of `thing`.
 
 The denominator (`:names`) is every type-shaped name in the vocabulary, and by
 [naming.md](naming.md) that includes a bare lowercase word: `likes` is a legal predicate
-*and* a legal type name, arity decides, and the index records no arity to tell them apart.
-`genl` itself is counted. Which is the reason the gap is the finding rather than either
-fraction on its own.
+*and* a legal type name. A unique declared arity other than one excludes a known
+non-unary predicate from both names and edges. Unknown or conflicting arities remain
+candidates, so an untyped root or disconnected unary island is not silently dropped.
+This is why the gap is the finding rather than either fraction on its own.
 
 The measured shape on the same OpenCyc conversion as the Gini above, and all three
 counts are that one run's own denominator: of roughly 124k types, about 71% carry a

--- a/docs/taxonomy.md
+++ b/docs/taxonomy.md
@@ -52,6 +52,30 @@ globally, and why: [below](#the-global-readers-and-who-may-use-one).
    materialize `(animal Muffet)`. `isa?` answers membership on demand.
 3. **(genlCx is the sibling relation over contexts — see contexts.md.)**
 
+### Relations and arity policy
+
+`relation` is the common parent of `predicate` and `function`: both can be applied to
+arguments, while only predicates hold or fail and only functions denote values. Arity
+policy is therefore relation-wide even though the current exact `arity` table remains
+predicate-typed.
+
+`fixed_arity` and `variable_arity` classify the two policies, with predicate and
+function specializations for each. `arityMin` states the lower bound of a
+variable-arity relation; every exact `(arity R N)` entails `(arityMin R N)`. Prefer
+variable arity for a repeatable, homogeneously typed argument role. A relation may
+explicitly define a bounded optional tail instead, as `functionCorrespondingPredicate`
+does.
+
+`at_least_binary_relation` and `at_least_ternary_relation` are generic derived
+classifications over `arityMin`; callers can conjoin them with `predicate` or `function`
+instead of maintaining duplicate predicate/function classes. `admitsArgnum` names the
+separate question of whether one positive argument position exists. No WFF/query reader
+currently consumes it, and no parallel finite position roster is inferred.
+
+No disjointness declaration currently separates the fixed and variable classes, and
+exact `arity` does not derive `fixed_arity`. This lets direct generic variable markers
+coexist with the new specializations without classifying the same relation both ways.
+
 ## The closures are derived state
 
 A cached closure is an optimization, and an optimization that disagrees with the

--- a/docs/taxonomy.md
+++ b/docs/taxonomy.md
@@ -56,12 +56,14 @@ globally, and why: [below](#the-global-readers-and-who-may-use-one).
 
 `relation` is the common parent of `predicate` and `function`: both can be applied to
 arguments, while only predicates hold or fail and only functions denote values. Arity
-policy is therefore relation-wide even though the current exact `arity` table remains
-predicate-typed.
+policy and the exact `arity` table are therefore relation-wide.
 
-`fixed_arity` and `variable_arity` classify the two policies, with predicate and
-function specializations for each. `arityMin` states the lower bound of a
-variable-arity relation; every exact `(arity R N)` entails `(arityMin R N)`. Prefer
+`fixed_arity` and `variable_arity` classify two disjoint policies, with predicate and
+function specializations for each. Unsuffixed `unary`, `binary` and `ternary` classify
+exact relations; `unary_predicate` / `unary_function` and their binary and ternary peers
+specialize those relation-wide classes. `relationTypeByArity` owns the shared mapping,
+while `predicateTypeByArity` and `functionTypeByArity` specialize it without parallel
+rule families. `arityMin` states the lower bound of a variable-arity relation. Prefer
 variable arity for a repeatable, homogeneously typed argument role. A relation may
 explicitly define a bounded optional tail instead, as `functionCorrespondingPredicate`
 does.
@@ -72,9 +74,9 @@ instead of maintaining duplicate predicate/function classes. `admitsArgnum` name
 separate question of whether one positive argument position exists. No WFF/query reader
 currently consumes it, and no parallel finite position roster is inferred.
 
-No disjointness declaration currently separates the fixed and variable classes, and
-exact `arity` does not derive `fixed_arity`. This lets direct generic variable markers
-coexist with the new specializations without classifying the same relation both ways.
+Exact `(arity R N)` entails `fixed_arity`; it is not also an `arityMin` floor. The four
+shipped variable predicates state their lower bound with `arityMin` instead of carrying
+an exact binary classification.
 
 ## The closures are derived state
 
@@ -1429,7 +1431,7 @@ classification never lands to derive a second value. The **top literal only**, e
 not. Open-world in the same shape — a predicate the KB has never declared can be used
 at any arity, since the declaration may simply not have arrived.
 
-`(variable_arity P)` exempts a predicate outright. `lessThan` is declared binary *and*
+`(variable_arity P)` exempts a predicate outright. `lessThan` has `arityMin` two and
 reads a chain of any length (`(lessThan 1 2 3)` is `1 < 2 < 3`); the declaration is what
 says so, rather than the check carrying a roster of predicates it quietly skips.
 

--- a/docs/taxonomy.md
+++ b/docs/taxonomy.md
@@ -61,9 +61,10 @@ policy and the exact `arity` table are therefore relation-wide.
 `fixed_arity` and `variable_arity` classify two disjoint policies, with predicate and
 function specializations for each. Unsuffixed `unary`, `binary` and `ternary` classify
 exact relations; `unary_predicate` / `unary_function` and their binary and ternary peers
-specialize those relation-wide classes. `relationTypeByArity` owns the shared mapping,
-while `predicateTypeByArity` and `functionTypeByArity` specialize it without parallel
-rule families. `arityMin` states the lower bound of a variable-arity relation. Prefer
+specialize those relation-wide classes. `relationTypeByArity` owns the shared mapping;
+`predicateTypeByArity` and `functionTypeByArity` are its `genl` specializations, and one
+rule derives a relation's exact `arity` from whichever mapped type classifies it, with no
+parallel rule families. `arityMin` states the lower bound of a variable-arity relation. Prefer
 variable arity for a repeatable, homogeneously typed argument role. A relation may
 explicitly define a bounded optional tail instead, as `functionCorrespondingPredicate`
 does.

--- a/docs/taxonomy.md
+++ b/docs/taxonomy.md
@@ -25,8 +25,11 @@ as a sentence.
 
 ## genl: the type hierarchy
 
-`(genl Sub Super)` — every `Sub` is a `Super`. Types are unary predicates, rooted
-at `thing`. We cache the reflexive-transitive closure both ways:
+`(genl Sub Super)` — every `Sub` tuple is a `Super` tuple. Types are unary predicates,
+rooted at `thing`. Predicate specializations of other arities also use `genl`;
+membership in that graph alone does not imply `unary_predicate`. The starter assigns
+unary membership to the subtypes of `thing`. We cache the reflexive-transitive closure
+both ways:
 
 - `genls tax t context` — supertypes of `t`, incl. `t` (up-closure).
 - `specs tax t context` — subtypes of `t`, incl. `t` (down-closure).

--- a/resources/kb/CxCore.txt
+++ b/resources/kb/CxCore.txt
@@ -222,24 +222,146 @@
 (arg interArg 4 positive_integer)
 (arg interArg 5 unary_predicate)
 
+(comment fixed_arity
+         "(fixed_arity ?relation) means that ?relation takes one exact number of arguments. Exact arity classes and numeric arity declarations specialize this relation-wide policy.")
+(unary_predicate fixed_arity)
+(arg fixed_arity 1 relation)
+(genl fixed_arity relation)
+
+(comment fixed_arity_predicate
+         "The fixed_arity relations that are predicates.")
+(unary_predicate fixed_arity_predicate)
+(arg fixed_arity_predicate 1 predicate)
+(genl fixed_arity_predicate fixed_arity)
+(genl fixed_arity_predicate predicate)
+
+(comment fixed_arity_function
+         "The fixed_arity relations that are functions.")
+(unary_predicate fixed_arity_function)
+(arg fixed_arity_function 1 function)
+(genl fixed_arity_function fixed_arity)
+(genl fixed_arity_function function)
+
+(comment variable_arity
+         "(variable_arity ?relation) means that ?relation does not take one exact number of arguments; arityMin states its lower bound. Prefer it for a repeatable, homogeneously typed argument role. A relation may explicitly define a bounded optional tail instead, as functionCorrespondingPredicate does. The arity check reads this generic type through specialization.")
+(unary_predicate variable_arity)
+(arg variable_arity 1 relation)
+(genl variable_arity relation)
+
+(comment variable_arity_predicate
+         "The variable_arity relations that are predicates.")
+(unary_predicate variable_arity_predicate)
+(arg variable_arity_predicate 1 predicate)
+(genl variable_arity_predicate variable_arity)
+(genl variable_arity_predicate predicate)
+
+(comment variable_arity_function
+         "The variable_arity relations that are functions.")
+(unary_predicate variable_arity_function)
+(arg variable_arity_function 1 function)
+(genl variable_arity_function variable_arity)
+(genl variable_arity_function function)
+
+(disjoint fixed_arity variable_arity)
+
+(comment unary "A relation of exactly one argument.")
+(unary_predicate unary)
+(arg unary 1 relation)
+(genl unary fixed_arity)
+
+(comment binary "A relation of exactly two arguments.")
+(unary_predicate binary)
+(arg binary 1 relation)
+(genl binary fixed_arity)
+
+(comment ternary "A relation of exactly three arguments.")
+(unary_predicate ternary)
+(arg ternary 1 relation)
+(genl ternary fixed_arity)
+
+(comment unary_function "A function of exactly one argument.")
+(unary_predicate unary_function)
+(arg unary_function 1 function)
+(genl unary_function unary)
+(genl unary_function function)
+
+(comment binary_function "A function of exactly two arguments.")
+(unary_predicate binary_function)
+(arg binary_function 1 function)
+(genl binary_function binary)
+(genl binary_function function)
+
+(comment ternary_function "A function of exactly three arguments.")
+(unary_predicate ternary_function)
+(arg ternary_function 1 function)
+(genl ternary_function ternary)
+(genl ternary_function function)
+
+(comment relationTypeByArity
+         "(relationTypeByArity ?type ?arity) maps a relation-wide exact-arity type to its arity. Its three declarations drive the shared arity/type rules.")
+(binary_predicate relationTypeByArity)
+(instance_relation_predicate relationTypeByArity)
+(functional relationTypeByArity)
+(arg relationTypeByArity 1 unary_predicate)
+(arg relationTypeByArity 2 non_negative_integer)
+
+(comment predicateTypeByArity
+         "The predicate specialization of relationTypeByArity.")
+(binary_predicate predicateTypeByArity)
+(instance_relation_predicate predicateTypeByArity)
+(arg predicateTypeByArity 1 unary_predicate)
+(arg predicateTypeByArity 2 non_negative_integer)
+
+(comment functionTypeByArity
+         "The function specialization of relationTypeByArity.")
+(binary_predicate functionTypeByArity)
+(instance_relation_predicate functionTypeByArity)
+(arg functionTypeByArity 1 unary_predicate)
+(arg functionTypeByArity 2 non_negative_integer)
+
+(relationTypeByArity unary 1)
+(relationTypeByArity binary 2)
+(relationTypeByArity ternary 3)
+(predicateTypeByArity unary_predicate 1)
+(predicateTypeByArity binary_predicate 2)
+(predicateTypeByArity ternary_predicate 3)
+(functionTypeByArity unary_function 1)
+(functionTypeByArity binary_function 2)
+(functionTypeByArity ternary_function 3)
+
+;; Predicate/function mappings specialize the relation-wide mapping extensionally.
+;; A genl edge is not the right level here: genl endpoints are types (unary predicates),
+;; while these three mappings are binary relations.  Ground rules state the complete
+;; six-member compatibility table without making the two subdomains unifiably overlap.
+(implies (and (predicateTypeByArity unary_predicate 1))
+         (relationTypeByArity unary_predicate 1))
+(implies (and (predicateTypeByArity binary_predicate 2))
+         (relationTypeByArity binary_predicate 2))
+(implies (and (predicateTypeByArity ternary_predicate 3))
+         (relationTypeByArity ternary_predicate 3))
+(implies (and (functionTypeByArity unary_function 1))
+         (relationTypeByArity unary_function 1))
+(implies (and (functionTypeByArity binary_function 2))
+         (relationTypeByArity binary_function 2))
+(implies (and (functionTypeByArity ternary_function 3))
+         (relationTypeByArity ternary_function 3))
+
 (comment arity
-         "(arity ?predicate ?n) means that ?predicate takes ?n arguments. One for a unary_predicate, two for a binary_predicate, three for a ternary_predicate. The arity and the predicate-type membership derive each other, so asserting either keeps the whole cycle believed, and retracting the one that was actually asserted collapses it. The three classifications are pairwise disjoint, so a predicate is at most one of them and a second classification is refused where it is written rather than surfacing later as two values in this table.")
+         "(arity ?relation ?n) means that ?relation takes exactly ?n arguments and is fixed_arity. One maps to unary, two to binary and three to ternary; predicate and function specializations inherit those relation-wide classes.")
 (binary_predicate arity)
 (instance_relation_predicate arity)
 (functional arity)
-(arg arity 1 predicate)
+(arg arity 1 relation)
 (arg arity 2 non_negative_integer)
 
 (comment arityMin
-         "(arityMin ?relation ?n) means that ?relation requires at least ?n arguments. It is the numeric shape for a genuinely variable-arity relation: every further position normally repeats the same argument role rather than introducing an unnamed optional field. Every exact (arity R N) entails the matching minimum. No WFF reader consumes this declaration.")
+         "(arityMin ?relation ?n) means that a variable-arity ?relation requires at least ?n arguments. Every further position normally repeats the same argument role rather than introducing an unnamed optional field. No WFF reader consumes this declaration.")
 (binary_predicate arityMin)
 (instance_relation_predicate arityMin)
 (arg arityMin 1 relation)
 (arg arityMin 2 non_negative_integer)
 
-(implies
- (and (arity ?relation ?arity))
- (arityMin ?relation ?arity))
+(implies (and (arity ?relation ?arity)) (fixed_arity ?relation))
 
 (comment admitsArgnum
          "(admitsArgnum ?relation ?argnum) means that positive argument position ?argnum exists in a well-formed application of ?relation. It asks about one position, not the application's total arity. No WFF or query reader consumes it.")
@@ -249,7 +371,7 @@
 (arg admitsArgnum 2 positive_integer)
 
 (comment at_least_binary_relation
-         "The type of relations whose stated minimum arity is two or greater. Derived from arityMin, including the matching minimum entailed by an exact arity.")
+         "The type of variable relations whose stated minimum arity is two or greater. Derived from arityMin.")
 (unary_predicate at_least_binary_relation)
 (arg at_least_binary_relation 1 relation)
 (genl at_least_binary_relation relation)
@@ -280,34 +402,40 @@
 ;; while (has-prop? kb :symmetric myRel ctx) — asked of the same declaration from the
 ;; same context — answered false.  One KB cannot say both.
 
-;; arity concludes the predicate type
-(implies (and (arity ?p 1)) (unary_predicate ?p))
-(implies (and (arity ?p 2)) (binary_predicate ?p))
-(implies (and (arity ?p 3)) (ternary_predicate ?p))
+;; relationTypeByArity is the one rule-bearing family.  Predicate and function mappings
+;; specialize its facts rather than carrying parallel arity/type rules.
+(implies (and (relationTypeByArity unary 1) (arity ?relation 1))
+         (unary ?relation))
+(implies (and (relationTypeByArity binary 2) (arity ?relation 2))
+         (binary ?relation))
+(implies (and (relationTypeByArity ternary 3) (arity ?relation 3))
+         (ternary ?relation))
 
-;; the predicate type concludes the arity
-(implies (and (unary_predicate ?p))   (arity ?p 1))
-(implies (and (binary_predicate ?p))  (arity ?p 2))
-(implies (and (ternary_predicate ?p)) (arity ?p 3))
+(implies (and (relationTypeByArity unary 1) (unary ?relation))
+         (arity ?relation 1))
+(implies (and (relationTypeByArity binary 2) (binary ?relation))
+         (arity ?relation 2))
+(implies (and (relationTypeByArity ternary 3) (ternary ?relation))
+         (arity ?relation 3))
 
-;; and the three classifications separate each other: a predicate takes ONE number of
-;; arguments, so a second classification is a contradiction rather than a second fact, and
-;; is refused where it is written.  That is what keeps the (arity ?p ?n) table above
-;; single-valued at its source — a predicate declared two classes would derive two arities
-;; for one ?p, and (functional arity) would then be convicting a clash that the two
-;; declarations had already made.
+;; The three relation-wide classifications separate each other: a relation takes ONE
+;; exact number of arguments, so a second classification is a contradiction rather than
+;; a second fact.  This keeps the (arity ?relation ?n) table single-valued at its source:
+;; two exact classes would derive two arities, and (functional arity) would otherwise
+;; convict a clash the class declarations had already made.
 ;;
-;; Pairwise, and NOT a (sibling_disjoint predicate) mark: predicate's specializations are
-;; every classification of a relation there is, and a predicate is rightly several of
-;; those at once — arity itself is a binary_predicate and an instance_relation_predicate, and
-;; the mark would refuse the pair.  The separation claimed here is among the three arity
-;; classes alone, which is three pairs and says exactly that.  It closes under genl like
-;; any disjointness, so functional / symmetric / transitive and the rest — every one of
-;; them a kind of binary_predicate — are separated from the unary and ternary classes with
-;; their parent, which is the claim their genl edge already makes.
+;; The predicate specializations remain explicitly pairwise disjoint too, and NOT via a
+;; (sibling_disjoint predicate) mark: predicate's specializations include many compatible
+;; classifications.  The three pairs say only that one predicate cannot have two exact
+;; arities.  Their separation closes down the predicate hierarchy, so functional,
+;; symmetric, transitive and every other binary_predicate subtype remain separated from
+;; unary_predicate and ternary_predicate.
 (disjoint unary_predicate binary_predicate)
 (disjoint unary_predicate ternary_predicate)
 (disjoint binary_predicate ternary_predicate)
+(disjoint unary binary)
+(disjoint unary ternary)
+(disjoint binary ternary)
 
 (comment believes
          "(believes ?agent ?sentence) means that ?agent holds ?sentence true in its own context — answered by proving ?sentence in ?agent's context (CxAgent<agent>) rather than in the asker's, so two agents may believe contradictory things without the KB being inconsistent. A modal_predicate: the projection is what BeliefProjectionProver does, and the marker is what turns it on (docs/belief.md). An ordinary relation for the rest — assertible and storable like any fact, so an asserted (believes a p) is answerable as a stored fact too; the projector augments, it does not shadow.")
@@ -442,18 +570,22 @@
 (comment PredAllExistsFn
          "(PredAllExistsFn ?pred ?indep ?dep) denotes the sanctioned ontological placeholder for the required but unnamed ?dep filler of ?pred over ?indep — the term an author may use to speak of the filler a predAllExists declaration requires, without naming it. An unreifiable_function, so a ground application stays a structural NAT the reader keeps readable inside the sentence; per-cell and full-arg (\"kinda like a named skolem\"), distinct from the other Exists cells' placeholders. An ontological marker, deliberately NOT a skolem witness: the engine never asserts it anywhere — its uses are the author's — and when used it is determinate, so it satisfies a predAllSpecified audit. See docs/nat.md.")
 (unreifiable_function PredAllExistsFn)
+(ternary_function PredAllExistsFn)
 
 (comment PredExistsAllFn
          "(PredExistsAllFn ?pred ?dep ?indep) denotes the sanctioned placeholder for the ?dep filler predExistsAll requires at ?pred's first position. An unreifiable_function; per-cell and full-arg, distinct from the other Exists cells' placeholders; never asserted by the engine. See docs/nat.md.")
 (unreifiable_function PredExistsAllFn)
+(ternary_function PredExistsAllFn)
 
 (comment PredExistsInstanceFn
          "(PredExistsInstanceFn ?pred ?indep ?fixed) denotes the sanctioned placeholder for the ?indep member predExistsInstance requires at ?pred's first position, against the fixed filler ?fixed. An unreifiable_function; per-cell and full-arg, distinct from the other Exists cells' placeholders; never asserted by the engine. See docs/nat.md.")
 (unreifiable_function PredExistsInstanceFn)
+(ternary_function PredExistsInstanceFn)
 
 (comment PredInstanceExistsFn
          "(PredInstanceExistsFn ?pred ?fixed ?dep) denotes the sanctioned placeholder for the ?dep member predInstanceExists requires at ?pred's second position, borne by the fixed subject ?fixed. An unreifiable_function; per-cell and full-arg, distinct from the other Exists cells' placeholders; never asserted by the engine. See docs/nat.md.")
 (unreifiable_function PredInstanceExistsFn)
+(ternary_function PredInstanceExistsFn)
 
 (comment predAllExists
          "(predAllExists ?pred ?indep ?dep) means that every instance of collection ?indep bears ?pred, at position 1, to some member of collection ?dep: for all x in ?indep, exists y in ?dep, (?pred x y). Inferentially inert (see the Exists header): the declaration is a stored, queryable record and the engine derives nothing from it — no rule, no witness, no membership. (PredAllExistsFn ?pred ?indep ?dep) is the sanctioned placeholder an author may use to name the required filler.")
@@ -586,7 +718,6 @@
 
 (comment functionCorrespondingPredicate
          "(functionCorrespondingPredicate ?function ?predicate ?position) means that ?function and ?predicate state the same relationship: ?function maps some arguments to a value exactly when ?predicate holds of those same arguments with the value at ?position. So (functionCorrespondingPredicate MotherFn motherOf 2) makes (MotherFn Muffet) resolve to the Mary of a believed (motherOf Muffet Mary), and, where no mother is known, projects the placeholder constant it mints back onto motherOf so the placeholder still answers questions about who Muffet's mother is. Reading it both ways is what stops the function and the predicate from being one claim the KB can reason with only half of, and a value arriving after its application is equated with the placeholder, so the order the two are asserted in does not decide the answer. ?position is 1-based over ?predicate's arguments and may be omitted, which puts the value last — the shape nearly every correspondence has. Read only for a reifiable_function, an undeclared function having no application to reify. See docs/nat.md.")
-(binary_predicate functionCorrespondingPredicate)
 (variable_arity functionCorrespondingPredicate)
 (variable_arity_predicate functionCorrespondingPredicate)
 (arityMin functionCorrespondingPredicate 2)
@@ -678,7 +809,6 @@
 
 (comment greaterThan
          "(greaterThan ?number1 ?number2 …) means that the numbers descend. Variable arity, so (greaterThan 3 2 1) is indistinguishable from the chain 3 > 2 > 1. Evaluable: computed on demand from ground numbers, never stored. Canonicalizes to lessThan with the arguments reversed, so only the < direction is ever stored and a greaterThan goal is still answerable.")
-(binary_predicate greaterThan)
 (instance_relation_predicate greaterThan)
 (arg greaterThan 1 thing)
 (arg greaterThan 2 thing)
@@ -714,7 +844,6 @@
 
 (comment lessThan
          "(lessThan ?number1 ?number2 …) means that the numbers ascend. Variable arity, so (lessThan 1 2 3) is indistinguishable from the chain 1 < 2 < 3. Evaluable: computed on demand from ground arguments, never stored and never forward-chained. Chained comparisons in a rule collapse into one literal, so (lessThan ?a ?b) beside (lessThan ?b ?c) becomes (lessThan ?a ?b ?c).")
-(binary_predicate lessThan)
 (instance_relation_predicate lessThan)
 (arg lessThan 1 thing)
 (arg lessThan 2 thing)
@@ -920,48 +1049,19 @@
 (arg typeToInstancePred 1 type_relation_predicate)
 (arg typeToInstancePred 2 instance_relation_predicate)
 
-(comment fixed_arity
-         "(fixed_arity ?relation) means that ?relation takes one exact number of arguments. Numeric exact arity is still stated separately; this type classifies the relation's argument policy without inventing a number.")
-(unary_predicate fixed_arity)
-(arg fixed_arity 1 relation)
-(genl fixed_arity relation)
-
-(comment fixed_arity_predicate
-         "The fixed_arity relations that are predicates.")
-(unary_predicate fixed_arity_predicate)
-(arg fixed_arity_predicate 1 predicate)
-(genl fixed_arity_predicate fixed_arity)
-(genl fixed_arity_predicate predicate)
-
-(comment fixed_arity_function
-         "The fixed_arity relations that are functions.")
-(unary_predicate fixed_arity_function)
-(arg fixed_arity_function 1 function)
-(genl fixed_arity_function fixed_arity)
-(genl fixed_arity_function function)
-
-(comment variable_arity
-         "(variable_arity ?relation) means that ?relation does not take one exact number of arguments; arityMin states its lower bound. Prefer it for a repeatable, homogeneously typed argument role. A relation may explicitly define a bounded optional tail instead, as functionCorrespondingPredicate does. The arity check reads this generic type through specialization.")
-(unary_predicate variable_arity)
-(arg variable_arity 1 relation)
-(genl variable_arity relation)
-
-(comment variable_arity_predicate
-         "The variable_arity relations that are predicates.")
-(unary_predicate variable_arity_predicate)
-(arg variable_arity_predicate 1 predicate)
-(genl variable_arity_predicate variable_arity)
-(genl variable_arity_predicate predicate)
-
-(comment variable_arity_function
-         "The variable_arity relations that are functions.")
-(unary_predicate variable_arity_function)
-(arg variable_arity_function 1 function)
-(genl variable_arity_function variable_arity)
-(genl variable_arity_function function)
-
 (comment unary_predicate      "A predicate of one argument: every type (a snake_case unary predicate) and every one-place property such as flies.")
 (genl unary_predicate predicate)
+(genl unary_predicate unary)
+(genl unary_predicate fixed_arity_predicate)
+
+(genl binary_predicate binary)
+(genl binary_predicate fixed_arity_predicate)
+(genl ternary_predicate ternary)
+(genl ternary_predicate fixed_arity_predicate)
+
+(genl unary_function fixed_arity_function)
+(genl binary_function fixed_arity_function)
+(genl ternary_function fixed_arity_function)
 
 ;; ---- curation cross-reference --------------------------------------------
 ;; Documentation vocabulary beside `comment`: relations a KB curator writes to point a
@@ -972,7 +1072,6 @@
 
 (comment termsRelated
          "(termsRelated ?term1 ?term2 …) means that the named terms form a related cluster — a curation grouping among vocabulary terms, so a reader meeting one is pointed at the rest. Variable arity, like lessThan: (termsRelated positiveExample negativeExample borderlineExample) groups the three example predicates as one family. Documentation only — nothing in the engine reads it and it draws no inference, the grouping being for a reader as comment's prose is.")
-(binary_predicate termsRelated)
 (instance_relation_predicate termsRelated)
 (arg termsRelated 1 thing)
 (arg termsRelated 2 thing)

--- a/resources/kb/CxCore.txt
+++ b/resources/kb/CxCore.txt
@@ -214,6 +214,7 @@
 (comment interArg
          "(interArg ?predicate ?position1 ?type1 ?position2 ?type2) means that whenever argument ?position1 of ?predicate is a ?type1, argument ?position2 must be a ?type2. The conditional argument constraint, and it says what arg cannot: (interArg eats 1 carnivore 2 meat) types the second argument only for the eaters that are carnivores, where (arg eats 2 meat) would demand meat of every eater. Open-world in both directions, and they point opposite ways — silence about the trigger argument's type leaves the constraint dormant rather than firing it, while silence about the target argument's is what convicts. Checked through genl transitivity from the writing context, like arg, and it entails the same way under assertive argument types.")
 (arity interArg 5)
+(fixed_arity_predicate interArg)
 (instance_relation_predicate interArg)
 (arg interArg 1 predicate)
 (arg interArg 2 positive_integer)
@@ -228,6 +229,48 @@
 (functional arity)
 (arg arity 1 predicate)
 (arg arity 2 non_negative_integer)
+
+(comment arityMin
+         "(arityMin ?relation ?n) means that ?relation requires at least ?n arguments. It is the numeric shape for a genuinely variable-arity relation: every further position normally repeats the same argument role rather than introducing an unnamed optional field. Every exact (arity R N) entails the matching minimum. No WFF reader consumes this declaration.")
+(binary_predicate arityMin)
+(instance_relation_predicate arityMin)
+(arg arityMin 1 relation)
+(arg arityMin 2 non_negative_integer)
+
+(implies
+ (and (arity ?relation ?arity))
+ (arityMin ?relation ?arity))
+
+(comment admitsArgnum
+         "(admitsArgnum ?relation ?argnum) means that positive argument position ?argnum exists in a well-formed application of ?relation. It asks about one position, not the application's total arity. No WFF or query reader consumes it.")
+(binary_predicate admitsArgnum)
+(instance_relation_predicate admitsArgnum)
+(arg admitsArgnum 1 relation)
+(arg admitsArgnum 2 positive_integer)
+
+(comment at_least_binary_relation
+         "The type of relations whose stated minimum arity is two or greater. Derived from arityMin, including the matching minimum entailed by an exact arity.")
+(unary_predicate at_least_binary_relation)
+(arg at_least_binary_relation 1 relation)
+(genl at_least_binary_relation relation)
+
+(comment at_least_ternary_relation
+         "The type of relations whose stated minimum arity is three or greater. Every such relation is also an at_least_binary_relation.")
+(unary_predicate at_least_ternary_relation)
+(arg at_least_ternary_relation 1 relation)
+(genl at_least_ternary_relation at_least_binary_relation)
+
+(implies
+ (and
+  (arityMin ?relation ?arity)
+  (greaterThan ?arity 1))
+ (at_least_binary_relation ?relation))
+
+(implies
+ (and
+  (arityMin ?relation ?arity)
+  (greaterThan ?arity 2))
+ (at_least_ternary_relation ?relation))
 
 ;; The meta-ontology rules below conclude into the ORDINARY placement — the maximal
 ;; context that sees the rule and the declaration — and not into a named one.  Every
@@ -545,6 +588,8 @@
          "(functionCorrespondingPredicate ?function ?predicate ?position) means that ?function and ?predicate state the same relationship: ?function maps some arguments to a value exactly when ?predicate holds of those same arguments with the value at ?position. So (functionCorrespondingPredicate MotherFn motherOf 2) makes (MotherFn Muffet) resolve to the Mary of a believed (motherOf Muffet Mary), and, where no mother is known, projects the placeholder constant it mints back onto motherOf so the placeholder still answers questions about who Muffet's mother is. Reading it both ways is what stops the function and the predicate from being one claim the KB can reason with only half of, and a value arriving after its application is equated with the placeholder, so the order the two are asserted in does not decide the answer. ?position is 1-based over ?predicate's arguments and may be omitted, which puts the value last — the shape nearly every correspondence has. Read only for a reifiable_function, an undeclared function having no application to reify. See docs/nat.md.")
 (binary_predicate functionCorrespondingPredicate)
 (variable_arity functionCorrespondingPredicate)
+(variable_arity_predicate functionCorrespondingPredicate)
+(arityMin functionCorrespondingPredicate 2)
 (arg functionCorrespondingPredicate 1 function)
 (arg functionCorrespondingPredicate 2 predicate)
 
@@ -637,7 +682,8 @@
 (instance_relation_predicate greaterThan)
 (arg greaterThan 1 thing)
 (arg greaterThan 2 thing)
-(variable_arity greaterThan)
+(variable_arity_predicate greaterThan)
+(arityMin greaterThan 2)
 
 (comment implies
          "(implies (and ?antecedent …) ?consequent) means the rule concluding ?consequent from those antecedents. A rule is a sentex like any other, so it gets a handle, truth maintenance and retraction for free, and it is indexed by its antecedent and its consequent predicates alike. Used forward and backward unless a set/*Rule wrapper narrows it. Range-restricted: every variable in the consequent must appear in an antecedent.")
@@ -672,7 +718,8 @@
 (instance_relation_predicate lessThan)
 (arg lessThan 1 thing)
 (arg lessThan 2 thing)
-(variable_arity lessThan)
+(variable_arity_predicate lessThan)
+(arityMin lessThan 2)
 
 (comment modal_predicate
          "(modal_predicate ?predicate) means that (?predicate ?agent ?sentence) is a belief-style projection: it holds when ?sentence holds in ?agent's context. A grant, and the only thing that turns projection on — an undeclared predicate is never projected, so the table is open (assert the marker to add knows / desires / intends) and closed by default to everything but what a context grants. Read scoped from the asking context, like abducible_predicate: which predicates a theory reads modally is a policy of the context that declares it, not a global switch. believes ships granted here.")
@@ -687,11 +734,14 @@
 (comment or
          "(or ?disjunct1 ?disjunct2 …) means the disjunction of the disjuncts inside an implies rule's antecedent. A syntactic connective rather than a predicate: it is never asserted on its own, and it never reaches a stored sentence — the rule is polycanonicalized into one rule per alternative, exactly as a conjunctive consequent is split into one rule per conjunct. A disjunctive conclusion is a choice rather than a derivation, and is written with set/assumptionRule instead. See docs/canonicalization.md.")
 
-(comment function            "The type of all functions — the reifiable and unreifiable heads a non-atomic term is built from. A function is a thing, and is not a predicate: it denotes or evaluates to a value where a predicate holds or fails.")
-(genl function thing)
+(comment relation            "The type of all predicates and functions — every head that may be applied to arguments. Its two specializations remain disjoint: a predicate holds or fails, while a function denotes or evaluates to a value.")
+(genl relation thing)
 
-(comment predicate           "The type of all predicates — the relations and types used in sentences. A predicate is a thing.")
-(genl predicate thing)
+(comment function            "The type of all functions — the reifiable and unreifiable heads a non-atomic term is built from. A function is a relation, and is not a predicate: it denotes or evaluates to a value where a predicate holds or fails.")
+(genl function relation)
+
+(comment predicate           "The type of all predicates — the relations and types used in sentences. A predicate is a relation.")
+(genl predicate relation)
 ;; What function's comment states in prose, as a fact the engine reads: the two are
 ;; separate kinds of thing. Every type is a unary_predicate and so a predicate, which is
 ;; what gives the separation its reach — a rule variable standing in a function-valued
@@ -870,10 +920,45 @@
 (arg typeToInstancePred 1 type_relation_predicate)
 (arg typeToInstancePred 2 instance_relation_predicate)
 
+(comment fixed_arity
+         "(fixed_arity ?relation) means that ?relation takes one exact number of arguments. Numeric exact arity is still stated separately; this type classifies the relation's argument policy without inventing a number.")
+(unary_predicate fixed_arity)
+(arg fixed_arity 1 relation)
+(genl fixed_arity relation)
+
+(comment fixed_arity_predicate
+         "The fixed_arity relations that are predicates.")
+(unary_predicate fixed_arity_predicate)
+(arg fixed_arity_predicate 1 predicate)
+(genl fixed_arity_predicate fixed_arity)
+(genl fixed_arity_predicate predicate)
+
+(comment fixed_arity_function
+         "The fixed_arity relations that are functions.")
+(unary_predicate fixed_arity_function)
+(arg fixed_arity_function 1 function)
+(genl fixed_arity_function fixed_arity)
+(genl fixed_arity_function function)
+
 (comment variable_arity
-         "(variable_arity ?predicate) means that ?predicate takes any number of arguments from its declared arity upward. The arity check does not hold it to one number, while its (arity ?predicate N) and N-ary predicate type still state the shape it reads as: lessThan is binary, and (lessThan 1 2 3) is the chain 1 < 2 < 3.")
+         "(variable_arity ?relation) means that ?relation does not take one exact number of arguments; arityMin states its lower bound. Prefer it for a repeatable, homogeneously typed argument role. A relation may explicitly define a bounded optional tail instead, as functionCorrespondingPredicate does. The arity check reads this generic type through specialization.")
 (unary_predicate variable_arity)
-(arg variable_arity 1 predicate)
+(arg variable_arity 1 relation)
+(genl variable_arity relation)
+
+(comment variable_arity_predicate
+         "The variable_arity relations that are predicates.")
+(unary_predicate variable_arity_predicate)
+(arg variable_arity_predicate 1 predicate)
+(genl variable_arity_predicate variable_arity)
+(genl variable_arity_predicate predicate)
+
+(comment variable_arity_function
+         "The variable_arity relations that are functions.")
+(unary_predicate variable_arity_function)
+(arg variable_arity_function 1 function)
+(genl variable_arity_function variable_arity)
+(genl variable_arity_function function)
 
 (comment unary_predicate      "A predicate of one argument: every type (a snake_case unary predicate) and every one-place property such as flies.")
 (genl unary_predicate predicate)
@@ -891,7 +976,8 @@
 (instance_relation_predicate termsRelated)
 (arg termsRelated 1 thing)
 (arg termsRelated 2 thing)
-(variable_arity termsRelated)
+(variable_arity_predicate termsRelated)
+(arityMin termsRelated 2)
 
 (comment seeAlso
          "(seeAlso ?term1 ?term2) means that ?term1 and ?term2 are worth reading together — an editorial 'see also' cross-reference between two terms. Directional: (seeAlso a b) points a reader from a to b, and the reverse is a separate assertion, not implied. Documentation only, like comment: nothing in the engine reads it and it draws no inference.")

--- a/resources/kb/CxCore.txt
+++ b/resources/kb/CxCore.txt
@@ -283,19 +283,16 @@
 (unary_predicate unary_function)
 (arg unary_function 1 function)
 (genl unary_function unary)
-(genl unary_function function)
 
 (comment binary_function "A function of exactly two arguments.")
 (unary_predicate binary_function)
 (arg binary_function 1 function)
 (genl binary_function binary)
-(genl binary_function function)
 
 (comment ternary_function "A function of exactly three arguments.")
 (unary_predicate ternary_function)
 (arg ternary_function 1 function)
 (genl ternary_function ternary)
-(genl ternary_function function)
 
 (comment relationTypeByArity
          "(relationTypeByArity ?type ?arity) maps a relation-wide exact-arity type to its arity. Its three declarations drive the shared arity/type rules.")
@@ -329,29 +326,19 @@
 (functionTypeByArity binary_function 2)
 (functionTypeByArity ternary_function 3)
 
-;; Predicate/function mappings specialize the relation-wide mapping extensionally.
-;; A genl edge is not the right level here: genl endpoints are types (unary predicates),
-;; while these three mappings are binary relations.  Ground rules state the complete
-;; six-member compatibility table without making the two subdomains unifiably overlap.
-(implies (and (predicateTypeByArity unary_predicate 1))
-         (relationTypeByArity unary_predicate 1))
-(implies (and (predicateTypeByArity binary_predicate 2))
-         (relationTypeByArity binary_predicate 2))
-(implies (and (predicateTypeByArity ternary_predicate 3))
-         (relationTypeByArity ternary_predicate 3))
-(implies (and (functionTypeByArity unary_function 1))
-         (relationTypeByArity unary_function 1))
-(implies (and (functionTypeByArity binary_function 2))
-         (relationTypeByArity binary_function 2))
-(implies (and (functionTypeByArity ternary_function 3))
-         (relationTypeByArity ternary_function 3))
+;; The predicate and function mappings are specializations of the relation-wide mapping:
+;; a genl edge between the predicates says so once, and every predicateTypeByArity or
+;; functionTypeByArity fact is thereby a relationTypeByArity fact.  No per-member
+;; compatibility table is needed.
+(genl predicateTypeByArity relationTypeByArity)
+(genl functionTypeByArity relationTypeByArity)
 
 (comment arity
          "(arity ?relation ?n) means that ?relation takes exactly ?n arguments and is fixed_arity. One maps to unary, two to binary and three to ternary; predicate and function specializations inherit those relation-wide classes.")
 (binary_predicate arity)
 (instance_relation_predicate arity)
 (functional arity)
-(arg arity 1 relation)
+(arg arity 1 fixed_arity)
 (arg arity 2 non_negative_integer)
 
 (comment arityMin
@@ -360,8 +347,6 @@
 (instance_relation_predicate arityMin)
 (arg arityMin 1 relation)
 (arg arityMin 2 non_negative_integer)
-
-(implies (and (arity ?relation ?arity)) (fixed_arity ?relation))
 
 (comment admitsArgnum
          "(admitsArgnum ?relation ?argnum) means that positive argument position ?argnum exists in a well-formed application of ?relation. It asks about one position, not the application's total arity. No WFF or query reader consumes it.")
@@ -403,20 +388,12 @@
 ;; same context — answered false.  One KB cannot say both.
 
 ;; relationTypeByArity is the one rule-bearing family.  Predicate and function mappings
-;; specialize its facts rather than carrying parallel arity/type rules.
-(implies (and (relationTypeByArity unary 1) (arity ?relation 1))
-         (unary ?relation))
-(implies (and (relationTypeByArity binary 2) (arity ?relation 2))
-         (binary ?relation))
-(implies (and (relationTypeByArity ternary 3) (arity ?relation 3))
-         (ternary ?relation))
-
-(implies (and (relationTypeByArity unary 1) (unary ?relation))
-         (arity ?relation 1))
-(implies (and (relationTypeByArity binary 2) (binary ?relation))
-         (arity ?relation 2))
-(implies (and (relationTypeByArity ternary 3) (ternary ?relation))
-         (arity ?relation 3))
+;; are its genl specializations rather than parallel arity/type rules, so one rule
+;; covers every exact-arity type in either subdomain: a relation classified under a type
+;; that maps to an arity has that arity.  The converse (an exact arity classifying the
+;; relation under the type) is not stated; exact arity is declared through the type.
+(implies (and (relationTypeByArity ?type ?arity) (?type ?relation))
+         (arity ?relation ?arity))
 
 ;; The three relation-wide classifications separate each other: a relation takes ONE
 ;; exact number of arguments, so a second classification is a contradiction rather than
@@ -424,15 +401,11 @@
 ;; two exact classes would derive two arities, and (functional arity) would otherwise
 ;; convict a clash the class declarations had already made.
 ;;
-;; The predicate specializations remain explicitly pairwise disjoint too, and NOT via a
-;; (sibling_disjoint predicate) mark: predicate's specializations include many compatible
-;; classifications.  The three pairs say only that one predicate cannot have two exact
-;; arities.  Their separation closes down the predicate hierarchy, so functional,
-;; symmetric, transitive and every other binary_predicate subtype remain separated from
-;; unary_predicate and ternary_predicate.
-(disjoint unary_predicate binary_predicate)
-(disjoint unary_predicate ternary_predicate)
-(disjoint binary_predicate ternary_predicate)
+;; The predicate and function specializations inherit that separation through their genl
+;; edges to the relation-wide classes (unary_predicate genl unary, and so on): restating
+;; the three predicate pairs here would only duplicate it.  Nothing marks predicate as
+;; (sibling_disjoint predicate) — its specializations include many compatible
+;; classifications, and only the exact-arity classes exclude one another.
 (disjoint unary binary)
 (disjoint unary ternary)
 (disjoint binary ternary)
@@ -446,7 +419,6 @@
 (modal_predicate believes)
 
 (comment binary_predicate     "A predicate of two arguments — a relation such as parentOf.")
-(genl binary_predicate predicate)
 
 (comment comment
          "(comment ?term ?text) means that ?text documents ?term. Ordinary sentexes, so the KB documents itself in its own representation and a comment is queried, retracted and justified like anything else. Written as a signature and a definition, as this one is, so that first clause doubles as the template an English gloss of any (?term …) sentence is composed from; everything after it is prose for a reader and no machine reads it.")
@@ -863,7 +835,7 @@
 (comment or
          "(or ?disjunct1 ?disjunct2 …) means the disjunction of the disjuncts inside an implies rule's antecedent. A syntactic connective rather than a predicate: it is never asserted on its own, and it never reaches a stored sentence — the rule is polycanonicalized into one rule per alternative, exactly as a conjunctive consequent is split into one rule per conjunct. A disjunctive conclusion is a choice rather than a derivation, and is written with set/assumptionRule instead. See docs/canonicalization.md.")
 
-(comment relation            "The type of all predicates and functions — every head that may be applied to arguments. Its two specializations remain disjoint: a predicate holds or fails, while a function denotes or evaluates to a value.")
+(comment relation            "The type of all predicates and functions — every operator that may be applied to arguments. Its two specializations remain disjoint: a predicate holds or fails, while a function denotes or evaluates to a value.")
 (genl relation thing)
 
 (comment function            "The type of all functions — the reifiable and unreifiable heads a non-atomic term is built from. A function is a relation, and is not a predicate: it denotes or evaluates to a value where a predicate holds or fails.")
@@ -963,7 +935,6 @@
 (arg transitiveInArgInverse 3 predicate)
 
 (comment ternary_predicate    "A predicate of three arguments, such as arg.")
-(genl ternary_predicate predicate)
 
 (comment target_following_predicate
          "(target_following_predicate ?predicate) means a (?predicate … (sentexHandle H) …) sentence is a meta-sentex that names sentex H and must not outlive it: retracting H retracts the meta with it (core/retract-following-metas!). Opt-in and belief-following — the engine's own except / exceptWhen deliberately do not carry it, so their orphan-on-retraction behavior is unchanged. koinii's reply acts declare it, so retracting a claim cascades to the replies about it, which a message bus cannot do.")
@@ -1050,7 +1021,6 @@
 (arg typeToInstancePred 2 instance_relation_predicate)
 
 (comment unary_predicate      "A predicate of one argument: every type (a snake_case unary predicate) and every one-place property such as flies.")
-(genl unary_predicate predicate)
 (genl unary_predicate unary)
 (genl unary_predicate fixed_arity_predicate)
 

--- a/resources/kb/CxCore.txt
+++ b/resources/kb/CxCore.txt
@@ -51,38 +51,38 @@
          "(and ?antecedent1 ?antecedent2 …) means the conjunction of the antecedents inside an implies rule. A syntactic connective rather than a predicate: it is never asserted on its own, and a rule with a single antecedent needs no and at all.")
 
 (comment genlArg
-         "(genlArg ?predicate ?position ?type) means that argument ?position of ?predicate must be a subtype of ?type. The arg constraint one level up, for a type_relation_predicate whose arguments name kinds rather than instances: (genlArg partType 1 physical_object) says the argument names a kind of physical object, where (arg partOf 1 physical_object) says it names one. Open-world, so an argument with no place in the genl hierarchy cannot violate it.")
+         "(genlArg ?relation ?position ?type) means that argument ?position of ?relation must be a subtype of ?type. The arg constraint one level up, for arguments naming kinds rather than instances: (genlArg partType 1 physical_object) says the argument names a kind of physical object, where (arg partOf 1 physical_object) says it names one. Open-world, so an argument with no place in the genl hierarchy cannot violate it. Relation-wide vocabulary; the current function-input enforcement boundary is documented in docs/argtypes.md.")
 (ternary_predicate genlArg)
-(arg genlArg 1 predicate)
+(arg genlArg 1 relation)
 (arg genlArg 2 positive_integer)
 (genlArg genlArg 3 thing)
 
 (comment arg
-         "(arg ?predicate ?position ?type) means that argument ?position of ?predicate must be of ?type. Checked through genl transitivity whenever a sentex is asserted, and open-world: an argument whose type is unknown cannot violate it, so this narrows what can be said without demanding that everything be typed.")
+         "(arg ?relation ?position ?type) means that argument ?position of ?relation must be of ?type. Its domain includes predicates and functions. Checked through genl transitivity whenever a sentex is asserted, and open-world: an argument whose type is unknown cannot violate it, so this narrows what can be said without demanding that everything be typed.")
 (ternary_predicate arg)
-(arg arg 1 predicate)
+(arg arg 1 relation)
 (arg arg 2 positive_integer)
 (genlArg arg 3 thing)
 (comment arg1
-         "(arg1 ?predicate ?type) means that argument 1 of ?predicate must be of ?type — the binary projection of (arg ?predicate 1 ?type), created so a positional argument constraint can itself stand in the subject position of a binary declaration such as (predAllSpecified arg1 predicate). The two spellings are bridged by rules in both directions and held to the same declaration checks at assert, so either may be asserted and both STORED spellings are believed. The projection relates stored declarations only: a reading arg answers through genl generalization or super-predicate inheritance has no argN twin, so a generalized or inherited question must be asked of arg itself. arg2 and arg3 project positions 2 and 3 the same way.")
+         "(arg1 ?relation ?type) means that argument 1 of ?relation must be of ?type — the binary projection of (arg ?relation 1 ?type), created so a positional argument constraint can itself stand in the subject position of a binary declaration such as (predAllSpecified arg1 relation). The two spellings are bridged by rules in both directions and held to the same declaration checks at assert, so either may be asserted and both STORED spellings are believed. The projection relates stored declarations only: a reading arg answers through genl generalization or super-predicate inheritance has no argN twin, so a generalized or inherited question must be asked of arg itself. arg2 and arg3 project positions 2 and 3 the same way.")
 (binary_predicate arg1)
-(arg arg1 1 predicate)
+(arg arg1 1 relation)
 (genlArg arg1 2 thing)
 (implies (and (arg1 ?reln ?type)) (arg ?reln 1 ?type))
 (implies (and (arg ?reln 1 ?type)) (arg1 ?reln ?type))
 
 (comment arg2
-         "(arg2 ?predicate ?type) is the binary projection of (arg ?predicate 2 ?type) — see arg1.")
+         "(arg2 ?relation ?type) is the binary projection of (arg ?relation 2 ?type) — see arg1.")
 (binary_predicate arg2)
-(arg arg2 1 predicate)
+(arg arg2 1 relation)
 (genlArg arg2 2 thing)
 (implies (and (arg2 ?reln ?type)) (arg ?reln 2 ?type))
 (implies (and (arg ?reln 2 ?type)) (arg2 ?reln ?type))
 
 (comment arg3
-         "(arg3 ?predicate ?type) is the binary projection of (arg ?predicate 3 ?type) — see arg1.")
+         "(arg3 ?relation ?type) is the binary projection of (arg ?relation 3 ?type) — see arg1.")
 (binary_predicate arg3)
-(arg arg3 1 predicate)
+(arg arg3 1 relation)
 (genlArg arg3 2 thing)
 (implies (and (arg3 ?reln ?type)) (arg ?reln 3 ?type))
 (implies (and (arg ?reln 3 ?type)) (arg3 ?reln ?type))
@@ -96,9 +96,9 @@
 ;; stays a plain fact (a sub-predicate may carry its own signature).
 
 (comment quotedArg
-         "(quotedArg ?predicate ?position ?type) means that argument ?position of ?predicate, taken AS A TERM — the syntactic object written in that position, not what it denotes — must be of ?type. The mention twin of arg: (arg name_of_guy 1 agent) types what the first argument names, (quotedArg name_of_guy 1 string) types the argument itself, the value sitting there. Its ?type is a syntactic type — string, number (with integer below it), symbol — and the argument is classified by its EDN kind, then checked through genl like arg. Closed about a value whose kind is decidable: (name_of_guy 5) violates (quotedArg name_of_guy 1 string), 5 being a number and not a string. It does not read the referent's type, which is arg's business.")
+         "(quotedArg ?relation ?position ?type) means that argument ?position of ?relation, taken AS A TERM — the syntactic object written in that position, not what it denotes — must be of ?type. The mention twin of arg: (arg name_of_guy 1 agent) types what the first argument names, (quotedArg name_of_guy 1 string) types the argument itself, the value sitting there. Its ?type is a syntactic type — string, number (with integer below it), symbol — and the argument is classified by its EDN kind, then checked through genl like arg. Closed about a value whose kind is decidable: (name_of_guy 5) violates (quotedArg name_of_guy 1 string), 5 being a number and not a string. It does not read the referent's type, which is arg's business. Relation-wide vocabulary; the current function-input enforcement boundary is documented in docs/argtypes.md.")
 (ternary_predicate quotedArg)
-(arg quotedArg 1 predicate)
+(arg quotedArg 1 relation)
 (arg quotedArg 2 positive_integer)
 (genlArg quotedArg 3 thing)
 
@@ -212,11 +212,11 @@
 (disjoint atomic_formula non_atomic_term)
 
 (comment interArg
-         "(interArg ?predicate ?position1 ?type1 ?position2 ?type2) means that whenever argument ?position1 of ?predicate is a ?type1, argument ?position2 must be a ?type2. The conditional argument constraint, and it says what arg cannot: (interArg eats 1 carnivore 2 meat) types the second argument only for the eaters that are carnivores, where (arg eats 2 meat) would demand meat of every eater. Open-world in both directions, and they point opposite ways — silence about the trigger argument's type leaves the constraint dormant rather than firing it, while silence about the target argument's is what convicts. Checked through genl transitivity from the writing context, like arg, and it entails the same way under assertive argument types.")
+         "(interArg ?relation ?position1 ?type1 ?position2 ?type2) means that whenever argument ?position1 of ?relation is a ?type1, argument ?position2 must be a ?type2. The conditional argument constraint, and it says what arg cannot: (interArg eats 1 carnivore 2 meat) types the second argument only for the eaters that are carnivores, where (arg eats 2 meat) would demand meat of every eater. Open-world in both directions, and they point opposite ways — silence about the trigger argument's type leaves the constraint dormant rather than firing it, while silence about the target argument's is what convicts. Checked through genl transitivity from the writing context, like arg, and it entails the same way under assertive argument types. Relation-wide vocabulary; the current function-input enforcement boundary is documented in docs/argtypes.md.")
 (arity interArg 5)
 (fixed_arity_predicate interArg)
 (instance_relation_predicate interArg)
-(arg interArg 1 predicate)
+(arg interArg 1 relation)
 (arg interArg 2 positive_integer)
 (arg interArg 3 unary_predicate)
 (arg interArg 4 positive_integer)
@@ -338,8 +338,10 @@
 (binary_predicate arity)
 (instance_relation_predicate arity)
 (functional arity)
-(arg arity 1 fixed_arity)
+(arg arity 1 relation)
 (arg arity 2 non_negative_integer)
+
+(implies (arity ?relation ?arity) (fixed_arity ?relation))
 
 (comment arityMin
          "(arityMin ?relation ?n) means that a variable-arity ?relation requires at least ?n arguments. Every further position normally repeats the same argument role rather than introducing an unnamed optional field. No WFF reader consumes this declaration.")

--- a/resources/kb/CxCore.txt
+++ b/resources/kb/CxCore.txt
@@ -388,12 +388,16 @@
 ;; same context — answered false.  One KB cannot say both.
 
 ;; relationTypeByArity is the one rule-bearing family.  Predicate and function mappings
-;; are its genl specializations rather than parallel arity/type rules, so one rule
+;; are its genl specializations rather than parallel arity/type rules, so one statement
 ;; covers every exact-arity type in either subdomain: a relation classified under a type
-;; that maps to an arity has that arity.  The converse (an exact arity classifying the
-;; relation under the type) is not stated; exact arity is declared through the type.
-(implies (and (relationTypeByArity ?type ?arity) (?type ?relation))
-         (arity ?relation ?arity))
+;; that maps to an arity has that arity.  It is a generator (docs/generators.md): the
+;; rule index is keyed by predicate, so (?type ?relation) cannot stand as a top-level
+;; antecedent, but as a hole the enclosing antecedent fills it is ground before the
+;; per-type rule is stamped — one minted rule per mapping fact, justified by that fact
+;; and withdrawn with it.  The converse (an exact arity classifying the relation under
+;; the type) is not stated; exact arity is declared through the type.
+(implies (relationTypeByArity ?type ?arity)
+         (implies (?type ?relation) (arity ?relation ?arity)))
 
 ;; The three relation-wide classifications separate each other: a relation takes ONE
 ;; exact number of arguments, so a second classification is a contradiction rather than

--- a/resources/kb/upper/CxLife.txt
+++ b/resources/kb/upper/CxLife.txt
@@ -66,6 +66,7 @@
 (comment FatherFn
          "(FatherFn ?animal) means the father of ?animal. A reifiable_function, so a ground application denotes an object rather than being computed, and it reifies to an opaque constant before it reaches the index. Corresponding to fatherOf is what keeps it from minting a second name for a father the KB already knows: (FatherFn Muffet) resolves to the father of a believed (fatherOf Muffet F). Where none is known it mints a placeholder and projects that back onto fatherOf, so the placeholder still answers whose father it is, and a father arriving later is equated with it. See docs/nat.md.")
 (reifiable_function FatherFn)
+(unary_function FatherFn)
 (functionCorrespondingPredicate FatherFn fatherOf)
 (result FatherFn animal)
 
@@ -128,6 +129,7 @@
 (comment MotherFn
          "(MotherFn ?animal) means the mother of ?animal. The same shape as FatherFn, over motherOf.")
 (reifiable_function MotherFn)
+(unary_function MotherFn)
 (functionCorrespondingPredicate MotherFn motherOf)
 (result MotherFn animal)
 

--- a/resources/kb/upper/CxMeasure.txt
+++ b/resources/kb/upper/CxMeasure.txt
@@ -145,6 +145,7 @@
 (comment QuantityFn
          "(QuantityFn ?magnitude ?unit) means the measure of ?magnitude ?unit. So (QuantityFn 5 Kilogram) is five kilograms. An unreifiable_function application, a structural NAT: it stays structural instead of being minted into an opaque constant, so the magnitude and the unit are still readable inside the sentence, and the quantity provers normalize it through the dimensionOf and conversionFactor facts.")
 (unreifiable_function QuantityFn)
+(binary_function QuantityFn)
 
 (comment quantityGreaterThan
          "(quantityGreaterThan ?measure1 ?measure2) means that ?measure1 is greater than ?measure2 once both are normalized to their dimension's base unit. Necessarily greater, so for intervals all of ?measure1 must lie strictly above all of ?measure2. Computed by a prover and never stored; two measures of different dimensions are not comparable rather than unequal.")
@@ -163,6 +164,7 @@
 (comment QuantityIntervalFn
          "(QuantityIntervalFn ?lo ?hi ?unit) means the measure lying somewhere between ?lo and ?hi ?unit. So (QuantityIntervalFn 1 2 Meter) is between one and two metres. An unreifiable_function application like QuantityFn, and compared under the necessary reading: a claim holds of the interval only when it holds of every value in it.")
 (unreifiable_function QuantityIntervalFn)
+(ternary_function QuantityIntervalFn)
 
 (comment quantityLessThan
          "(quantityLessThan ?measure1 ?measure2) means that ?measure1 is less than ?measure2 once both are normalized to their dimension's base unit. Necessarily less, so for intervals all of ?measure1 must lie strictly below all of ?measure2. Computed by a prover and never stored; two measures of different dimensions are not comparable rather than unequal.")

--- a/resources/kb/upper/CxTime.txt
+++ b/resources/kb/upper/CxTime.txt
@@ -122,6 +122,7 @@
 (comment DayFn
          "(DayFn ?year ?month ?day) means the calendar day, as an interval — so (DayFn 2000 1 15) is the fifteenth of January 2000. An unreifiable_function application like YearFn and MonthFn: it stays structural, so the three fields are readable inside the term and a reader can see that the day sits inside its month. One field per argument, coarsest first, so the arity is the precision. See docs/context-nat.md.")
 (unreifiable_function DayFn)
+(ternary_function DayFn)
 (result DayFn temporal_thing)
 
 (comment during
@@ -211,6 +212,7 @@
 (comment InstantFn
          "(InstantFn ?year ?month ?day ?hour ?minute ?second) means the moment those six calendar fields name, so (InstantFn 2000 1 1 0 0 0) is midnight at the start of 2000. A time_point and not a temporal_thing: YearFn, MonthFn and DayFn name stretches, and this names the moments one of them lies between. Six fields always — its arity is not its precision — so every moment has exactly one spelling, which is what makes the end of one year and the start of the next the same term. An unreifiable_function application like the calendar constructors, structural so the fields stay readable. What startOf and endOf answer for a calendar term, computed and never stored. See docs/time.md.")
 (unreifiable_function InstantFn)
+(fixed_arity_function InstantFn)
 (result InstantFn time_point)
 
 (comment instantNotAfter
@@ -265,6 +267,7 @@
 (comment MonthFn
          "(MonthFn ?year ?month) means the calendar month, as an interval — so (MonthFn 2000 1) is January 2000, and ?month is 1 through 12. An unreifiable_function application like YearFn and DayFn, structural so the ordering can read its fields: January 2000 is inside 2000, and February is inside neither January nor itself twice over. See docs/context-nat.md.")
 (unreifiable_function MonthFn)
+(binary_function MonthFn)
 (result MonthFn temporal_thing)
 
 (comment overlapDuration
@@ -375,4 +378,5 @@
 (comment YearFn
          "(YearFn ?year) means the calendar year, as an interval — so (YearFn 2000) is the whole of 2000. The coarsest of the three calendar constructors (with MonthFn and DayFn beneath it), and an unreifiable_function application: it stays structural rather than minting a constant, because its one field is what says which years contain which. A calendar term and the reduced-precision ISO string naming the same interval denote the same interval and order against each other. See docs/context-nat.md.")
 (unreifiable_function YearFn)
+(unary_function YearFn)
 (result YearFn temporal_thing)

--- a/resources/kb/upper/CxTime.txt
+++ b/resources/kb/upper/CxTime.txt
@@ -213,6 +213,7 @@
          "(InstantFn ?year ?month ?day ?hour ?minute ?second) means the moment those six calendar fields name, so (InstantFn 2000 1 1 0 0 0) is midnight at the start of 2000. A time_point and not a temporal_thing: YearFn, MonthFn and DayFn name stretches, and this names the moments one of them lies between. Six fields always — its arity is not its precision — so every moment has exactly one spelling, which is what makes the end of one year and the start of the next the same term. An unreifiable_function application like the calendar constructors, structural so the fields stay readable. What startOf and endOf answer for a calendar term, computed and never stored. See docs/time.md.")
 (unreifiable_function InstantFn)
 (fixed_arity_function InstantFn)
+(arity InstantFn 6)
 (result InstantFn time_point)
 
 (comment instantNotAfter

--- a/resources/kb/upper/CxTime.txt
+++ b/resources/kb/upper/CxTime.txt
@@ -214,6 +214,12 @@
 (unreifiable_function InstantFn)
 (fixed_arity_function InstantFn)
 (arity InstantFn 6)
+(arg InstantFn 1 integer)
+(arg InstantFn 2 integer)
+(arg InstantFn 3 integer)
+(arg InstantFn 4 integer)
+(arg InstantFn 5 integer)
+(arg InstantFn 6 integer)
 (result InstantFn time_point)
 
 (comment instantNotAfter

--- a/src/vaelii/impl/checks.clj
+++ b/src/vaelii/impl/checks.clj
@@ -807,8 +807,8 @@
 
   Open-world in the same shape as `arg`: a predicate the KB has never declared can
   be used at any arity, since the declaration may simply not have arrived.  A
-  `variable_arity` predicate is exempt outright — `lessThan` is declared binary *and*
-  reads a chain of any length, and the declaration is what says so.
+  `variable_arity` predicate is exempt outright — `lessThan` has a binary floor and
+  reads a chain of any length, and the declarations are what say so.
 
   The binding arity **descends the predicate hierarchy** where the predicate declares
   none of its own (`inherited-arity`): a `fatherOf` tuple is a `parentOf` tuple, so its

--- a/src/vaelii/impl/predicates.clj
+++ b/src/vaelii/impl/predicates.clj
@@ -551,6 +551,20 @@
                                       " sweep that decides from one that only names.")}
                        (str "checks/arity-problem at the entry point, settle/report-arity-reach! over"
                             " content stored before it"))]
+     ['arityMin
+      (enforced {:shape {:args [:relation :integer]} :storage [:none] :checked false
+                 :family nil :facets #{}
+                 :notes (str "ordinary CxCore rules make exact arity entail the same minimum and"
+                             " derive the at_least_*_relation classifications. No WFF"
+                             " or constraint reader consumes the declaration.")}
+                "ordinary rule inference in CxCore; no WFF/constraint reader")]
+     ['admitsArgnum
+      (inert {:shape {:args [:relation :position]} :storage [:none] :checked false
+              :family nil :facets #{}
+              :notes (str "names whether one positive argument position exists in a"
+                          " well-formed application. No finite facts or parallel"
+                          " inference are installed; no WFF/query reader consumes it.")}
+             "documentary position question with no runtime reader")]
      ['functionalInArg {:shape   {:args [:predicate :position]}
                         :storage [:pred-position :functional-in-arg]
                         :checked true
@@ -846,11 +860,15 @@
     ;; ---- the hierarchy roots and the meta-level targets -------------------
     [['thing     (enforced (collection :notes "the hierarchy root the open-world floors test against by name.")
                            "checks — the hierarchy root the open-world floors test against by name")]
+     ['relation  (enforced (collection :notes "the common arg target for predicates and functions.")
+                           (str "generic: the common parent of predicate and function, and the"
+                                " arg target for relation-wide arity vocabulary"))]
      ['predicate (enforced (collection :notes "the arg target CxCore constrains its own meta-level with.")
-                           "generic: the arg target CxCore constrains its own meta-level with")]
+                           "generic: the predicate specialization of relation")]
      ['function  (enforced (collection :notes "the arg target the function-valued positions name.")
-                           (str "generic: the arg target the function-valued positions of result,"
-                                " genlResult and functionCorrespondingPredicate name"))]
+                           (str "generic: the function specialization of relation and the arg"
+                                " target the function-valued positions of result, genlResult"
+                                " and functionCorrespondingPredicate name"))]
 
      ;; ---- the predicate types --------------------------------------------
      ['unary_predicate   (enforced (collection :facets #{:convicts :reach}
@@ -871,6 +889,18 @@
                                    (str "checks/predicate-type-arities — the membership spelling of an arity;"
                                         " plus its disjointness with the other two classes, so a predicate is at"
                                         " most one of the three"))]
+     ['fixed_arity       (enforced (collection
+                                    :notes (str "classifies one exact argument policy without"
+                                                " inventing its numeric arity. No CxCore rule"
+                                                " derives this classification from arity; the two"
+                                                " declarations remain independent."))
+                                   "generic taxonomy classification; no keyed runtime reader")]
+     ['fixed_arity_predicate
+      (enforced (collection :notes "the predicate specialization of fixed_arity.")
+                "generic taxonomy classification under fixed_arity and predicate")]
+     ['fixed_arity_function
+      (enforced (collection :notes "the function specialization of fixed_arity.")
+                "generic taxonomy classification under fixed_arity and function")]
      ['variable_arity    (enforced (collection
                                     :notes (str "the one *exemption* from the arity check — it"
                                                 " un-convicts, which is why it carries no facet at"
@@ -878,6 +908,22 @@
                                                 " a term causes, and none names something it"
                                                 " prevents."))
                                    "checks/arity-problem — the one exemption from the arity check")]
+     ['variable_arity_predicate
+      (enforced (collection
+                 :notes (str "the predicate specialization of variable_arity; the arity"
+                             " check reads the generic superclass through taxonomy closure."))
+                "checks/arity-problem through inherited variable_arity membership")]
+     ['variable_arity_function
+      (enforced (collection
+                 :notes (str "the function specialization of variable_arity; it shares the"
+                             " relation-wide taxonomy. No function WFF reader consumes it."))
+                "generic taxonomy classification under variable_arity and function")]
+     ['at_least_binary_relation
+      (enforced (collection :notes "derived by a CxCore rule from arityMin greater than one.")
+                "ordinary CxCore rule inference from arityMin")]
+     ['at_least_ternary_relation
+      (enforced (collection :notes "derived by a CxCore rule from arityMin greater than two.")
+                "ordinary CxCore rule inference from arityMin")]
      ['relation_kind     (enforced (collection :notes "a disjoint_metatype, so its two members separate each other.")
                                    "generic: a disjoint_metatype, so its two members separate each other")]
      ['instance_relation_predicate

--- a/src/vaelii/impl/predicates.clj
+++ b/src/vaelii/impl/predicates.clj
@@ -554,10 +554,25 @@
      ['arityMin
       (enforced {:shape {:args [:relation :integer]} :storage [:none] :checked false
                  :family nil :facets #{}
-                 :notes (str "ordinary CxCore rules make exact arity entail the same minimum and"
-                             " derive the at_least_*_relation classifications. No WFF"
+                 :notes (str "ordinary CxCore rules derive the at_least_*_relation"
+                             " classifications. No WFF"
                              " or constraint reader consumes the declaration.")}
                 "ordinary rule inference in CxCore; no WFF/constraint reader")]
+     ['relationTypeByArity
+      (enforced {:shape {:args [:type :integer]} :storage [:none] :checked false
+                 :family nil :facets #{}
+                 :notes "the three relation-wide mappings are the premises of the shared exact-arity rules."}
+                "ordinary CxCore rules map exact arities to relation-wide types and back")]
+     ['predicateTypeByArity
+      (enforced {:shape {:args [:type :integer]} :storage [:none] :checked false
+                 :family nil :facets #{}
+                 :notes "ordinary CxCore inference projects this predicate-specific mapping into relationTypeByArity."}
+                "ordinary CxCore specialization rule into relationTypeByArity")]
+     ['functionTypeByArity
+      (enforced {:shape {:args [:type :integer]} :storage [:none] :checked false
+                 :family nil :facets #{}
+                 :notes "ordinary CxCore inference projects this function-specific mapping into relationTypeByArity."}
+                "ordinary CxCore specialization rule into relationTypeByArity")]
      ['admitsArgnum
       (inert {:shape {:args [:relation :position]} :storage [:none] :checked false
               :family nil :facets #{}
@@ -870,6 +885,13 @@
                                 " target the function-valued positions of result, genlResult"
                                 " and functionCorrespondingPredicate name"))]
 
+     ['unary   (enforced (collection :notes "the relation-wide exact-one-argument type.")
+                         "ordinary CxCore relationTypeByArity rules")]
+     ['binary  (enforced (collection :notes "the relation-wide exact-two-argument type.")
+                         "ordinary CxCore relationTypeByArity rules")]
+     ['ternary (enforced (collection :notes "the relation-wide exact-three-argument type.")
+                         "ordinary CxCore relationTypeByArity rules")]
+
      ;; ---- the predicate types --------------------------------------------
      ['unary_predicate   (enforced (collection :facets #{:convicts :reach}
                                                :notes (str "the membership spelling of an arity —"
@@ -889,12 +911,20 @@
                                    (str "checks/predicate-type-arities — the membership spelling of an arity;"
                                         " plus its disjointness with the other two classes, so a predicate is at"
                                         " most one of the three"))]
+     ['unary_function
+      (enforced (collection :notes "the function specialization of unary.")
+                "generic taxonomy classification under unary and function")]
+     ['binary_function
+      (enforced (collection :notes "the function specialization of binary.")
+                "generic taxonomy classification under binary and function")]
+     ['ternary_function
+      (enforced (collection :notes "the function specialization of ternary.")
+                "generic taxonomy classification under ternary and function")]
      ['fixed_arity       (enforced (collection
-                                    :notes (str "classifies one exact argument policy without"
-                                                " inventing its numeric arity. No CxCore rule"
-                                                " derives this classification from arity; the two"
-                                                " declarations remain independent."))
-                                   "generic taxonomy classification; no keyed runtime reader")]
+                                    :notes (str "classifies one exact argument policy; exact"
+                                                " arity declarations and the unary/binary/ternary"
+                                                " families specialize it."))
+                                   "generic taxonomy classification and ordinary CxCore arity rule")]
      ['fixed_arity_predicate
       (enforced (collection :notes "the predicate specialization of fixed_arity.")
                 "generic taxonomy classification under fixed_arity and predicate")]

--- a/src/vaelii/impl/predicates.clj
+++ b/src/vaelii/impl/predicates.clj
@@ -561,18 +561,18 @@
      ['relationTypeByArity
       (enforced {:shape {:args [:type :integer]} :storage [:none] :checked false
                  :family nil :facets #{}
-                 :notes "the three relation-wide mappings are the premises of the shared exact-arity rules."}
-                "ordinary CxCore rules map exact arities to relation-wide types and back")]
+                 :notes "the relation-wide mappings are the premises of the one shared rule that derives a relation's exact arity from its type."}
+                "one ordinary CxCore rule derives exact arity from the relation-wide types")]
      ['predicateTypeByArity
       (enforced {:shape {:args [:type :integer]} :storage [:none] :checked false
                  :family nil :facets #{}
-                 :notes "ordinary CxCore inference projects this predicate-specific mapping into relationTypeByArity."}
-                "ordinary CxCore specialization rule into relationTypeByArity")]
+                 :notes "a genl specialization of relationTypeByArity; its facts are relationTypeByArity facts by ordinary CxCore inference."}
+                "genl specialization of relationTypeByArity")]
      ['functionTypeByArity
       (enforced {:shape {:args [:type :integer]} :storage [:none] :checked false
                  :family nil :facets #{}
-                 :notes "ordinary CxCore inference projects this function-specific mapping into relationTypeByArity."}
-                "ordinary CxCore specialization rule into relationTypeByArity")]
+                 :notes "a genl specialization of relationTypeByArity; its facts are relationTypeByArity facts by ordinary CxCore inference."}
+                "genl specialization of relationTypeByArity")]
      ['admitsArgnum
       (inert {:shape {:args [:relation :position]} :storage [:none] :checked false
               :family nil :facets #{}

--- a/src/vaelii/impl/predicates.clj
+++ b/src/vaelii/impl/predicates.clj
@@ -561,8 +561,8 @@
      ['relationTypeByArity
       (enforced {:shape {:args [:type :integer]} :storage [:none] :checked false
                  :family nil :facets #{}
-                 :notes "the relation-wide mappings are the premises of the one shared rule that derives a relation's exact arity from its type."}
-                "one ordinary CxCore rule derives exact arity from the relation-wide types")]
+                 :notes "the relation-wide mappings are the premises of one CxCore generator that stamps, per mapping fact, the rule deriving a relation's exact arity from its type."}
+                "one CxCore generator stamps the per-type exact-arity rules")]
      ['predicateTypeByArity
       (enforced {:shape {:args [:type :integer]} :storage [:none] :checked false
                  :family nil :facets #{}

--- a/src/vaelii/impl/quality.clj
+++ b/src/vaelii/impl/quality.clj
@@ -386,18 +386,22 @@
   the reading means the same on a corpus that never heard of `thing`.
 
   The denominator is every type-shaped name in the vocabulary, which by `docs/naming.md`
-  includes a bare lowercase word (`likes` is a legal predicate *and* a legal type name;
-  arity decides and the index does not record arity).  That is why the gap is the finding
-  rather than either fraction on its own.
+  includes a bare lowercase word (`likes` is a legal predicate *and* a legal type name).
+  A unique declared arity other than one excludes a known non-unary predicate; unknown
+  or conflicting arities remain candidates rather than hiding disconnected type islands.
+  That is why the gap is the finding rather than either fraction on its own.
 
   Reachability is **reflexive**, as `genls` is: the root reaches itself, so `:rooted`
   counts it and `:islands` is exactly the edged types outside the root's ancestor set."
   [kb pass progress!]
   (let [taxo  (:taxonomy kb)
-        nodes (tax/types taxo)
-        named (:type-names pass)]
+        type-candidate? (fn [name]
+                          (let [arity (tax/declared-arity taxo name)]
+                            (or (nil? arity) (= 1 arity))))
+        nodes (into #{} (filter type-candidate?) (tax/types taxo))
+        named (into #{} (filter type-candidate?) (:type-names pass))]
     (progress! {:phase :taxonomy :done 0 :total (count nodes)})
-    (let [reach (frequencies (mapcat #(tax/genls-global taxo %) nodes))
+    (let [reach (frequencies (mapcat #(filter type-candidate? (tax/genls-global taxo %)) nodes))
           [root rooted] (first (sort-by (juxt (comp - val) (comp nm/print-key key)) reach))]
       {:names   (count (into named nodes))
        :edged   (count nodes)

--- a/src/vaelii/impl/starter.clj
+++ b/src/vaelii/impl/starter.clj
@@ -67,8 +67,7 @@
   (:require [vaelii.core :as v]
             [vaelii.impl.core-context :as core-context]
             [vaelii.impl.naming :as nm]
-            [vaelii.impl.seed :as seed]
-            [vaelii.impl.taxonomy :as tax]))
+            [vaelii.impl.seed :as seed]))
 
 (defn load-into
   "Populate `kb` with the starter schema — every context under resources/kb/, loaded
@@ -77,8 +76,8 @@
   (core-context/load-into kb)                                       ; CxCore.txt: the vocabulary head
   (seed/load-layer kb "upper"  (seed/layer-contexts "upper"))  ; every definitional context
   (seed/load-layer kb "middle" (seed/layer-contexts "middle")) ; every theory context
-  ;; every type is a unary_predicate — computed over the taxonomy, so it stays in code;
-  ;; a predicate classification, placed with the others in CxCore
-  (doseq [t (nm/by-print-key (tax/types (:taxonomy kb)))]
+  ;; The subtypes of thing are unary types. Other genl components may relate
+  ;; predicates of any arity and do not imply unary membership.
+  (doseq [t (nm/by-print-key (v/specs kb 'thing))]
     (v/assert kb (list 'unary_predicate t) 'CxCore))
   kb)

--- a/src/vaelii/impl/taxonomy.clj
+++ b/src/vaelii/impl/taxonomy.clj
@@ -4,7 +4,7 @@
   "Cached transitive closures for the two transitivity relations at the heart of
   common-sense reasoning:
 
-    genl    relates unary *types*    (genl dog animal)   — the type hierarchy
+    genl    relates predicates       (genl dog animal)   — types are its unary case
     genlCx  relates *contexts*       (genlCx CxA CxB)     — context inheritance
 
   Transitivity is not done with rules (too central, too hot); instead we store the

--- a/test/vaelii/arggenl_test.clj
+++ b/test/vaelii/arggenl_test.clj
@@ -279,7 +279,7 @@
       (is (= :arity (ex-type #(v/assert kb (list rel a) 'CxUniverse)))))))
 
 (tu/deftest-kb a-variableArity-predicate-is-exempt
-  ;; lessThan is declared binary and reads a chain of any length; the declaration says so
+  ;; lessThan has a binary floor and reads a chain of any length; the declaration says so
   (let [rel (tu/tmp-pred) a (tu/tmp-ind) b (tu/tmp-ind)]
     (v/assert kb (list 'binary_predicate rel) 'CxUniverse)
     (is (= :arity (ex-type #(v/assert kb (list rel a b (tu/tmp-ind)) 'CxUniverse))))

--- a/test/vaelii/arity_vocabulary_test.clj
+++ b/test/vaelii/arity_vocabulary_test.clj
@@ -1,0 +1,73 @@
+;; SPDX-License-Identifier: SSPL-1.0
+;; Copyright © 2026 Vaelii LLC and the Vaelii contributors.
+(ns vaelii.arity-vocabulary-test
+  "The relation-wide arity vocabulary, including the current absence of WFF/query
+  readers for arityMin and admitsArgnum."
+  (:require [clojure.test :refer [is testing use-fixtures]]
+            [vaelii.core :as v]
+            [vaelii.impl.starter :as starter]
+            [vaelii.test-util :as tu]))
+
+(use-fixtures :once (tu/loaded starter/load-into))
+(use-fixtures :each (tu/neutral))
+
+(tu/deftest-kb relation-is-the-common-parent
+  (is (v/genl? kb 'predicate 'relation))
+  (is (v/genl? kb 'function 'relation))
+  (is (v/genl? kb 'relation 'thing))
+  (is (v/isa? kb 'lessThan 'relation))
+  (is (v/isa? kb 'MotherFn 'relation)))
+
+(tu/deftest-kb exact-arity-entails-the-same-minimum
+  (testing "the existing exact declaration entails a minimum"
+    (is (v/ask? kb '(arityMin interArg 5) 'CxCore)))
+  (testing "the four current variable-arity relations state their lower bounds"
+    (doseq [relation '[functionCorrespondingPredicate greaterThan lessThan termsRelated]]
+      (is (some? (v/handle-of kb (list 'arityMin relation 2) 'CxCore))
+          (str relation " has an asserted minimum")))))
+
+(tu/deftest-kb fixed-and-variable-arity-have-relation-kind-specializations
+  (testing "the historically direct fixed predicate is classified"
+    (is (v/isa? kb 'interArg 'fixed_arity_predicate))
+    (is (v/isa? kb 'interArg 'fixed_arity))
+    (is (v/isa? kb 'interArg 'relation)))
+  (testing "all current variable predicates carry the predicate specialization"
+    (doseq [relation '[functionCorrespondingPredicate greaterThan lessThan termsRelated]]
+      (is (v/isa? kb relation 'variable_arity_predicate))
+      (is (v/isa? kb relation 'variable_arity))
+      (is (v/isa? kb relation 'relation))))
+  (testing "the function specializations exist without inventing instances"
+    (is (v/genl? kb 'fixed_arity_function 'fixed_arity))
+    (is (v/genl? kb 'fixed_arity_function 'function))
+    (is (v/genl? kb 'variable_arity_function 'variable_arity))
+    (is (v/genl? kb 'variable_arity_function 'function)))
+  (testing "a function may use the relation-wide variable vocabulary"
+    (tu/with-terms [RepeatFn]
+      (v/assert kb (list 'variable_arity_function RepeatFn) 'CxUniverse)
+      (v/assert kb (list 'arityMin RepeatFn 2) 'CxUniverse)
+      (is (v/isa? kb RepeatFn 'function))
+      (is (v/isa? kb RepeatFn 'variable_arity))
+      (is (v/isa? kb RepeatFn 'at_least_binary_relation)))))
+
+(tu/deftest-kb arity-minimum-classifies-relations-generically
+  (testing "a minimum of two derives only the binary floor"
+    (is (v/isa? kb 'lessThan 'at_least_binary_relation))
+    (is (not (v/isa? kb 'lessThan 'at_least_ternary_relation))))
+  (testing "an exact arity of five reaches both floors through arityMin"
+    (is (v/isa? kb 'interArg 'at_least_binary_relation))
+    (is (v/isa? kb 'interArg 'at_least_ternary_relation)))
+  (testing "the ternary floor specializes the binary floor"
+    (is (v/genl? kb 'at_least_ternary_relation 'at_least_binary_relation))))
+
+(tu/deftest-kb admits-argnum-is-vocabulary-only
+  (is (v/isa? kb 'admitsArgnum 'binary_predicate))
+  (is (v/ask? kb '(arg admitsArgnum 1 relation) 'CxCore))
+  (is (v/ask? kb '(arg admitsArgnum 2 positive_integer) 'CxCore))
+  (is (not (v/ask? kb '(admitsArgnum lessThan 212) 'CxCore))
+      "no parallel finite rule set answers the documentary position query"))
+
+(tu/deftest-kb fixed-and-variable-classifications-remain-independent
+  (is (not (v/isa? kb 'comment 'fixed_arity))
+      "exact arity does not classify every relation as fixed")
+  (is (nil? (v/handle-of kb '(disjoint fixed_arity variable_arity) 'CxCore))
+      "the classes have no disjointness declaration"))

--- a/test/vaelii/arity_vocabulary_test.clj
+++ b/test/vaelii/arity_vocabulary_test.clj
@@ -1,8 +1,7 @@
 ;; SPDX-License-Identifier: SSPL-1.0
 ;; Copyright © 2026 Vaelii LLC and the Vaelii contributors.
 (ns vaelii.arity-vocabulary-test
-  "The relation-wide arity vocabulary, including the current absence of WFF/query
-  readers for arityMin and admitsArgnum."
+  "The relation-wide exact/variable arity partition and its documentary floor vocabulary."
   (:require [clojure.test :refer [is testing use-fixtures]]
             [vaelii.core :as v]
             [vaelii.impl.starter :as starter]
@@ -11,6 +10,13 @@
 (use-fixtures :once (tu/loaded starter/load-into))
 (use-fixtures :each (tu/neutral))
 
+(defn- refusal-data [f]
+  (try
+    (f)
+    nil
+    (catch clojure.lang.ExceptionInfo e
+      (ex-data e))))
+
 (tu/deftest-kb relation-is-the-common-parent
   (is (v/genl? kb 'predicate 'relation))
   (is (v/genl? kb 'function 'relation))
@@ -18,13 +24,77 @@
   (is (v/isa? kb 'lessThan 'relation))
   (is (v/isa? kb 'MotherFn 'relation)))
 
-(tu/deftest-kb exact-arity-entails-the-same-minimum
-  (testing "the existing exact declaration entails a minimum"
-    (is (v/ask? kb '(arityMin interArg 5) 'CxCore)))
-  (testing "the four current variable-arity relations state their lower bounds"
+(tu/deftest-kb exact-arity-and-variable-floors-are-distinct
+  (testing "an exact declaration is fixed, not an overloaded floor"
+    (is (v/ask? kb '(fixed_arity interArg) 'CxCore))
+    (is (not (v/ask? kb '(arityMin interArg 5) 'CxCore))))
+  (testing "the four current variable-arity predicates state only their lower bounds"
     (doseq [relation '[functionCorrespondingPredicate greaterThan lessThan termsRelated]]
       (is (some? (v/handle-of kb (list 'arityMin relation 2) 'CxCore))
-          (str relation " has an asserted minimum")))))
+          (str relation " has an asserted minimum"))
+      (is (not (v/isa? kb relation 'binary_predicate))
+          (str relation " is not overloaded as exactly binary")))))
+
+(tu/deftest-kb relation-wide-types-own-the-arity-rules
+  (doseq [[type arity] '[[unary 1] [binary 2] [ternary 3]]]
+    (is (v/ask? kb (list 'relationTypeByArity type arity) 'CxCore)))
+  (doseq [[type arity] '[[unary_predicate 1]
+                         [binary_predicate 2]
+                         [ternary_predicate 3]]]
+    (is (v/ask? kb (list 'predicateTypeByArity type arity) 'CxCore))
+    (is (v/ask? kb (list 'relationTypeByArity type arity) 'CxCore)
+        "the predicate mapping specializes the relation mapping"))
+  (doseq [[type arity] '[[unary_function 1]
+                         [binary_function 2]
+                         [ternary_function 3]]]
+    (is (v/ask? kb (list 'functionTypeByArity type arity) 'CxCore))
+    (is (v/ask? kb (list 'relationTypeByArity type arity) 'CxCore)
+        "the function mapping specializes the relation mapping"))
+  (is (v/genl? kb 'unary_predicate 'unary))
+  (is (v/genl? kb 'binary_predicate 'binary))
+  (is (v/genl? kb 'ternary_predicate 'ternary))
+  (is (v/genl? kb 'unary_function 'unary))
+  (is (v/genl? kb 'binary_function 'binary))
+  (is (v/genl? kb 'ternary_function 'ternary))
+  (doseq [type '[unary_predicate binary_predicate ternary_predicate]]
+    (is (v/genl? kb type 'fixed_arity_predicate)))
+  (doseq [type '[unary_function binary_function ternary_function]]
+    (is (v/genl? kb type 'fixed_arity_function)))
+  (is (v/isa? kb 'parentOf 'fixed_arity_predicate))
+  (is (v/isa? kb 'MotherFn 'fixed_arity_function)))
+
+(tu/deftest-kb disjoint-arity-policies-refuse-the-second-write
+  (doseq [[first-policy second-policy] '[[fixed_arity variable_arity]
+                                         [variable_arity fixed_arity]]]
+    (tu/with-terms [candidateRelation]
+      (v/assert kb (list first-policy candidateRelation) 'CxUniverse)
+      (let [second-sentence (list second-policy candidateRelation)
+            refusal         (refusal-data #(v/assert kb second-sentence 'CxUniverse))]
+        (is (= :disjoint (:type refusal)))
+        (is (nil? (v/handle-of kb second-sentence 'CxUniverse))
+            "the refused policy is not stored")
+        (is (v/ask? kb (list first-policy candidateRelation) 'CxUniverse)
+            "the compatible first policy remains believed"))))
+  (tu/with-terms [compatiblePredicate]
+    (v/assert kb (list 'unary_predicate compatiblePredicate) 'CxUniverse)
+    (is (v/assert kb (list 'fixed_arity_predicate compatiblePredicate) 'CxUniverse)
+        "a predicate specialization and its fixed policy are compatible")))
+
+(tu/deftest-kb relation-wide-exact-classes-refuse-each-other
+  (doseq [[first-type second-type] '[[unary binary] [binary unary]
+                                     [unary ternary] [ternary unary]
+                                     [binary ternary] [ternary binary]]]
+    (tu/with-terms [candidateRelation]
+      (v/assert kb (list first-type candidateRelation) 'CxUniverse)
+      (let [second-sentence (list second-type candidateRelation)
+            refusal         (refusal-data #(v/assert kb second-sentence 'CxUniverse))]
+        (is (= :disjoint (:type refusal)))
+        (is (nil? (v/handle-of kb second-sentence 'CxUniverse))
+            "the refused exact class is not stored"))))
+  (tu/with-terms [compatibleRelation]
+    (v/assert kb (list 'unary compatibleRelation) 'CxUniverse)
+    (is (v/assert kb (list 'fixed_arity compatibleRelation) 'CxUniverse)
+        "an exact class and its fixed policy are compatible")))
 
 (tu/deftest-kb fixed-and-variable-arity-have-relation-kind-specializations
   (testing "the historically direct fixed predicate is classified"
@@ -41,6 +111,21 @@
     (is (v/genl? kb 'fixed_arity_function 'function))
     (is (v/genl? kb 'variable_arity_function 'variable_arity))
     (is (v/genl? kb 'variable_arity_function 'function)))
+  (testing "the shipped functions use their exact relation-wide specializations"
+    (doseq [[function type] '[[FatherFn unary_function]
+                              [MotherFn unary_function]
+                              [YearFn unary_function]
+                              [MonthFn binary_function]
+                              [QuantityFn binary_function]
+                              [DayFn ternary_function]
+                              [QuantityIntervalFn ternary_function]
+                              [PredAllExistsFn ternary_function]
+                              [PredExistsAllFn ternary_function]
+                              [PredExistsInstanceFn ternary_function]
+                              [PredInstanceExistsFn ternary_function]]]
+      (is (v/isa? kb function type) (str function " is " type)))
+    (is (v/isa? kb 'InstantFn 'fixed_arity_function)
+        "the six-argument function stays explicitly fixed without minting a named family"))
   (testing "a function may use the relation-wide variable vocabulary"
     (tu/with-terms [RepeatFn]
       (v/assert kb (list 'variable_arity_function RepeatFn) 'CxUniverse)
@@ -53,9 +138,9 @@
   (testing "a minimum of two derives only the binary floor"
     (is (v/isa? kb 'lessThan 'at_least_binary_relation))
     (is (not (v/isa? kb 'lessThan 'at_least_ternary_relation))))
-  (testing "an exact arity of five reaches both floors through arityMin"
-    (is (v/isa? kb 'interArg 'at_least_binary_relation))
-    (is (v/isa? kb 'interArg 'at_least_ternary_relation)))
+  (testing "an exact arity is not also a variable floor"
+    (is (not (v/isa? kb 'interArg 'at_least_binary_relation)))
+    (is (not (v/isa? kb 'interArg 'at_least_ternary_relation))))
   (testing "the ternary floor specializes the binary floor"
     (is (v/genl? kb 'at_least_ternary_relation 'at_least_binary_relation))))
 
@@ -66,8 +151,23 @@
   (is (not (v/ask? kb '(admitsArgnum lessThan 212) 'CxCore))
       "no parallel finite rule set answers the documentary position query"))
 
-(tu/deftest-kb fixed-and-variable-classifications-remain-independent
-  (is (not (v/isa? kb 'comment 'fixed_arity))
-      "exact arity does not classify every relation as fixed")
-  (is (nil? (v/handle-of kb '(disjoint fixed_arity variable_arity) 'CxCore))
-      "the classes have no disjointness declaration"))
+(tu/deftest-kb every-relation-has-exactly-one-arity-policy
+  (let [relations  (->> (v/query kb '(relation ?relation) 'CxInference)
+                        (map #(get % '?relation))
+                        set)
+        violations (into (sorted-map)
+                         (keep (fn [relation]
+                                 (let [fixed?    (v/ask? kb (list 'fixed_arity relation)
+                                                         'CxInference)
+                                       variable? (v/ask? kb (list 'variable_arity relation)
+                                                         'CxInference)]
+                                   (when (= fixed? variable?)
+                                     [relation {:fixed fixed? :variable variable?}]))))
+                         relations)]
+    (is (> (count relations) 300)
+        "the oracle enumerates the loaded CxInference vocabulary, not an empty fixture")
+    (is (empty? violations)
+        (str "relations outside the exactly-one arity-policy partition: "
+             (pr-str violations)))
+    (is (some? (v/handle-of kb '(disjoint fixed_arity variable_arity) 'CxCore))
+        "the partition is declared in KB data")))

--- a/test/vaelii/arity_vocabulary_test.clj
+++ b/test/vaelii/arity_vocabulary_test.clj
@@ -24,6 +24,36 @@
   (is (v/isa? kb 'lessThan 'relation))
   (is (v/isa? kb 'MotherFn 'relation)))
 
+(tu/deftest-kb starter-distinguishes-type-nodes-from-binary-predicate-nodes
+  (doseq [mapping '[relationTypeByArity predicateTypeByArity functionTypeByArity]]
+    (is (v/isa? kb mapping 'binary_predicate))
+    (is (not (v/isa? kb mapping 'unary_predicate)))
+    (is (v/ask? kb (list 'arity mapping 2) 'CxCore)))
+  (doseq [type '[thing animal physical_object fixed_arity]]
+    (is (v/isa? kb type 'unary_predicate)))
+  (is (v/genl? kb 'predicateTypeByArity 'relationTypeByArity))
+  (is (v/genl? kb 'functionTypeByArity 'relationTypeByArity)))
+
+(tu/deftest-kb arity-generator-tracks-mapping-support-without-a-converse
+  (doseq [mapping-first? [true false]]
+    (tu/with-terms [four_place_relation classifiedRelation exactOnlyRelation]
+      (v/assert kb (list 'genl four_place_relation 'fixed_arity) 'CxCore)
+      (let [mapping (list 'relationTypeByArity four_place_relation 4)
+            member  (list four_place_relation classifiedRelation)
+            h       (if mapping-first?
+                      (let [h (v/assert kb mapping 'CxCore)]
+                        (v/assert kb member 'CxCore)
+                        h)
+                      (do (v/assert kb member 'CxCore)
+                          (v/assert kb mapping 'CxCore)))]
+        (is (v/ask? kb (list 'arity classifiedRelation 4) 'CxCore))
+        (v/assert kb (list 'arity exactOnlyRelation 4) 'CxCore)
+        (is (not (v/ask? kb (list four_place_relation exactOnlyRelation) 'CxCore)))
+        (v/retract! kb h)
+        (is (v/ask? kb member 'CxCore))
+        (is (not (v/ask? kb (list 'arity classifiedRelation 4) 'CxCore)))
+        (is (v/ask? kb (list 'arity exactOnlyRelation 4) 'CxCore))))))
+
 (tu/deftest-kb exact-arity-and-variable-floors-are-distinct
   (testing "an exact declaration is fixed, not an overloaded floor"
     (is (v/ask? kb '(fixed_arity interArg) 'CxCore))

--- a/test/vaelii/constraint_vocabulary_test.clj
+++ b/test/vaelii/constraint_vocabulary_test.clj
@@ -96,7 +96,7 @@
     (is (= [(list relOf A B C)] (:sample (get (arity-entries kb) relOf))))))
 
 (tu/deftest-kb a-variableArity-predicate-is-exempt-on-the-retroactive-path-too
-  ;; The exemption is the declaration's whole point (`lessThan` is declared binary *and*
+  ;; The exemption is the declaration's whole point (`lessThan` has a binary floor and
   ;; reads a chain), and it is read by one `arity-problem` — so it must hold whichever
   ;; direction the check is asked from.
   (tu/with-terms [chainOf A B C]

--- a/test/vaelii/core_context_test.clj
+++ b/test/vaelii/core_context_test.clj
@@ -56,14 +56,14 @@
                  (v/assert kb (list 'arity rel 7) 'CxCore)))))
 
 (tu/deftest-kb the-core-vocabulary-is-the-size-docs-kbs-says
-  ;; A bound, not a pin.  docs/kbs.md's row says "~562", and the exact number moves
+  ;; A bound, not a pin.  docs/kbs.md's row says "~920", and the exact number moves
   ;; whenever CxCore gains a term on purpose — which made an equality here pure churn:
   ;; it failed on every deliberate change and caught nothing else, because
   ;; `vocabulary-audit` already fails a functor nobody classified.  What a count *can*
   ;; catch is the load going wrong in bulk — an empty classpath, a file read twice — so
   ;; that is what this asserts.
   (let [n (v/sentex-count kb)]
-    (is (< 300 n 700)
-        (str "CxCore loaded " n " sentexes; docs/kbs.md's Core vocabulary row says ~562."
+    (is (< 500 n 1800)
+        (str "CxCore loaded " n " sentexes; docs/kbs.md's Core vocabulary row says ~920."
              "  A number outside this band means the load is wrong, not that the"
              "  vocabulary grew — check the classpath before touching the row."))))

--- a/test/vaelii/core_context_test.clj
+++ b/test/vaelii/core_context_test.clj
@@ -4,6 +4,7 @@
   "The CxCore ontology loads and documents the core predicates."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [vaelii.core :as v]
+            [vaelii.impl.checks :as checks]
             [vaelii.impl.core-context :as core-context]
             [vaelii.test-util :as tu]))
 
@@ -45,6 +46,28 @@
       (is (thrown? clojure.lang.ExceptionInfo
                    (v/assert kb (list kin boulder tom) 'CxData))))))   ; a rock is not an animal
 
+(tu/deftest-kb argument-declarations-accept-functions-and-predicates
+  (tu/with-terms [ReviewFn reviewRelation]
+    (v/assert kb (list 'ternary_function ReviewFn) 'CxCore)
+    (v/assert kb (list 'ternary_predicate reviewRelation) 'CxCore)
+    (doseq [relation [ReviewFn reviewRelation]
+            [position projection] [[1 'arg1] [2 'arg2] [3 'arg3]]]
+      (v/assert kb (list 'arg relation position 'integer) 'CxCore)
+      (is (true? (v/ask? kb (list projection relation 'integer) 'CxCore)))
+      (is (empty? (v/check kb (list projection relation 'integer) 'CxCore))))))
+
+(tu/deftest-kb remaining-argument-metadata-accepts-relations
+  (tu/with-terms [ReviewFn reviewRelation]
+    (v/assert kb (list 'binary_function ReviewFn) 'CxCore)
+    (v/assert kb (list 'binary_predicate reviewRelation) 'CxCore)
+    (doseq [relation [ReviewFn reviewRelation]
+            declaration [(list 'genlArg relation 1 'thing)
+                         (list 'quotedArg relation 1 'integer)
+                         (list 'interArg relation 1 'integer 2 'integer)]]
+      (is (empty? (v/check kb declaration 'CxCore)))
+      (v/assert kb declaration 'CxCore)
+      (is (true? (v/ask? kb declaration 'CxCore))))))
+
 (tu/deftest-kb arity-is-declared-functional
   ;; a predicate has one arity, and the two spellings derive each other — so a second,
   ;; different (arity P N) is a clash rather than a second belief.  Two numbers can
@@ -54,6 +77,16 @@
     (v/assert kb (list 'binary_predicate rel) 'CxCore)
     (is (thrown? clojure.lang.ExceptionInfo
                  (v/assert kb (list 'arity rel 7) 'CxCore)))))
+
+(tu/deftest-kb exact-arity-derives-fixed-policy-without-argument-entailment
+  (binding [checks/*assertive-arg-types?* false]
+    (tu/with-terms [freshRelation]
+      (let [h (v/assert kb (list 'arity freshRelation 4) 'CxCore)]
+        (is (v/ask? kb (list 'fixed_arity freshRelation) 'CxCore))
+        (is (v/isa? kb freshRelation 'fixed_arity 'CxCore))
+        (v/retract! kb h)
+        (is (not (v/ask? kb (list 'fixed_arity freshRelation) 'CxCore)))
+        (is (not (v/isa? kb freshRelation 'fixed_arity 'CxCore)))))))
 
 (tu/deftest-kb the-core-vocabulary-is-the-size-docs-kbs-says
   ;; A bound, not a pin.  docs/kbs.md's row says "~920", and the exact number moves

--- a/test/vaelii/meta_test.clj
+++ b/test/vaelii/meta_test.clj
@@ -55,12 +55,12 @@
     (is (not (v/isa? kb 'dog 'binary_predicate)))
     (is (not (v/isa? kb 'siblingOf 'unary_predicate)))))
 
-(tu/deftest-kb arity-and-predicate-type-derive-each-other
-  ;; (arity P N) and the N-ary predicate-type membership conclude each other, each
+(tu/deftest-kb arity-and-relation-type-derive-each-other
+  ;; (arity R N) and the N-ary relation-type membership conclude each other, each
   ;; landing where the declaration it was read off lives — the ordinary placement.
   (testing "arity is itself a binary predicate"
     (is (v/isa? kb 'arity 'binary_predicate)))
-  (testing "an asserted predicate-type concludes the arity, in the declaration's context"
+  (testing "an asserted predicate specialization concludes the arity, in its context"
     (is (seq (v/sentexes-matching kb '(arity dog 1) 'CxCore)))        ; a type is unary
     (is (seq (v/sentexes-matching kb '(arity awake 1) 'CxLife)))      ; a one-place property
     (is (seq (v/sentexes-matching kb '(arity parentOf 2) 'CxLife)))
@@ -72,36 +72,39 @@
     (is (empty? (v/sentexes-matching kb '(arity parentOf 2) 'CxNaturalWorld)))
     (is (v/isa? kb 'parentOf 'binary_predicate 'CxNaturalWorld)
         "but a data context below Well still sees it, since it sees CxLife"))
-  (testing "an asserted arity concludes the predicate-type, hence a predicate"
-    (tu/with-terms [fooPred]
-      (v/assert kb (list 'arity fooPred 2) 'CxCore)
-      (is (v/isa? kb fooPred 'binary_predicate))
-      (is (v/isa? kb fooPred 'predicate))
-      (is (seq (v/sentexes-matching kb (list 'binary_predicate fooPred) 'CxCore)))))
+  (testing "an asserted arity concludes the relation-wide type and fixed policy"
+    (tu/with-terms [fooRelation]
+      (v/assert kb (list 'arity fooRelation 2) 'CxCore)
+      (is (v/isa? kb fooRelation 'binary))
+      (is (v/isa? kb fooRelation 'relation))
+      (is (v/isa? kb fooRelation 'fixed_arity))
+      (is (seq (v/sentexes-matching kb (list 'binary fooRelation) 'CxCore)))))
   (testing "the derived membership is justified by the arity fact and the rule"
-    (tu/with-terms [barPred]
-      (v/assert kb (list 'arity barPred 3) 'CxCore)
-      (let [h (v/handle-of kb (list 'ternary_predicate barPred) 'CxCore)
+    (tu/with-terms [barRelation]
+      (v/assert kb (list 'arity barRelation 3) 'CxCore)
+      (let [h (v/handle-of kb (list 'ternary barRelation) 'CxCore)
             d (first (v/supporting-justifications kb h))]
-        (is (some #(= (list 'arity barPred 3) (:sentence (v/sentex kb %)))
+        (is (some #(= (list 'arity barRelation 3) (:sentence (v/sentex kb %)))
                   (:antecedents d)))))))
 
 (tu/deftest-kb arity-cycle-is-self-preserving-only-with-an-asserted-member
-  ;; the two directions form a positive cycle: (arity P N) <-> (N-ary predicate P).
+  ;; the two directions form a positive cycle: (arity R N) <-> (N-ary relation R).
   ;; A member asserted as a premise grounds the whole cycle; the derived twin cannot
   ;; ground itself, so retracting the sole premise collapses both (well-founded).
   (testing "asserting the arity keeps both the arity and the type believed"
-    (tu/with-terms [pPred]
-      (let [h (v/assert kb (list 'arity pPred 2) 'CxCore)]
-        (is (seq (v/sentexes-matching kb (list 'arity pPred 2) 'CxCore)))
-        (is (seq (v/sentexes-matching kb (list 'binary_predicate pPred) 'CxCore)))
+    (tu/with-terms [binaryRelation]
+      (let [h (v/assert kb (list 'arity binaryRelation 2) 'CxCore)]
+        (is (seq (v/sentexes-matching kb (list 'arity binaryRelation 2) 'CxCore)))
+        (is (seq (v/sentexes-matching kb (list 'binary binaryRelation) 'CxCore)))
         (testing "retracting the sole premise collapses the whole cycle"
           (v/retract! kb h)
-          (is (empty? (v/sentexes-matching kb (list 'binary_predicate pPred) 'CxCore)))
-          (is (empty? (v/sentexes-matching kb (list 'arity pPred 2) 'CxCore)))))))
-  (testing "asserting the type keeps both the type and the arity believed"
+          (is (empty? (v/sentexes-matching kb (list 'binary binaryRelation) 'CxCore)))
+          (is (empty? (v/sentexes-matching kb (list 'arity binaryRelation 2) 'CxCore)))))))
+  (testing "a specialized predicate witness keeps its type, arity, and predicate policy"
     (tu/with-terms [qPred]
       (let [h (v/assert kb (list 'unary_predicate qPred) 'CxCore)]
+        (is (v/isa? kb qPred 'unary))
+        (is (v/isa? kb qPred 'fixed_arity_predicate))
         (is (seq (v/sentexes-matching kb (list 'arity qPred 1) 'CxCore)))
         (testing "and retracting it collapses the derived arity"
           (v/retract! kb h)

--- a/test/vaelii/meta_test.clj
+++ b/test/vaelii/meta_test.clj
@@ -55,9 +55,7 @@
     (is (not (v/isa? kb 'dog 'binary_predicate)))
     (is (not (v/isa? kb 'siblingOf 'unary_predicate)))))
 
-(tu/deftest-kb arity-and-relation-type-derive-each-other
-  ;; (arity R N) and the N-ary relation-type membership conclude each other, each
-  ;; landing where the declaration it was read off lives — the ordinary placement.
+(tu/deftest-kb relation-types-derive-arity-and-numeric-arity-derives-fixed-policy
   (testing "arity is itself a binary predicate"
     (is (v/isa? kb 'arity 'binary_predicate)))
   (testing "an asserted predicate specialization concludes the arity, in its context"
@@ -72,33 +70,42 @@
     (is (empty? (v/sentexes-matching kb '(arity parentOf 2) 'CxNaturalWorld)))
     (is (v/isa? kb 'parentOf 'binary_predicate 'CxNaturalWorld)
         "but a data context below Well still sees it, since it sees CxLife"))
-  (testing "an asserted arity concludes the relation-wide type and fixed policy"
+  (testing "an asserted arity concludes the fixed policy without classifying an exact type"
     (tu/with-terms [fooRelation]
       (v/assert kb (list 'arity fooRelation 2) 'CxCore)
-      (is (v/isa? kb fooRelation 'binary))
+      (is (not (v/isa? kb fooRelation 'binary)))
       (is (v/isa? kb fooRelation 'relation))
       (is (v/isa? kb fooRelation 'fixed_arity))
-      (is (seq (v/sentexes-matching kb (list 'binary fooRelation) 'CxCore)))))
-  (testing "the derived membership is justified by the arity fact and the rule"
+      (is (seq (v/sentexes-matching kb (list 'fixed_arity fooRelation) 'CxCore)))
+      (is (empty? (v/sentexes-matching kb (list 'binary fooRelation) 'CxCore)))))
+  (testing "the fixed policy is justified by the arity fact and the rule"
     (tu/with-terms [barRelation]
       (v/assert kb (list 'arity barRelation 3) 'CxCore)
-      (let [h (v/handle-of kb (list 'ternary barRelation) 'CxCore)
-            d (first (v/supporting-justifications kb h))]
-        (is (some #(= (list 'arity barRelation 3) (:sentence (v/sentex kb %)))
-                  (:antecedents d)))))))
+      (let [h (v/handle-of kb (list 'fixed_arity barRelation) 'CxCore)
+            rule (v/handle-of kb '(implies (arity ?relation ?arity)
+                                           (fixed_arity ?relation)) 'CxCore)]
+        (is (some? h))
+        (is (some? rule))
+        (when h
+          (is (some (fn [d]
+                      (and (some #{rule} (:antecedents d))
+                           (some #(= (list 'arity barRelation 3)
+                                     (:sentence (v/sentex kb %)))
+                                 (:antecedents d))))
+                    (v/supporting-justifications kb h))))
+        (is (not (v/isa? kb barRelation 'ternary)))))))
 
-(tu/deftest-kb arity-cycle-is-self-preserving-only-with-an-asserted-member
-  ;; the two directions form a positive cycle: (arity R N) <-> (N-ary relation R).
-  ;; A member asserted as a premise grounds the whole cycle; the derived twin cannot
-  ;; ground itself, so retracting the sole premise collapses both (well-founded).
-  (testing "asserting the arity keeps both the arity and the type believed"
+(tu/deftest-kb arity-conclusions-retract-with-their-declarations
+  (testing "asserting the arity derives a fixed policy without an exact-type converse"
     (tu/with-terms [binaryRelation]
       (let [h (v/assert kb (list 'arity binaryRelation 2) 'CxCore)]
         (is (seq (v/sentexes-matching kb (list 'arity binaryRelation 2) 'CxCore)))
-        (is (seq (v/sentexes-matching kb (list 'binary binaryRelation) 'CxCore)))
-        (testing "retracting the sole premise collapses the whole cycle"
+        (is (seq (v/sentexes-matching kb (list 'fixed_arity binaryRelation) 'CxCore)))
+        (is (empty? (v/sentexes-matching kb (list 'binary binaryRelation) 'CxCore)))
+        (testing "retracting the arity withdraws its fixed-policy conclusion"
           (v/retract! kb h)
           (is (empty? (v/sentexes-matching kb (list 'binary binaryRelation) 'CxCore)))
+          (is (empty? (v/sentexes-matching kb (list 'fixed_arity binaryRelation) 'CxCore)))
           (is (empty? (v/sentexes-matching kb (list 'arity binaryRelation 2) 'CxCore)))))))
   (testing "a specialized predicate witness keeps its type, arity, and predicate policy"
     (tu/with-terms [qPred]

--- a/test/vaelii/ontology_test.clj
+++ b/test/vaelii/ontology_test.clj
@@ -273,15 +273,65 @@
 
 ;; ---- the shipped rules, read against each other --------------------------
 
-(tu/deftest-kb no-shipped-rule-is-covered-by-another
-  ;; `kb-quality`'s subsumption reading over the shipped schema and the test-world's
-  ;; fables.  Zero is the claim: nothing here fires wherever another rule fires and
-  ;; concludes no more than it does, so no rule in the ontology is carrying its weight
-  ;; only because somebody wrote it twice at two levels of the hierarchy.
-  (let [q (:subsumption (v/kb-quality kb {:limit 100}))]
-    (is (pos? (:total q)) "the reading ran over rules rather than over nothing")
-    (is (zero? (:subsumed-count q))
-        (str "covered: " (pr-str (mapv (juxt :by-sentence :sentence) (:subsumed q)))))))
+(defn- arity-rule [type arity]
+  (list 'implies (list type '?relation) (list 'arity '?relation arity)))
+
+(defn- generated-arity-pairs [kb]
+  ;; Temporary, exact exception until generators decline subsumed rules. No general
+  ;; exemption for generated rules: the provenance and complete pair set are tested.
+  (set (for [[general arity specializations]
+             '[[unary 1 [unary_predicate unary_function]]
+               [binary 2 [binary_predicate binary_function]]
+               [ternary 3 [ternary_predicate ternary_function]]]
+             specialized specializations]
+         [(v/handle-of kb (arity-rule general arity) 'CxCore)
+          (v/handle-of kb (arity-rule specialized arity) 'CxCore)])))
+
+(defn- unexpected-subsumptions [expected reading]
+  (remove #(contains? expected [(:by %) (:subsumed %)]) (:subsumed reading)))
+
+(tu/deftest-kb no-shipped-rule-is-covered-except-the-exact-generated-arity-pairs
+  (let [q (:subsumption (v/kb-quality kb {:limit 100}))
+        expected (generated-arity-pairs kb)
+        generator (v/handle-of kb
+                               '(implies (relationTypeByArity ?type ?arity)
+                                         (implies (?type ?relation) (arity ?relation ?arity)))
+                               'CxCore)]
+    (is (pos? (:total q)))
+    (is (not (:truncated? q)))
+    (is (= 6 (count expected)))
+    (is (some? generator))
+    (doseq [h (set (mapcat identity expected))]
+      (is (some? h))
+      (is (not (v/premise? kb h)) "the exception cannot cover a hand-written rule")
+      (is (some #(some #{generator} (:antecedents %))
+                (v/supporting-justifications kb h))
+          "each rule is actually stamped by the arity generator"))
+    (is (= expected (set (map (juxt :by :subsumed) (:subsumed q))))
+        "the exception must be removed when its motivating redundancies disappear")
+    (is (empty? (unexpected-subsumptions expected q))
+        (str "unexpected covered rules: "
+             (pr-str (mapv (juxt :by-sentence :sentence)
+                           (unexpected-subsumptions expected q)))))))
+
+(tu/deftest-kb unexpected-generated-subsumption-is-not-exempt
+  (tu/with-terms [broad_type narrow_type outcome_type generatesType]
+    (v/assert kb (list 'genl broad_type 'thing) 'CxCore)
+    (v/assert kb (list 'genl narrow_type broad_type) 'CxCore)
+    (v/assert kb (list 'genl outcome_type 'thing) 'CxCore)
+    (v/assert kb (list 'implies (list generatesType '?type)
+                       (list 'implies (list '?type '?x) (list outcome_type '?x))) 'CxCore)
+    (doseq [type [broad_type narrow_type]]
+      (v/assert kb (list generatesType type) 'CxCore))
+    (let [rule (fn [type] (list 'implies (list type '?x) (list outcome_type '?x)))
+          pair [(v/handle-of kb (rule broad_type) 'CxCore)
+                (v/handle-of kb (rule narrow_type) 'CxCore)]
+          q (:subsumption (v/kb-quality kb {:limit 100}))]
+      (is (every? some? pair))
+      (is (not (:truncated? q)))
+      (is (some #(= pair [(:by %) (:subsumed %)])
+                (unexpected-subsumptions (generated-arity-pairs kb) q))
+          "even another generated subtype pair must still fail the gate"))))
 
 (tu/deftest-kb every-negated-conclusion-the-ontology-can-clash-with-is-stated-as-an-exception
   ;; The other rule-hygiene reading, and the structure of what it finds here is the finding.

--- a/test/vaelii/quality_test.clj
+++ b/test/vaelii/quality_test.clj
@@ -245,10 +245,24 @@
       (is (= 2 (:islands t)) "the island pair, and nothing else")
       (testing "the denominator is every type-shaped name in the vocabulary — the six here
                 plus `genl` itself, because a bare lowercase word is a legal type name as
-                well as a legal predicate and the index records no arity to tell them
+                well as a legal predicate and this KB declares no arity to tell them
                 apart.  Which is exactly why the *gap* above is the finding rather than
                 either fraction on its own"
         (is (= 7 (:names t)))))))
+
+(tu/deftest-kb taxonomy-coverage-excludes-known-nonunary-components-not-unknown-types
+  (tu/with-terms [root_type mid_type leaf_type island_a island_b parent_relation child_relation]
+    (doseq [[sub super] [[leaf_type mid_type] [mid_type root_type]
+                         [island_a island_b] [child_relation parent_relation]]]
+      (v/assert kb (list 'genl sub super) 'CxUniverse))
+    (doseq [relation [parent_relation child_relation]]
+      (v/assert kb (list 'arity relation 2) 'CxUniverse))
+    (v/assert kb (list 'arity leaf_type 1) 'CxUniverse)
+    (let [t (:taxonomy (v/kb-quality kb))]
+      (is (= root_type (:root t)) "a corpus need not use thing as its root")
+      (is (= 5 (:edged t)) "declared binary predicates are not unary type nodes")
+      (is (= 3 (:rooted t)) "known unary and unknown types both remain")
+      (is (= 2 (:islands t)) "untyped disconnected islands are still findings"))))
 
 ;; ---- the options, and the emitter ----------------------------------------
 

--- a/test/vaelii/rule_variable_arg_test.clj
+++ b/test/vaelii/rule_variable_arg_test.clj
@@ -122,7 +122,7 @@
         p (tu/tmp-pred) rel (tu/tmp-pred)]
     (v/assert kb (list 'genl text 'thing) 'CxUniverse)
     (v/assert kb (list 'disjoint text 'unary_predicate) 'CxUniverse)
-    (v/assert kb (list 'arity rel 2) 'CxUniverse)
+    (v/assert kb (list 'binary_predicate rel) 'CxUniverse)
     (v/assert kb (list 'arg p 1 text) 'CxUniverse)
     (v/assert kb (list 'type_relation_predicate rel) 'CxUniverse)
     (v/assert kb (list 'genlArg rel 1 'thing) 'CxUniverse)   ; position 1 only

--- a/test/vaelii/web_test.clj
+++ b/test/vaelii/web_test.clj
@@ -273,17 +273,24 @@
     ;; claim is that this context leads the ranking, and a fixed 400 makes that a bet
     ;; on the shipped ontology staying smaller than it — which CxCore, carrying an
     ;; argument declaration for every position of every predicate, does not.
-    (let [n (+ 50 (apply max 0 (map #(v/count-in-context kb %) (v/contexts kb))))]
+    (let [n (max 1000 (+ 50 (apply max 0 (map #(v/count-in-context kb %) (v/contexts kb)))))]
       (v/assert-many kb (for [i (range n)] (list heldBy (symbol (str "TmpBig" i))))
                      CxBiggest {:chain? false})
       (let [cap  (ns-resolve 'vaelii.impl.web 'lattice-cap)
-            body (with-redefs-fn {cap 0}                ; no lattice to draw, at any size
-                   #(:body (GET "/")))
+            locale (java.util.Locale/getDefault)
+            body (try
+                   (java.util.Locale/setDefault java.util.Locale/US)
+                   (with-redefs-fn {cap 0}             ; no lattice to draw, at any size
+                     #(:body (GET "/")))
+                   (finally (java.util.Locale/setDefault locale)))
             seg  (segment body "holding the most" 4000)
-            ns'  (mapv #(Long/parseLong (second %)) (re-seq #" — (\d+) sentexes" seg))]
+            ns'  (mapv #(Long/parseLong (str/replace (second %) "," ""))
+                       (re-seq #" — (\d{1,3}(?:,\d{3})*|\d+) sentexes" seg))]
+        (is (= locale (java.util.Locale/getDefault)) "rendering restores the default locale")
         (is (some? seg) "the fallback says what it is showing instead")
         (is (re-find (re-pattern (str ">" CxBiggest "</a><span class=\"muted\"> — "
-                                      n " sentexes"))
+                                      (String/format java.util.Locale/US "%,d" (to-array [n]))
+                                      " sentexes"))
                      seg)
             "the biggest context, named with what it holds")
         (is (seq ns') "and it is a list of counts, not of names alone")


### PR DESCRIPTION
## Summary

- Introduce `relation` as the common parent of predicates and functions, with relation-wide fixed/variable and exact-arity classes and their predicate/function specializations.
- Apply the seven arity-review findings: remove redundant rules/disjoints/parents, use operator terminology, complete arity declarations, and specialize the two mapping predicates through `genl` with one forward arity generator and no converse.
- Derive `fixed_arity` from exact `arity` even with assertive argument typing disabled; keep fixed and variable policies disjoint.
- Fix starter loading so binary predicate specializations are not falsely classified as unary types. Taxonomy coverage excludes declared non-unary nodes while preserving unknown roots and disconnected type islands.
- Generalize argument metadata (`arg` and its projections, `genlArg`, `quotedArg`, `interArg`) to relations; declare `InstantFn`'s six existing integer inputs.

Current head: `657933a4754eb5cc704422a2d1518df4f3662b91`, reviewed tree `7a5d13dbe6789204e690659da0ce04282b7701d1`. The six commits over `b19d549f9ca245087cdc76e1a369f040a9b12c9f` were reauthored and signed off by Pace Heart; the final tree is byte-identical to the independently reviewed repair. #74 has merged; this PR targets `develop` and is ready for review under maintainer approval. Full upstream CI is still required before merge.

## Boundaries and follow-ups

- `arityMin`/`admitsArgnum` runtime enforcement remains #68. Existing optional-tail semantics of `functionCorrespondingPredicate` are preserved.
- Generator-engine subsumption suppression remains #77. The ontology guard temporarily accepts exactly six known arity-rule pairs, verifies their generator provenance, and still rejects unrelated generated redundancies. There is no blanket generated-rule exemption.
- Recursive function-input enforcement remains #78. Relation-wide declaration acceptance does not implement that runtime behavior; `docs/argtypes.md` records the distinction between `arg`/`genlArg` result typing and `quotedArg`'s compound exemption.

## Verification

- Focused aggregate before the final three metadata-domain generalizations: 14 namespaces, **231 tests / 2,642 assertions**, zero failures/errors.
- Final metadata delta: core-context, constraint-vocabulary, argtype-entail, argtype-ground, and ontology namespaces: **78 tests / 651 assertions**, zero failures/errors.
- Regression oracles demonstrated old failures before the relevant fixes: lowercase exact-arity inference, starter loading, taxonomy coverage, and function-subject argument declarations.
- Full lint: **11/11 clean**. Final documentation-only precision fix also passed links/drift/prose checks; drift reports one existing changelog warning, zero errors.
- Independent local review of the exact final tree: zero verified findings. Full upstream CI is still required; the full suite was intentionally not duplicated locally.

## Current upstream gates

- [Test run](https://github.com/vaelii/vaelii/actions/runs/34021575388), [lint](https://github.com/vaelii/vaelii/actions/runs/34021575449), and [authorship](https://github.com/vaelii/vaelii/actions/runs/34021575384) await maintainer workflow approval. The test run has no jobs yet: this is **not** a passing full-suite receipt.
- DCO and `license/cla` are successful on the reauthored head. Workflow approval remains a separate gate.
