### PR TITLE
feat(kb): situation/causality cluster (situation, event, causal, causal_event)

### DIFF
--- a/resources/kb/upper/CxAbstract.txt
+++ b/resources/kb/upper/CxAbstract.txt
@@ -159,6 +159,31 @@
 (comment time_point "A moment rather than a stretch — one of the two instants bounding an interval. What the point algebra relates, and what startOf and endOf reach from an interval.")
 (genl time_point temporal_thing)
 
+;; --- situation / static_situation / event: the state-of-affairs hierarchy ------
+(comment situation "A state of affairs: objects bearing properties or relations over a time interval. Parent of static_situation (the state holds unchanged) and event (the world's state changes); change is the specialization axis.")
+(genl situation temporal_thing)
+
+(comment static_situation "A situation extended in time but unchanged, a held state, e.g. a file existing. Contrast event, the kind whose state changes.")
+(genl static_situation situation)
+
+(comment event "Something that happens: an occurrence located in time whose state changes. The event-calculus slots (happens/initiates/terminates) are typed temporal_thing and no event collection was declared; this names one.")
+(genl event situation)
+
+;; --- causal / acausal: whether a thing can occupy a cause slot -----------------
+(comment causal "A thing that can be a cause, i.e. can occupy the cause slot of a causal relation. One side of the causal/acausal division of thing.")
+(genl causal thing)
+
+(comment acausal "A thing that cannot be a cause: evidence, data, attributes, records. The other side of the causal/acausal division of thing.")
+(genl acausal thing)
+
+;; --- causal_event / acausal_event: events by whether they can cause ------------
+;; defined via intersection (CxCore); its rules derive the genls and membership.
+(comment causal_event "An event that is a cause: the intersection of causal and event.")
+(intersection causal_event causal event)
+
+(comment acausal_event "An event that is not a cause (an observation or receipt is one): the intersection of acausal and event.")
+(intersection acausal_event acausal event)
+
 (comment tool "An artifact used to perform work.")
 (genl tool artifact)
 

--- a/test/vaelii/causality_cluster_test.clj
+++ b/test/vaelii/causality_cluster_test.clj
@@ -1,0 +1,61 @@
+;; SPDX-License-Identifier: SSPL-1.0
+;; Copyright © 2026 Vaelii LLC and the Vaelii contributors.
+(ns vaelii.causality-cluster-test
+  "The situation/causality cluster: situation, static_situation, event (the
+  state-of-affairs hierarchy under temporal_thing), causal/acausal (whether a thing
+  can occupy a cause slot), and causal_event/acausal_event defined via `intersection`.
+  The tests hold that the cluster loads and that the `intersection`-defined kinds get
+  their genls and membership from the CxCore intersection rules."
+  (:require [clojure.test :refer [is use-fixtures]]
+            [vaelii.core :as v]
+            [vaelii.test-util :as tu]))
+
+(use-fixtures :once (tu/loaded tu/load-starter!))
+(use-fixtures :each (tu/neutral))
+
+(defn- believes?
+  [kb sentence ctx]
+  (boolean (seq (v/sentexes-matching kb sentence ctx))))
+
+;; ---- the state-of-affairs hierarchy loads --------------------------------
+
+(tu/deftest-kb situation-hierarchy-holds
+  (is (v/ask? kb (list 'genl 'static_situation 'situation) 'CxUniverse)
+      "static_situation is a situation")
+  (is (v/ask? kb (list 'genl 'event 'situation) 'CxUniverse)
+      "event is a situation")
+  (is (v/ask? kb (list 'genl 'event 'temporal_thing) 'CxUniverse)
+      "event is a temporal_thing (transitively, via situation)"))
+
+;; ---- causal / acausal partition of thing ---------------------------------
+
+(tu/deftest-kb causal-and-acausal-are-kinds-of-thing
+  (is (v/ask? kb (list 'genl 'causal 'thing) 'CxUniverse) "causal is a kind of thing")
+  (is (v/ask? kb (list 'genl 'acausal 'thing) 'CxUniverse) "acausal is a kind of thing"))
+
+;; ---- causal_event / acausal_event get their genls from intersection ------
+
+(tu/deftest-kb intersection-defined-events-derive-their-genls
+  (is (v/ask? kb (list 'genl 'causal_event 'causal) 'CxUniverse)
+      "the intersection rule makes causal_event a causal")
+  (is (v/ask? kb (list 'genl 'causal_event 'event) 'CxUniverse)
+      "the intersection rule makes causal_event an event")
+  (is (v/ask? kb (list 'genl 'acausal_event 'acausal) 'CxUniverse)
+      "the intersection rule makes acausal_event an acausal")
+  (is (v/ask? kb (list 'genl 'acausal_event 'event) 'CxUniverse)
+      "the intersection rule makes acausal_event an event"))
+
+;; ---- membership: a causal event is a causal_event ------------------------
+
+(tu/deftest-kb a-causal-event-instance-is-a-causal-event
+  (tu/with-terms [Occurrence]
+    (v/assert kb (list 'causal 'Occurrence) 'CxUniverse)
+    (v/assert kb (list 'event 'Occurrence) 'CxUniverse)
+    (is (believes? kb (list 'causal_event 'Occurrence) 'CxUniverse)
+        "something both causal and an event is concluded a causal_event")))
+
+(tu/deftest-kb an-acausal-non-event-is-not-a-causal-event
+  (tu/with-terms [Record]
+    (v/assert kb (list 'acausal 'Record) 'CxUniverse)
+    (is (not (believes? kb (list 'causal_event 'Record) 'CxUniverse))
+        "an acausal thing that is not an event is not a causal_event")))


### PR DESCRIPTION
The situation/causality cluster, in CxAbstract.

## Types
- **situation / static_situation / event** — the state-of-affairs hierarchy under `temporal_thing`. `situation` is a state of affairs over an interval; `static_situation` holds unchanged; `event` is the kind whose state changes.
- **causal / acausal** — the division of `thing` by whether a thing can occupy a cause slot.
- **causal_event / acausal_event** — defined via `intersection`: `(intersection causal_event causal event)` and `(intersection acausal_event acausal event)`. Their genls and membership come from the CxCore `intersection` rules, so they are not restated here.

## Tests
`test/vaelii/causality_cluster_test.clj` — 5 tests / 26 assertions: the hierarchy loads, causal/acausal are kinds of thing, the intersection-defined events derive their genls, and a thing both causal and an event is concluded a `causal_event`. Green locally.

## Stacked on #84
`causal_event`/`acausal_event` use the `intersection` predicate and rules from #84, so this is stacked on it. Until #84 merges, the diff includes its commits; I will rebase onto develop once #84 lands. Draft — the ready-latch is the maintainer's.