### PR TITLE
feat(core): subsumption-statuses + inconsistency detection

### DIFF
--- a/docs/namespaces.md
+++ b/docs/namespaces.md
@@ -247,9 +247,12 @@ them ([why they live here](defenses.md#the-layering-inversions-live-in-wiringclj
   the preparation a public read runs. The reader asks through the public read path, and
   the delegation points up to reach it ([predall.md](predall.md)).
 
-- **`subsumption-status`** / **`disjointness-audit`** — the genl-hierarchy audit pair,
-  both in `vaelii.core` with no delegation. `subsumption-status` classifies one
-  `(a, b)` pair; `disjointness-audit` sweeps every unordered pair of types.
+- **`subsumption-statuses`** / **`subsumption-status`** / **`disjointness-audit`** — the
+  genl-hierarchy audit family, all in `vaelii.core` with no delegation.
+  `subsumption-statuses` returns the full set of applicable relationships for one pair
+  (a singleton when consistent, multiple when contradictory, empty when unknown);
+  `subsumption-status` wraps it as a single keyword (`:inconsistent` for contradictions,
+  `:unknown` for empty); `disjointness-audit` sweeps every unordered pair of types.
 
 `lein lint`'s **E8** fails a literal `requiring-resolve` anywhere else under `src/`,
 excepting the keyword-dispatch registries it names.

--- a/src/vaelii/core.clj
+++ b/src/vaelii/core.clj
@@ -4054,13 +4054,12 @@
   [kb result]
   (abduce/discard! kb (if (map? result) (:context result) result) abduce-ops))
 
-(defn subsumption-status
-  "The subsumption relationship of type `a` to type `b`, one of:
-  `:coextensional` (each is `genl` the other), `:genl` (`(genl a b)` holds — `a` is a
-  subtype of `b`), `:spec` (`(genl b a)` holds — `a` is a supertype of `b`), `:disjoint`
-  (provably no shared instance), `:orthogonal` (neither subsumes the other and not
-  disjoint, but a shared instance the registry answers without rule expansion exists),
-  or `:unknown` (none of the above is provable). Judged from the global vantage.
+(defn subsumption-statuses
+  "The set of applicable subsumption relationships between types `a` and `b`:
+  any subset of `#{:coextensional :genl :spec :disjoint :orthogonal}`.  A consistent
+  pair yields a singleton; an inconsistent pair (e.g. both genl-related and disjoint)
+  yields multiple; a pair with no provable relationship yields the empty set.
+  Judged from the global vantage.
   `:orthogonal`'s witness is a shared instance — a member of `a` that is also a member
   of `b` — the only way overlap is shown when neither the taxonomy nor a `disjoint`
   declaration settles the pair. The witness is a facts-only read (`{:max-depth 0}`), so
@@ -4068,11 +4067,11 @@
   [kb a b]
   (let [a<b (genl? kb a b)
         b<a (genl? kb b a)]
-    (cond
-      (and a<b b<a)      :coextensional
-      a<b                :genl
-      b<a                :spec
-      (disjoint? kb a b) :disjoint
+    (cond-> #{}
+      (and a<b b<a)                                        (conj :coextensional)
+      (and a<b (not b<a))                                  (conj :genl)
+      (and b<a (not a<b))                                  (conj :spec)
+      (disjoint? kb a b)                                   (conj :disjoint)
       ;; The shared-instance check is facts-only, pinned with `{:max-depth 0}` so it
       ;; expands no rule and does not inherit an ambient depth. `query` with no depth
       ;; falls back to `inference/*max-depth*` (`query-depth`), which the query-engine
@@ -4081,9 +4080,22 @@
       ;; under a breadth-first tactician. `:orthogonal`'s witness is a shared instance
       ;; the registry answers without rule expansion, which is what the default engine
       ;; already reads and what keeps this status engine-independent.
-      (boolean (some #(isa? kb (get % '?x) b)
-                     (query kb (list a '?x) 'CxUniverse {:max-depth 0}))) :orthogonal
-      :else              :unknown)))
+      (and (not a<b) (not b<a) (not (disjoint? kb a b))
+           (boolean (some #(isa? kb (get % '?x) b)
+                          (query kb (list a '?x) 'CxUniverse {:max-depth 0})))) (conj :orthogonal))))
+
+(defn subsumption-status
+  "The subsumption relationship of type `a` to type `b`, one of:
+  `:coextensional`, `:genl`, `:spec`, `:disjoint`, `:orthogonal`, `:unknown`
+  (no provable relationship), or `:inconsistent` (multiple contradictory
+  relationships hold, e.g. both genl-related and disjoint).
+  Judged from the global vantage."
+  [kb a b]
+  (let [ss (subsumption-statuses kb a b)]
+    (case (count ss)
+      0 :unknown
+      1 (first ss)
+      :inconsistent)))
 
 (defn disjointness-audit
   "The `subsumption-status` of every unordered pair of distinct types in the genl
@@ -4091,7 +4103,9 @@
   [{:a t :b t :status s} …]}`. `genl?` and `disjoint?` read cached closures, and the
   shared-instance query runs only for a pair the taxonomy and disjoint declarations
   leave open — so the N² sweep over the starter is cheap. The `:unknown` pairs are the
-  candidates for a missing `disjoint` assertion."
+  candidates for a missing `disjoint` assertion.  Each entry carries both the resolved
+  `:status` keyword and the raw `:statuses` set from `subsumption-statuses`, so
+  contradictions are visible without re-querying."
   [kb]
   (let [ts   (vec (sort (types kb)))
         n    (count ts)
@@ -4100,8 +4114,14 @@
                (fn [acc i]
                  (reduce
                   (fn [a j]
-                    (conj! a {:a (nth ts i) :b (nth ts j)
-                              :status (subsumption-status kb (nth ts i) (nth ts j))}))
+                    (let [ss (subsumption-statuses kb (nth ts i) (nth ts j))]
+                      (conj! a {:a        (nth ts i)
+                                :b        (nth ts j)
+                                :statuses ss
+                                :status   (case (count ss)
+                                            0 :unknown
+                                            1 (first ss)
+                                            :inconsistent)})))
                   acc (range (inc i) n)))
                (transient []) (range n)))]
     {:types     n

--- a/test/golden/api-surface.edn
+++ b/test/golden/api-surface.edn
@@ -285,6 +285,7 @@
   "[[kb pred indep context] [kb pred indep context arg-pos]]",
   specs "[[kb t] [kb t context]]",
   subsumption-status "[[kb a b]]",
+  subsumption-statuses "[[kb a b]]",
   supporting-justifications "[[kb handle]]",
   term-count "[[kb]]",
   term-expression "[[kb term]]",

--- a/test/vaelii/disjointness_audit_test.clj
+++ b/test/vaelii/disjointness_audit_test.clj
@@ -62,11 +62,11 @@
     ;; X and Y are genl-related, so the trusted bulk path is the
     ;; narrow existing bypass for testing inconsistency detection.
     (v/bulk-assert-facts! kb
-      [(list 'genl 'alphaKind 'thing)
-       (list 'genl 'betaKind 'thing)
-       (list 'genl 'alphaKind 'betaKind)
-       (list 'disjoint 'alphaKind 'betaKind)]
-      'CxUniverse)
+                          [(list 'genl 'alphaKind 'thing)
+                           (list 'genl 'betaKind 'thing)
+                           (list 'genl 'alphaKind 'betaKind)
+                           (list 'disjoint 'alphaKind 'betaKind)]
+                          'CxUniverse)
     (is (= #{:genl :disjoint} (v/subsumption-statuses kb 'alphaKind 'betaKind))
         "the set contains both relationships")
     (is (= :inconsistent (v/subsumption-status kb 'alphaKind 'betaKind))

--- a/test/vaelii/disjointness_audit_test.clj
+++ b/test/vaelii/disjointness_audit_test.clj
@@ -56,14 +56,20 @@
         "a consistent disjoint pair yields a singleton set")))
 
 (tu/deftest-kb inconsistent-pair-is-both-genl-and-disjoint
-  (tu/with-terms [a-kind b-kind]
-    (v/assert kb (list 'genl 'a-kind 'thing) 'CxUniverse)
-    (v/assert kb (list 'genl 'b-kind 'thing) 'CxUniverse)
-    (v/assert kb (list 'genl 'a-kind 'b-kind) 'CxUniverse)
-    (v/assert kb (list 'disjoint 'a-kind 'b-kind) 'CxUniverse)
-    (is (= #{:genl :disjoint} (v/subsumption-statuses kb 'a-kind 'b-kind))
+  (tu/with-terms [alphaKind betaKind]
+    ;; Use bulk-assert-facts! to construct the inconsistent snapshot:
+    ;; the production WFF guard correctly refuses (disjoint X Y) when
+    ;; X and Y are genl-related, so the trusted bulk path is the
+    ;; narrow existing bypass for testing inconsistency detection.
+    (v/bulk-assert-facts! kb
+      [(list 'genl 'alphaKind 'thing)
+       (list 'genl 'betaKind 'thing)
+       (list 'genl 'alphaKind 'betaKind)
+       (list 'disjoint 'alphaKind 'betaKind)]
+      'CxUniverse)
+    (is (= #{:genl :disjoint} (v/subsumption-statuses kb 'alphaKind 'betaKind))
         "the set contains both relationships")
-    (is (= :inconsistent (v/subsumption-status kb 'a-kind 'b-kind))
+    (is (= :inconsistent (v/subsumption-status kb 'alphaKind 'betaKind))
         "subsumption-status returns :inconsistent for a contradictory pair")))
 
 ;; ---- the audit ------------------------------------------------------------

--- a/test/vaelii/disjointness_audit_test.clj
+++ b/test/vaelii/disjointness_audit_test.clj
@@ -45,6 +45,27 @@
   ;; function and predicate are declared disjoint in CxCore.
   (is (= :disjoint (v/subsumption-status kb 'function 'predicate))))
 
+;; ---- subsumption-statuses and inconsistency --------------------------------
+
+(tu/deftest-kb subsumption-statuses-returns-singleton-for-consistent-pair
+  (tu/with-terms [plant mineral]
+    (v/assert kb (list 'genl 'plant 'thing) 'CxUniverse)
+    (v/assert kb (list 'genl 'mineral 'thing) 'CxUniverse)
+    (v/assert kb (list 'disjoint 'plant 'mineral) 'CxUniverse)
+    (is (= #{:disjoint} (v/subsumption-statuses kb 'plant 'mineral))
+        "a consistent disjoint pair yields a singleton set")))
+
+(tu/deftest-kb inconsistent-pair-is-both-genl-and-disjoint
+  (tu/with-terms [a-kind b-kind]
+    (v/assert kb (list 'genl 'a-kind 'thing) 'CxUniverse)
+    (v/assert kb (list 'genl 'b-kind 'thing) 'CxUniverse)
+    (v/assert kb (list 'genl 'a-kind 'b-kind) 'CxUniverse)
+    (v/assert kb (list 'disjoint 'a-kind 'b-kind) 'CxUniverse)
+    (is (= #{:genl :disjoint} (v/subsumption-statuses kb 'a-kind 'b-kind))
+        "the set contains both relationships")
+    (is (= :inconsistent (v/subsumption-status kb 'a-kind 'b-kind))
+        "subsumption-status returns :inconsistent for a contradictory pair")))
+
 ;; ---- the audit ------------------------------------------------------------
 
 (tu/deftest-kb audit-covers-every-unordered-pair-with-a-status
@@ -53,7 +74,7 @@
     (is (pos? n) "the starter has types")
     (is (= (:pairs a) (/ (* n (dec n)) 2)) "every unordered distinct pair")
     (is (= (:pairs a) (reduce + (vals (:by-status a)))) "every pair got exactly one status")
-    (is (every? #{:genl :spec :coextensional :disjoint :orthogonal :unknown}
+    (is (every? #{:genl :spec :coextensional :disjoint :orthogonal :unknown :inconsistent}
                 (keys (:by-status a)))
         "only the defined statuses appear")
     (is (contains? (:by-status a) :disjoint) "the starter has some disjoint pairs")))


### PR DESCRIPTION
Follow-up to #86 (merged before this landed).

Adds `subsumption-statuses`, which returns the full set of applicable
relationships for a type pair — singleton when consistent, multiple when
contradictory, empty when unknown. Rewrites `subsumption-status` to wrap
it: singleton → that status, empty → `:unknown`, multiple → `:inconsistent`.

`disjointness-audit` now calls `subsumption-statuses` and each pair carries
both `:statuses` (the raw set) and `:status` (the resolved keyword), so
contradictions are visible without re-querying.

Tests: inconsistency detection + audit status set expanded.

Signed-off-by: paceheart <ubiquity@gmail.com>