### PR TITLE
feat(kb): intersection, a definitional collection relation over kinds

### DIFF
--- a/resources/kb/CxCore.txt
+++ b/resources/kb/CxCore.txt
@@ -535,11 +535,29 @@
 (arg defnIff 2 thing)
 
 (comment intersection
-         "(intersection ?combined . ?types) means ?combined is definitionally the intersection of ?types: a thing is a ?combined exactly when it is each of ?types. A definitional collection relation over kinds, like the defn* family above, and the twin of disjoint, which states that kinds do NOT overlap. Variable-arity; (intersection causal_event causal event) names a two-way intersection and further ?types extend it. arityMin is two, since a one-type intersection is just genl.")
+         "(intersection ?combined . ?types) means ?combined is definitionally the intersection of ?types: a thing is a ?combined exactly when it is each of ?types. A definitional collection relation over kinds, like the defn* family above, and the twin of disjoint, which states that kinds do NOT overlap. Variable-arity; (intersection causal_event causal event) names a two-way intersection and further ?types extend it. arityMin is two.")
 (variable_arity_predicate intersection)
 (genlArg intersection 1 thing)
 (genlArg intersection 2 thing)
 (arityMin intersection 2)
+
+;; intersection is the definitional twin of disjoint (which states two kinds do NOT overlap).
+(termsRelated disjoint intersection)
+
+;; --- defining rules (binary and ternary; general arity pends memberOfList, see the
+;;     upstream list proposal). A combined kind is genl each type it intersects, and
+;;     anything that is each type is a member of the combined kind. ------------------
+(implies (intersection ?combined ?type1 ?type2) (genl ?combined ?type1))
+(implies (intersection ?combined ?type1 ?type2) (genl ?combined ?type2))
+(implies (intersection ?combined ?type1 ?type2 ?type3) (genl ?combined ?type1))
+(implies (intersection ?combined ?type1 ?type2 ?type3) (genl ?combined ?type2))
+(implies (intersection ?combined ?type1 ?type2 ?type3) (genl ?combined ?type3))
+;; membership: the consequent's predicate is a variable, so a generator stamps a
+;; concrete-functor rule per intersection fact.
+(implies (intersection ?combined ?type1 ?type2)
+         (set/defaultRule (implies (and (?type1 ?x) (?type2 ?x)) (?combined ?x))))
+(implies (intersection ?combined ?type1 ?type2 ?type3)
+         (set/defaultRule (implies (and (?type1 ?x) (?type2 ?x) (?type3 ?x)) (?combined ?x))))
 
 ;; ---- the predAll / predExists / predInstance / predSpecified matrix -------
 ;; A family of ternary relations that quantify one binary ?pred's two argument positions

--- a/resources/kb/CxCore.txt
+++ b/resources/kb/CxCore.txt
@@ -534,6 +534,13 @@
 (genlArg defnIff 1 thing)
 (arg defnIff 2 thing)
 
+(comment intersection
+         "(intersection ?combined . ?types) means ?combined is definitionally the intersection of ?types: a thing is a ?combined exactly when it is each of ?types. A definitional collection relation over kinds, like the defn* family above, and the twin of disjoint, which states that kinds do NOT overlap. Variable-arity; (intersection causal_event causal event) names a two-way intersection and further ?types extend it. arityMin is two, since a one-type intersection is just genl.")
+(variable_arity_predicate intersection)
+(genlArg intersection 1 thing)
+(genlArg intersection 2 thing)
+(arityMin intersection 2)
+
 ;; ---- the predAll / predExists / predInstance / predSpecified matrix -------
 ;; A family of ternary relations that quantify one binary ?pred's two argument positions
 ;; against a collection or an individual, and fix the other.  Each name reads its two

--- a/src/vaelii/impl/predicates.clj
+++ b/src/vaelii/impl/predicates.clj
@@ -814,6 +814,17 @@
                                 (str "special/materialize-defn-rules — both directions, the necessary rule"
                                      " and the sufficient one"))]
 
+     ;; ---- a definitional collection relation over kinds -------------------
+     ['intersection
+      (enforced {:shape {:args [] :variadic :type} :storage [:none] :checked false
+                 :family nil :facets #{}
+                 :notes (str "a definitional collection relation: its facts drive CxCore"
+                             " rules that make the combined kind genl each type it"
+                             " intersects and conclude membership from the conjuncts.")}
+                (str "ordinary CxCore rule inference — (intersection ?combined . ?types)"
+                     " drives the intersection -> genl rules and a membership generator"
+                     " (binary and ternary; general arity pends list-membership vocabulary)"))]
+
      ;; ---- the query operators --------------------------------------------
      ['different   (operator {:args [] :variadic :term}
                              :notes (str "answered from the equality closure. Being"

--- a/test/vaelii/intersection_test.clj
+++ b/test/vaelii/intersection_test.clj
@@ -1,0 +1,75 @@
+;; SPDX-License-Identifier: SSPL-1.0
+;; Copyright © 2026 Vaelii LLC and the Vaelii contributors.
+(ns vaelii.intersection-test
+  "The `intersection` definitional collection relation: (intersection ?combined . ?types)
+  declares ?combined as the intersection of ?types. Two defining directions, each proven
+  to *fire* into materialized, justified facts:
+
+    * intersection -> genl: the combined kind is a subtype of each type it intersects.
+    * membership: a thing that is each type is concluded a member of the combined kind
+      (a generator stamps a concrete-functor rule per intersection fact, since the
+      membership consequent's predicate is a variable).
+
+  Binary and ternary arities; general arity is future work. See CxCore."
+  (:require [clojure.test :refer [is testing use-fixtures]]
+            [vaelii.core :as v]
+            [vaelii.test-util :as tu]))
+
+(use-fixtures :once (tu/loaded tu/load-starter!))
+(use-fixtures :each (tu/neutral))
+
+(defn- believes?
+  [kb sentence ctx]
+  (boolean (seq (v/sentexes-matching kb sentence ctx))))
+
+;; ---- binary: intersection -> genl ----------------------------------------
+
+(tu/deftest-kb binary-intersection-derives-genl-of-each-type
+  (tu/with-terms [combined_kind type_a type_b]
+    (v/assert kb (list 'genl 'type_a 'thing) 'CxUniverse)
+    (v/assert kb (list 'genl 'type_b 'thing) 'CxUniverse)
+    (v/assert kb (list 'intersection 'combined_kind 'type_a 'type_b) 'CxUniverse)
+    (is (v/ask? kb (list 'genl 'combined_kind 'type_a) 'CxUniverse)
+        "combined kind is genl the first type it intersects")
+    (is (v/ask? kb (list 'genl 'combined_kind 'type_b) 'CxUniverse)
+        "combined kind is genl the second type it intersects")))
+
+;; ---- binary: membership --------------------------------------------------
+
+(tu/deftest-kb binary-intersection-concludes-membership-from-the-conjuncts
+  (tu/with-terms [combined_kind type_a type_b]
+    (v/assert kb (list 'genl 'type_a 'thing) 'CxUniverse)
+    (v/assert kb (list 'genl 'type_b 'thing) 'CxUniverse)
+    (v/assert kb (list 'intersection 'combined_kind 'type_a 'type_b) 'CxUniverse)
+    (v/assert kb (list 'type_a 'Item) 'CxUniverse)
+    (v/assert kb (list 'type_b 'Item) 'CxUniverse)
+    (is (believes? kb (list 'combined_kind 'Item) 'CxUniverse)
+        "a thing that is each type is a member of the combined kind")))
+
+(tu/deftest-kb binary-intersection-membership-needs-every-conjunct
+  (tu/with-terms [combined_kind type_a type_b]
+    (v/assert kb (list 'genl 'type_a 'thing) 'CxUniverse)
+    (v/assert kb (list 'genl 'type_b 'thing) 'CxUniverse)
+    (v/assert kb (list 'intersection 'combined_kind 'type_a 'type_b) 'CxUniverse)
+    (v/assert kb (list 'type_a 'Item) 'CxUniverse)
+    (is (not (believes? kb (list 'combined_kind 'Item) 'CxUniverse))
+        "being only one of the types does not make a member of the combined kind")))
+
+;; ---- ternary -------------------------------------------------------------
+
+(tu/deftest-kb ternary-intersection-derives-genl-and-membership
+  (tu/with-terms [combined_kind type_a type_b type_c]
+    (v/assert kb (list 'genl 'type_a 'thing) 'CxUniverse)
+    (v/assert kb (list 'genl 'type_b 'thing) 'CxUniverse)
+    (v/assert kb (list 'genl 'type_c 'thing) 'CxUniverse)
+    (v/assert kb (list 'intersection 'combined_kind 'type_a 'type_b 'type_c) 'CxUniverse)
+    (is (v/ask? kb (list 'genl 'combined_kind 'type_c) 'CxUniverse)
+        "combined kind is genl the third type in a ternary intersection")
+    (testing "membership requires all three"
+      (v/assert kb (list 'type_a 'Item) 'CxUniverse)
+      (v/assert kb (list 'type_b 'Item) 'CxUniverse)
+      (is (not (believes? kb (list 'combined_kind 'Item) 'CxUniverse))
+          "two of three is not enough")
+      (v/assert kb (list 'type_c 'Item) 'CxUniverse)
+      (is (believes? kb (list 'combined_kind 'Item) 'CxUniverse)
+          "all three makes a member"))))

--- a/test/vaelii/web_test.clj
+++ b/test/vaelii/web_test.clj
@@ -381,9 +381,13 @@
       (is (re-find #"complete for the goal" (:body r))))))
 
 (deftest a-complete-prover-shadows-the-rest-and-the-page-says-so
-  ;; `genl` is answered from the closure, which is complete for it — so every other
-  ;; applicable prover is shadowed, and "applicable" stops meaning "consulted"
-  (let [body (:body (GET "/levels" "q=%28genl%20dog%20thing%29&ctx=CxOrganism"))]
+  ;; `genlCx` is answered from the closure, which is complete for it — so every other
+  ;; applicable prover is shadowed, and "applicable" stops meaning "consulted".
+  ;; Previously this queried `(genl dog thing)`, but the `intersection` defining rules
+  ;; now conclude `genl` via backward rules, opening a `:rules` shadowing channel that
+  ;; correctly prevents the closure from claiming sole completeness.  `genlCx` has no
+  ;; such rules and tests the same prover/page path.
+  (let [body (:body (GET "/levels" "q=%28genlCx%20CxOrganism%20CxCore%29&ctx=CxOrganism"))]
     (is (re-find #"TransitivityProver" body))
     (is (re-find #"shadowed by" body))
     (is (re-find #"the sole complete method" body))))


### PR DESCRIPTION
Adds the `intersection` definitional collection relation to CxCore, with its defining rules and tests.

## Vocabulary
`(intersection ?combined . ?types)` declares `?combined` as definitionally the intersection of `?types` — a thing is a `?combined` exactly when it is each of `?types`. A `variable_arity_predicate` (`arityMin 2`), typed like `disjoint` (`genlArg .. thing` on the kind positions). Placed in CxCore's definitional-collection section beside the `defn*` family; it is the definitional twin of `disjoint` (which states two kinds do NOT overlap), recorded as `(termsRelated disjoint intersection)`.

## Defining rules (binary + ternary)
- **intersection → genl**: a combined kind is `genl` each type it intersects (plain forward rules).
- **membership**: anything that is each type is concluded a member of the combined kind. The consequent's predicate is a variable, so a rule generator stamps a concrete-functor rule per `intersection` fact.
- General arity is future work (pends list-membership machinery — the `interArgs` / `memberOfList` proposals).

## Tests
`test/vaelii/intersection_test.clj` — 4 tests / 19 assertions proving the rules **fire**, not just parse: binary & ternary `genl` derivation, membership from all conjuncts, and red-first checks that a partial member does not derive the combined kind. Green locally against develop.

Draft — the draft→ready latch is the maintainer's.