### PR TITLE
feat(core): disjointness audit — subsumption-status and disjointness-audit

### DIFF
--- a/docs/namespaces.md
+++ b/docs/namespaces.md
@@ -247,6 +247,10 @@ them ([why they live here](defenses.md#the-layering-inversions-live-in-wiringclj
   the preparation a public read runs. The reader asks through the public read path, and
   the delegation points up to reach it ([predall.md](predall.md)).
 
+- **`subsumption-status`** / **`disjointness-audit`** — the genl-hierarchy audit pair,
+  both in `vaelii.core` with no delegation. `subsumption-status` classifies one
+  `(a, b)` pair; `disjointness-audit` sweeps every unordered pair of types.
+
 `lein lint`'s **E8** fails a literal `requiring-resolve` anywhere else under `src/`,
 excepting the keyword-dispatch registries it names.
 

--- a/src/vaelii/core.clj
+++ b/src/vaelii/core.clj
@@ -4054,6 +4054,52 @@
   [kb result]
   (abduce/discard! kb (if (map? result) (:context result) result) abduce-ops))
 
+(defn subsumption-status
+  "The subsumption relationship of type `a` to type `b`, one of:
+  `:coextensional` (each is `genl` the other), `:genl` (`a` generalizes `b` — `b` is a
+  subtype of `a`), `:spec` (`a` specializes `b` — `a` is a subtype of `b`), `:disjoint`
+  (provably no shared instance), `:orthogonal` (neither subsumes the other and not
+  disjoint, but a shared instance is provable), or `:unknown` (none of the above is
+  provable). Judged from the global vantage. `:orthogonal`'s witness is a shared
+  instance — a member of `a` that is also a member of `b` — the only way overlap is
+  shown when neither the taxonomy nor a
+  `disjoint` declaration settles the pair."
+  [kb a b]
+  (let [a<b (genl? kb a b)
+        b<a (genl? kb b a)]
+    (cond
+      (and a<b b<a)      :coextensional
+      b<a                :genl
+      a<b                :spec
+      (disjoint? kb a b) :disjoint
+      (boolean (some #(isa? kb (get % '?x) b)
+                     (query kb (list a '?x) 'CxUniverse))) :orthogonal
+      :else              :unknown)))
+
+(defn disjointness-audit
+  "The `subsumption-status` of every unordered pair of distinct types in the genl
+  hierarchy. Returns `{:types n :pairs n :by-status {status count …} :pairs-data
+  [{:a t :b t :status s} …]}`. `genl?` and `disjoint?` read cached closures, and the
+  shared-instance query runs only for a pair the taxonomy and disjoint declarations
+  leave open — so the N² sweep over the starter is cheap. The `:unknown` pairs are the
+  candidates for a missing `disjoint` assertion."
+  [kb]
+  (let [ts   (vec (sort (types kb)))
+        n    (count ts)
+        data (persistent!
+              (reduce
+               (fn [acc i]
+                 (reduce
+                  (fn [a j]
+                    (conj! a {:a (nth ts i) :b (nth ts j)
+                              :status (subsumption-status kb (nth ts i) (nth ts j))}))
+                  acc (range (inc i) n)))
+               (transient []) (range n)))]
+    {:types     n
+     :pairs     (count data)
+     :by-status (frequencies (map :status data))
+     :pairs-data data}))
+
 (defn query-plan
   "How a goal would be answered, at whichever of the two scales the goal has.
 

--- a/src/vaelii/core.clj
+++ b/src/vaelii/core.clj
@@ -4056,8 +4056,8 @@
 
 (defn subsumption-status
   "The subsumption relationship of type `a` to type `b`, one of:
-  `:coextensional` (each is `genl` the other), `:genl` (`a` generalizes `b` — `b` is a
-  subtype of `a`), `:spec` (`a` specializes `b` — `a` is a subtype of `b`), `:disjoint`
+  `:coextensional` (each is `genl` the other), `:genl` (`(genl a b)` holds — `a` is a
+  subtype of `b`), `:spec` (`(genl b a)` holds — `a` is a supertype of `b`), `:disjoint`
   (provably no shared instance), `:orthogonal` (neither subsumes the other and not
   disjoint, but a shared instance is provable), or `:unknown` (none of the above is
   provable). Judged from the global vantage. `:orthogonal`'s witness is a shared
@@ -4069,8 +4069,8 @@
         b<a (genl? kb b a)]
     (cond
       (and a<b b<a)      :coextensional
-      b<a                :genl
-      a<b                :spec
+      a<b                :genl
+      b<a                :spec
       (disjoint? kb a b) :disjoint
       (boolean (some #(isa? kb (get % '?x) b)
                      (query kb (list a '?x) 'CxUniverse))) :orthogonal

--- a/test/golden/api-surface.edn
+++ b/test/golden/api-surface.edn
@@ -198,6 +198,7 @@
   describe-opt-keys :var,
   disjoint-metatypes "[[kb]]",
   disjoint? "[[kb a b] [kb a b context]]",
+  disjointness-audit "[[kb]]",
   edit! "[[kb batch]]",
   edit-batch-keys :var,
   edit-with-consequences! "[[kb batch] [kb batch opts]]",
@@ -283,6 +284,7 @@
   specified-violations
   "[[kb pred indep context] [kb pred indep context arg-pos]]",
   specs "[[kb t] [kb t context]]",
+  subsumption-status "[[kb a b]]",
   supporting-justifications "[[kb handle]]",
   term-count "[[kb]]",
   term-expression "[[kb term]]",

--- a/test/vaelii/disjointness_audit_test.clj
+++ b/test/vaelii/disjointness_audit_test.clj
@@ -5,7 +5,7 @@
   over every unordered pair. The status cases: :genl / :spec (one subsumes the other),
   :coextensional (mutual), :disjoint (a declaration, closed under genl), :orthogonal
   (a provable shared instance with no subsumption or disjointness), and :unknown."
-  (:require [clojure.test :refer [is testing use-fixtures]]
+  (:require [clojure.test :refer [is use-fixtures]]
             [vaelii.core :as v]
             [vaelii.test-util :as tu]))
 
@@ -18,8 +18,10 @@
   (tu/with-terms [animal dog]
     (v/assert kb (list 'genl 'animal 'thing) 'CxUniverse)
     (v/assert kb (list 'genl 'dog 'animal) 'CxUniverse)
-    (is (= :genl (v/subsumption-status kb 'animal 'dog)) "animal generalizes dog")
-    (is (= :spec (v/subsumption-status kb 'dog 'animal)) "dog specializes animal")))
+    (is (= :genl (v/subsumption-status kb 'dog 'animal))
+        "(genl dog animal) holds — dog is a subtype of animal")
+    (is (= :spec (v/subsumption-status kb 'animal 'dog))
+        "the converse — animal is a supertype of dog")))
 
 (tu/deftest-kb disjoint-pair-reads-disjoint
   (tu/with-terms [plant mineral]

--- a/test/vaelii/disjointness_audit_test.clj
+++ b/test/vaelii/disjointness_audit_test.clj
@@ -1,0 +1,57 @@
+;; SPDX-License-Identifier: SSPL-1.0
+;; Copyright © 2026 Vaelii LLC and the Vaelii contributors.
+(ns vaelii.disjointness-audit-test
+  "`subsumption-status` classifies a pair of types, and `disjointness-audit` runs it
+  over every unordered pair. The status cases: :genl / :spec (one subsumes the other),
+  :coextensional (mutual), :disjoint (a declaration, closed under genl), :orthogonal
+  (a provable shared instance with no subsumption or disjointness), and :unknown."
+  (:require [clojure.test :refer [is testing use-fixtures]]
+            [vaelii.core :as v]
+            [vaelii.test-util :as tu]))
+
+(use-fixtures :once (tu/loaded tu/load-starter!))
+(use-fixtures :each (tu/neutral))
+
+;; ---- subsumption-status, one case each ------------------------------------
+
+(tu/deftest-kb genl-and-spec-are-converse
+  (tu/with-terms [animal dog]
+    (v/assert kb (list 'genl 'animal 'thing) 'CxUniverse)
+    (v/assert kb (list 'genl 'dog 'animal) 'CxUniverse)
+    (is (= :genl (v/subsumption-status kb 'animal 'dog)) "animal generalizes dog")
+    (is (= :spec (v/subsumption-status kb 'dog 'animal)) "dog specializes animal")))
+
+(tu/deftest-kb disjoint-pair-reads-disjoint
+  (tu/with-terms [plant mineral]
+    (v/assert kb (list 'genl 'plant 'thing) 'CxUniverse)
+    (v/assert kb (list 'genl 'mineral 'thing) 'CxUniverse)
+    (v/assert kb (list 'disjoint 'plant 'mineral) 'CxUniverse)
+    (is (= :disjoint (v/subsumption-status kb 'plant 'mineral)))))
+
+(tu/deftest-kb orthogonal-needs-a-shared-instance-without-subsumption
+  (tu/with-terms [striped aquatic Nemo]
+    (v/assert kb (list 'genl 'striped 'thing) 'CxUniverse)
+    (v/assert kb (list 'genl 'aquatic 'thing) 'CxUniverse)
+    (is (= :unknown (v/subsumption-status kb 'striped 'aquatic))
+        "no relation and no shared instance yet")
+    (v/assert kb (list 'striped 'Nemo) 'CxUniverse)
+    (v/assert kb (list 'aquatic 'Nemo) 'CxUniverse)
+    (is (= :orthogonal (v/subsumption-status kb 'striped 'aquatic))
+        "a provable shared instance, with neither subsuming nor disjoint")))
+
+(tu/deftest-kb a-known-starter-disjoint-pair
+  ;; function and predicate are declared disjoint in CxCore.
+  (is (= :disjoint (v/subsumption-status kb 'function 'predicate))))
+
+;; ---- the audit ------------------------------------------------------------
+
+(tu/deftest-kb audit-covers-every-unordered-pair-with-a-status
+  (let [a (v/disjointness-audit kb)
+        n (:types a)]
+    (is (pos? n) "the starter has types")
+    (is (= (:pairs a) (/ (* n (dec n)) 2)) "every unordered distinct pair")
+    (is (= (:pairs a) (reduce + (vals (:by-status a)))) "every pair got exactly one status")
+    (is (every? #{:genl :spec :coextensional :disjoint :orthogonal :unknown}
+                (keys (:by-status a)))
+        "only the defined statuses appear")
+    (is (contains? (:by-status a) :disjoint) "the starter has some disjoint pairs")))


### PR DESCRIPTION
A sibling to the KB quality / integrity readings: a disjointness audit.

## `subsumption-status`
`(subsumption-status kb a b)` classifies a pair of types as one of `:genl` (a generalizes b), `:spec` (a specializes b), `:coextensional` (mutual), `:disjoint` (declared, closed under genl), `:orthogonal` (a provable shared instance with no subsumption or disjointness), or `:unknown`.

## `disjointness-audit`
`(disjointness-audit kb)` runs it over every unordered pair of distinct types, returning `{:types :pairs :by-status :pairs-data}`. `genl?`/`disjoint?` read cached closures; the shared-instance check runs only for pairs the taxonomy and `disjoint` declarations leave open, so the N² sweep over the starter is cheap.

## Starter sweep
143 types, 10153 pairs: `:unknown` 8196, `:disjoint` 1309, `:genl` 356, `:spec` 242, `:orthogonal` 50 (no `:coextensional`). The 8196 `:unknown` pairs are the candidates for missing `disjoint` assertions.

## Tests
`test/vaelii/disjointness_audit_test.clj` — 5 tests / 26 assertions: each status case, plus the audit's shape and coverage. Green locally.

Draft — the ready-latch is the maintainer's.