### PR TITLE
recover: require complete edge shape when replaying genl/genlCx declarations

### DIFF
--- a/src/vaelii/impl/special.clj
+++ b/src/vaelii/impl/special.clj
@@ -3673,23 +3673,37 @@
 
 (defn- replay-edge
   "Replay one stored `genl` / `genlCx` declaration through `add` (`tax/add-genl` or
-  `tax/add-genlCx`), but only when both endpoints are symbols — a valid taxonomy node.
+  `tax/add-genlCx`), but only when the stored sentence's **complete shape** is exactly
+  `(expected-f <symbol> <symbol>)` — a valid two-endpoint taxonomy edge.
 
-  The rebuild arms read the edge positionally (`[_ a b]`) off whatever the functor root
-  returns, and `recover` replays the **stored** sentexes rather than the checked ones, so
-  a store an older or foreign writer left a non-edge sentex under the genl / genlCx
-  functor root reaches here as a malformed edge: a 2-element metatype membership binds the
-  member as `a` and nil as `b`, an `arity` / `arg` declaration binds an integer.  Added,
-  the nil enters the closure's node set, and `strong-components` throws on it
-  (`java.util.ArrayDeque` rejects a null element) the moment `restore-depths` walks a loose
-  relation — the crash `recover` hits on such a store.
+  `recover` replays the **stored** sentexes rather than the checked ones, and
+  `stored-declarations` is a candidate read over the durable functor root, not proof that
+  every returned sentence has the requested functor or the current WFF shape.  So a store
+  an older, foreign, or stale writer left reaches here as a malformed edge, and reading it
+  positionally (`[_ a b]`) launders three distinct malformations into a spurious edge:
+
+    - a 2-element declaration (`(genl foo)`, a metatype membership, an `arity` / `arg`
+      row) binds the member as `a` and nil as `b` — the nil enters the closure's node set,
+      and `strong-components` throws on it (`java.util.ArrayDeque` rejects a null element)
+      the moment `restore-depths` walks a loose relation (the `recover` crash of #80);
+    - an **over-arity** row (`(genl a b surplus)`) binds `a` and `b` and silently discards
+      the surplus, fabricating `(genl a b)` from a sentence that never was one;
+    - a **wrong-functor** row (`(disjoint a b)` handed up under the genl root by a foreign
+      or stale index) has symbols in both positions and would replay as `(genl a b)`.
+
+  The last two both satisfy `(symbol? a) (symbol? b)`, so the endpoint-only guard passed
+  them; requiring the whole shape — arity three, the literal expected functor, both
+  endpoints symbols — is the producer boundary #80 drew, applied to the sentence entire.
 
   Dropping the malformed declaration is `rebuild-tms`'s discipline for a justification the
   store cannot root: the bad sentex is skipped and counted, never a spurious edge added.
   Returns tax."
-  [add tax a b id ctx]
-  (if (and (symbol? a) (symbol? b))
-    (add tax a b id ctx)
+  [add tax sentence expected-f id ctx]
+  (if (and (= 3 (count sentence))
+           (= expected-f (first sentence))
+           (symbol? (second sentence))
+           (symbol? (nth sentence 2)))
+    (add tax (second sentence) (nth sentence 2) id ctx)
     (do (when-let [v *edge-replay-skips*] (vswap! v inc)) tax)))
 
 (def ^:private arms
@@ -3720,8 +3734,8 @@
                            (let [[_ a b] (:sentence sx)]
                              (tax/del-genl! (:taxonomy kb) a b (:id sx))
                              (recheck-genl-edge kb a b)))
-           :rebuild      (fn [tax {[_ a b] :sentence id :id ctx :context}]
-                           (replay-edge tax/add-genl tax a b id ctx))
+           :rebuild      (fn [tax {sentence :sentence id :id ctx :context}]
+                           (replay-edge tax/add-genl tax sentence 'genl id ctx))
            :wff          wff/genl-problems}
     'genlCx {:integrate    (fn [kb sx h]
                              (let [[_ a b] (:sentence sx)]
@@ -3739,8 +3753,8 @@
                                (tax/del-genlCx! (:taxonomy kb) a b (:id sx))
                                (recheck-genlCx-edge kb a)
                                (recheck-except-ancestors kb)))
-             :rebuild      (fn [tax {[_ a b] :sentence id :id ctx :context}]
-                             (replay-edge tax/add-genlCx tax a b id ctx))
+             :rebuild      (fn [tax {sentence :sentence id :id ctx :context}]
+                             (replay-edge tax/add-genlCx tax sentence 'genlCx id ctx))
              :wff          wff/genlCx-problems}
     'disjoint {:integrate    (fn [kb sx h]
                                (let [[_ a b] (:sentence sx)]

--- a/test/vaelii/recovery_test.clj
+++ b/test/vaelii/recovery_test.clj
@@ -151,6 +151,49 @@
       (testing "and the drop is reported, not silent"
         (is (re-find #"not well-formed edges" out))))))
 
+(tu/deftest-kb recover-drops-over-arity-edge-declarations-rather-than-fabricating
+  ;; #82: v0.17's replay guard requires both endpoints to be symbols, but the rebuild arm
+  ;; reads the edge positionally (`[_ a b]`) off the stored sentence — so an OVER-ARITY row
+  ;; `(genl a b surplus)` an older or foreign writer left under the genl / genlCx functor
+  ;; root has symbols in positions 1 and 2, passes the endpoint-only guard, and is replayed
+  ;; as `(genl a b)`: an edge fabricated from a sentence that never was one, its surplus
+  ;; term silently discarded.  The endpoints are non-nil, so — unlike #80 — there is no
+  ;; `strong-components` crash; the bug is a SILENT fabrication.  The complete-shape guard
+  ;; (arity three, the expected functor, both endpoints symbols) drops it and counts it,
+  ;; the same producer boundary #80 drew, applied to the sentence entire.
+  (let [rec      (:records kb)
+        idx      (:index kb)
+        store!   (fn [sentence]                        ; put a sentex past the assert checks
+                   (let [s (sx/sentex sentence 'CxUniverse)
+                         h (p/put-sentex rec s)]
+                     (p/mark-premise rec h :default)
+                     (p/index-sentex idx (assoc s :id h) h)))
+        sub-ok   (tu/tmp-type)
+        super-ok (tu/tmp-type)]
+    ;; well-formed edges that MUST survive the rebuild
+    (v/assert kb (list 'genl sub-ok super-ok) 'CxUniverse)
+    (v/assert kb (list 'genlCx 'CxSubOk 'CxSuperOk) 'CxUniverse)
+    ;; over-arity declarations under the correct functor root, symbols in both endpoints —
+    ;; the shape the v0.17 endpoint guard replays and this fix rejects
+    (store! '(genl SubOver SuperOver SurplusOver))
+    (store! '(genlCx CxSubOver CxSuperOver CxSurplusOver))
+    (let [kb2   (restart)
+          level (v/log-level)
+          out   (try (v/set-log-level :warn)
+                     (with-out-str (v/recover kb2))
+                     (finally (v/set-log-level level)))
+          tax2  @(:taxonomy kb2)]
+      (testing "the well-formed edges survive the rebuild"
+        (is (contains? (set (v/genls kb2 sub-ok)) super-ok))
+        (is (contains? (get-in tax2 [:genlCx :nodes]) 'CxSubOk)))
+      (testing "the over-arity row seeds neither edge nor node"
+        (is (not (contains? (set (v/genls kb2 'SubOver)) 'SuperOver)))
+        (is (not (contains? (get-in tax2 [:genl :nodes]) 'SubOver)))
+        (is (not (contains? (get-in tax2 [:genl :nodes]) 'SurplusOver)))
+        (is (not (contains? (get-in tax2 [:genlCx :nodes]) 'CxSubOver))))
+      (testing "and the drop is reported, not silent"
+        (is (re-find #"not well-formed edges" out))))))
+
 (tu/deftest-kb recover-rebuilds-disjoint-metatype-membership
   ;; A metatype's members are cached in memory, not stored: the only durable trace is
   ;; the `(M T)` sentexes themselves.  So recovery has to re-read them *after* the


### PR DESCRIPTION
## What

Recovery's `genl` / `genlCx` rebuild arm replays each stored declaration through
`replay-edge`, which the v0.17.0 fix for #80 guards by requiring both positional
endpoints to be symbols. But the arm reads the stored sentence positionally
(`[_ a b]`), and `stored-declarations` is a candidate read over the durable functor
root — not proof of shape. Two malformations still slip through and fabricate a
taxonomy edge:

- an **over-arity** row `(genl a b surplus)` binds `a` and `b` and silently discards
  the surplus, replaying `(genl a b)` from a sentence that never was one;
- a **wrong-functor** row `(disjoint a b)` handed up under the `genl` root by a
  foreign or stale index has symbols in both positions and replays as `(genl a b)`.

Both satisfy the endpoint-only guard.

## Fix

Pass the whole stored sentence and the literal expected functor into `replay-edge`,
and require the complete shape before calling the taxonomy adder:

```clojure
(and (= 3 (count sentence))
     (= expected-f (first sentence))
     (symbol? (second sentence))
     (symbol? (nth sentence 2)))
```

Everything else is counted and dropped under the existing `::edges-malformed`
warning. This applies #80's producer boundary to the sentence entire, so a foreign
or stale index can neither fabricate a taxonomy edge nor hide a malformed row that
would later crash `strong-components`.

## Testing

- **New killing test** `recover-drops-over-arity-edge-declarations-rather-than-fabricating`:
  stores over-arity `genl` / `genlCx` declarations under the correct functor root
  (symbols in both endpoints, so the v0.17 guard replays them), then confirms the
  rebuild seeds neither edge nor node, leaves the well-formed edges intact, and
  reports the drop. Verified as a genuine killing test — it fails four assertions
  against the endpoint-only guard and passes with the complete-shape guard.
- Focused `vaelii.recovery-test`: 23 tests / 138 assertions, 0 failures.
- **Eight-backend recovery matrix**: `vaelii.recovery-test` (23 tests / 138
  assertions) run under every storage backend — `memory`, `memory-dense`,
  `memory-columnar`, `disk-memory`, `disk-dense`, `disk-columnar`, `disk-snapshot`,
  `disk-log` — plus `overlay`: **0 failures / 0 errors on all nine**. The recovery
  path is where the store/index/restart pairing actually varies, so this is the axis
  that matters for the fix. (`scripts/lib/suite-configs.sh` classifies the diff as
  backend-agnostic — the change lives in the shared rebuild arm — so the per-backend
  recovery run is the relevant confirmation rather than a swap of a store or index
  implementation.)

## Notes

- Targets `develop`, which already carries the v0.17.0 #80 endpoint guard (build
  `0.17.1-SNAPSHOT`); this strengthens that guard rather than reintroducing it.
- Closes #82.
