### PR TITLE
fix(kb): rename temporal_thing→temporal, spatial_thing→spatial

### DIFF
--- a/docs/context-nat.md
+++ b/docs/context-nat.md
@@ -179,7 +179,7 @@ year one way and the month the other still orders the two contexts. Fields are n
 Three constructors and not six: a year, a month and a day are the granularities somebody
 writes a holiday or a policy *for*, and each finer field is a spelling ISO already gives.
 The three are declared in `resources/kb/upper/CxTime.txt` — they are about time, and CxTime
-is the upper context that owns time — each with a `(result … temporal_thing)`, so a
+is the upper context that owns time — each with a `(result … temporal)`, so a
 calendar term is an interval and not an instant. That is also why it cannot stand in an
 `instantBefore`, and why the moments it lies between are a separate term with a separate
 constructor: see [What this does not cover](#what-this-does-not-cover).
@@ -267,7 +267,7 @@ which is the only spelling the map is keyed by.
   `context_denoting_function`, a `contextArgSubrelation`, and either registering a comparator
   or asserting the `R` facts.
 - **A calendar term's endpoints are somebody else's job.** `(YearFn 2000)` is a
-  `temporal_thing`, so it takes the interval relations and not `instantBefore`, which is a
+  `temporal`, so it takes the interval relations and not `instantBefore`, which is a
   claim about moments. The moments it lies between are computed — half-open, so 2000 ends
   where 2001 begins — by the calendar clock, which answers `startOf` / `endOf` with an
   `(InstantFn Y M D h m s)` term and stores nothing ([time.md](time.md), "The calendar

--- a/docs/contexts.md
+++ b/docs/contexts.md
@@ -71,7 +71,7 @@ Data hangs below CxWell.
 - **CxCore** — the upper spindle's *head*: the code-supported vocabulary (every
   special predicate the engine interprets), asserted by `vaelii.host.core-context`. The
   root — every context sees it. It also holds the five collections at the top of the
-  ontology — `intangible`, `spatial_thing`, `physical_object`, `living_thing`,
+  ontology — `intangible`, `spatial`, `physical_object`, `living_thing`,
   `capability` — which the engine reads by no name and which are here for the reason
   below: the members of a spindle see each other not at all, so a term two of them
   extend has to be defined in the head.

--- a/docs/space.md
+++ b/docs/space.md
@@ -285,7 +285,7 @@ calculi are *about* space: CxCore holds only the grammar they are stated in
 a KB built from CxCore plus the layers it wants carries regions only if it reasons
 about them (the starter, which loads every upper context it finds, takes them). Regions,
 places, and the things a frame or a distance is about are all **ordinary individuals**:
-every argument position is declared `(arg … spatial_thing)`, the type a location is
+every argument position is declared `(arg … spatial)`, the type a location is
 what makes something an instance of. `physical_object` sits under it, so every animal,
 artifact and substance qualifies without a further declaration, while a region or a frame
 of reference — which occupy space without being made of anything — is declared into it

--- a/docs/time.md
+++ b/docs/time.md
@@ -44,8 +44,8 @@ unsatisfiable network reported as a contradiction.
 The unit is an **interval**, not an instant. A meeting, a reign, a journey — something
 with a start and an end — so two of them can meet, overlap or nest, which is exactly the
 structure a point calculus throws away. The interval relations are declared `(arg …
-temporal_thing)` and the instant relations `(arg … time_point)`, `time_point` sitting
-under `temporal_thing`, so `startOf` and `endOf` bridge the two by declaration as well as
+temporal)` and the instant relations `(arg … time_point)`, `time_point` sitting
+under `temporal`, so `startOf` and `endOf` bridge the two by declaration as well as
 by meaning. A temporal relation between two predicates is refused rather than stored.
 The algebra itself knows nothing of clocks or calendars — only order and containment; the
 calendar constructors below *name* intervals for it, and compute no relation of their own.
@@ -222,7 +222,7 @@ constructors give a name to the interval a calendar already picks out:
 Each takes one integer field per argument, coarsest first, so **its arity is its
 precision**, and each is an `unreifiable_function` — the application stays structural, so
 the fields are readable inside the term rather than collapsed into an opaque constant. Each
-declares `(result … temporal_thing)`, which is what makes a calendar term an ordinary
+declares `(result … temporal)`, which is what makes a calendar term an ordinary
 argument of `before`, `during` or `subintervalOf` and **not** of `instantBefore`: a year is
 a stretch, not a moment.
 
@@ -352,7 +352,7 @@ the narrative did not. State the links, and the whole theory reads them: `clippe
 over `InstantFn` moments, `holdsAt` answers, and retracting a link takes both back.
 
 An event happens at a **moment**, so a calendar term is not one: `(happens E (DayFn 2000 1
-15))` is refused by the argument check, a day being a `temporal_thing` and `happens`'
+15))` is refused by the argument check, a day being a `temporal` and `happens`'
 second argument a `time_point`. `(happens E (InstantFn 2000 1 15 0 0 0))` is the moment
 that day begins, and `(startOf (DayFn 2000 1 15) ?i)` is how to name it.
 
@@ -394,7 +394,7 @@ every other reasoner here (`add-reasoner kb :calendar`) and answering three fami
 ```
 
 **A moment is `(InstantFn Y M D h m s)` — six integer fields, always.** It is a
-`time_point` where the calendar constructors are `temporal_thing`s, declared in `CxTime`
+`time_point` where the calendar constructors are `temporal`s, declared in `CxTime`
 beside them and `unreifiable_function` for their reason: the fields are what the ordering
 reads. Six fields and not a reduced-precision spelling, because a term is identified by
 its shape and one moment must have exactly **one** term — `"2000-01-01T00:00:00"` and

--- a/resources/kb/CxCore.txt
+++ b/resources/kb/CxCore.txt
@@ -210,13 +210,13 @@
 ;; stay in the band: (genl artifact physical_object) is CxAbstract's, (genl animal
 ;; living_thing) is CxOrganism's, and both now resolve.
 (comment intangible "Something with no mass or location: an attribute, a relation, a time.")
-(comment spatial_thing "Something with a location, so that it can stand in a spatial relation to another — a physical object, but also a region or a place, which occupy space without being made of anything. What the four spatial calculi relate.")
+(comment spatial "Something with a location, so that it can stand in a spatial relation to another — a physical object, but also a region or a place, which occupy space without being made of anything. What the four spatial calculi relate.")
 (comment physical_object "Something with mass and a location in space.")
 (comment living_thing "An organism — it is born, lives, and (by default) dies.")
 (comment capability "Something a kind of thing can do — flying, or travelling. A noun for an ability, so that what a kind can do is a term the KB relates it to rather than a verb-shaped predicate of its own.")
 (genl intangible thing)
-(genl spatial_thing thing)
-(genl physical_object spatial_thing)
+(genl spatial thing)
+(genl physical_object spatial)
 (genl living_thing physical_object)
 (genl capability intangible)
 

--- a/resources/kb/CxCore.txt
+++ b/resources/kb/CxCore.txt
@@ -216,9 +216,11 @@
 (comment capability "Something a kind of thing can do — flying, or travelling. A noun for an ability, so that what a kind can do is a term the KB relates it to rather than a verb-shaped predicate of its own.")
 (genl intangible thing)
 (genl spatial thing)
+(genl temporal thing)
 (genl physical_object spatial)
 (genl living_thing physical_object)
 (genl capability intangible)
+(genl abstract intangible)
 
 ;; The expression kinds — what a sentence is BUILT OUT OF, named as collections so a
 ;; declaration can type an argument by the FORM of the expression written there rather

--- a/resources/kb/upper/CxAbstract.txt
+++ b/resources/kb/upper/CxAbstract.txt
@@ -153,20 +153,21 @@
 (comment substance "A homogeneous stuff (water, iron) rather than a countable object.")
 (genl substance physical_object)
 
-(comment temporal_thing "Something that happens or exists in time (an event, an interval).")
-(genl temporal_thing intangible)
+(disjoint physical_object intangible)
+
+(comment temporal "Something that happens or exists in time. Physical objects, events, and situations are all temporal.")
 
 (comment time_point "A moment rather than a stretch — one of the two instants bounding an interval. What the point algebra relates, and what startOf and endOf reach from an interval.")
-(genl time_point temporal_thing)
+(genl time_point temporal)
 
 ;; --- situation / static_situation / event: the state-of-affairs hierarchy ------
 (comment situation "A state of affairs: objects bearing properties or relations over a time interval. Parent of static_situation (the state holds unchanged) and event (the world's state changes); change is the specialization axis.")
-(genl situation temporal_thing)
+(genl situation temporal)
 
 (comment static_situation "A situation extended in time but unchanged, a held state, e.g. a file existing. Contrast event, the kind whose state changes.")
 (genl static_situation situation)
 
-(comment event "Something that happens: an occurrence located in time whose state changes. The event-calculus slots (happens/initiates/terminates) are typed temporal_thing and no event collection was declared; this names one.")
+(comment event "Something that happens: an occurrence located in time whose state changes. The event-calculus slots (happens/initiates/terminates) are typed temporal and no event collection was declared; this names one.")
 (genl event situation)
 
 ;; A situation either holds unchanged or changes, never both — the specialization axis

--- a/resources/kb/upper/CxSpace.txt
+++ b/resources/kb/upper/CxSpace.txt
@@ -51,7 +51,7 @@
 ;; (leftOf A B) with (leftOf B C) answers (leftOf A C) in the frame all three were stated
 ;; in; and (coLocatedWith A B) with (closeTo B C) answers (closeTo A C). Each prover is
 ;; opt-in; the vocabulary is not. Every argument position here is declared at
-;; spatial_thing — the type the four calculi relate — and nothing narrower;
+;; spatial — the type the four calculi relate — and nothing narrower;
 ;; picking them out more finely is not this file's job. See docs/space.md.
 
 (genlCx CxSpace CxCore)
@@ -61,348 +61,348 @@
          "(atSomeDistanceFrom ?thing1 ?thing2) means that ?thing1 and ?thing2 are some distance apart. Any class of the distance chain but the zero one, so it is the complement of coLocatedWith and holds of nothing and itself.")
 (binary_predicate atSomeDistanceFrom)
 (instance_relation_predicate atSomeDistanceFrom)
-(arg atSomeDistanceFrom 1 spatial_thing)
-(arg atSomeDistanceFrom 2 spatial_thing)
+(arg atSomeDistanceFrom 1 spatial)
+(arg atSomeDistanceFrom 2 spatial)
 
 (comment behind
          "(behind ?object ?reference) means that ?object lies directly behind ?reference. To the rear on the front-back axis and level on the left-right one, in the frame of reference the context is. The converse of inFrontOf.")
 (binary_predicate behind)
 (instance_relation_predicate behind)
-(arg behind 1 spatial_thing)
-(arg behind 2 spatial_thing)
+(arg behind 1 spatial)
+(arg behind 2 spatial)
 
 (comment behindLeftOf
          "(behindLeftOf ?object ?reference) means that ?object lies behind ?reference and to its left. Both axes at once. The converse of frontRightOf.")
 (binary_predicate behindLeftOf)
 (instance_relation_predicate behindLeftOf)
-(arg behindLeftOf 1 spatial_thing)
-(arg behindLeftOf 2 spatial_thing)
+(arg behindLeftOf 1 spatial)
+(arg behindLeftOf 2 spatial)
 
 (comment behindRightOf
          "(behindRightOf ?object ?reference) means that ?object lies behind ?reference and to its right. Both axes at once. The converse of frontLeftOf.")
 (binary_predicate behindRightOf)
 (instance_relation_predicate behindRightOf)
-(arg behindRightOf 1 spatial_thing)
-(arg behindRightOf 2 spatial_thing)
+(arg behindRightOf 1 spatial)
+(arg behindRightOf 2 spatial)
 
 (comment beyondFarDistanceFrom
          "(beyondFarDistanceFrom ?thing1 ?thing2) means that ?thing1 and ?thing2 are at least far apart. Far or very far: the upper end of the distance chain.")
 (binary_predicate beyondFarDistanceFrom)
 (instance_relation_predicate beyondFarDistanceFrom)
-(arg beyondFarDistanceFrom 1 spatial_thing)
-(arg beyondFarDistanceFrom 2 spatial_thing)
+(arg beyondFarDistanceFrom 1 spatial)
+(arg beyondFarDistanceFrom 2 spatial)
 
 (comment closeTo
          "(closeTo ?thing1 ?thing2) means that ?thing1 and ?thing2 are close together. The third class of the distance chain, one step further out than veryCloseTo and one step in from nearTo.")
 (binary_predicate closeTo)
 (instance_relation_predicate closeTo)
-(arg closeTo 1 spatial_thing)
-(arg closeTo 2 spatial_thing)
+(arg closeTo 1 spatial)
+(arg closeTo 2 spatial)
 
 (comment coLocatedWith
          "(coLocatedWith ?thing1 ?thing2) means that ?thing1 and ?thing2 are no distance apart at all. The zero class of the distance chain and the identity of its algebra. A claim about how far apart two things are, so it is neither the compass's sameLocationAs nor the equality closure's sameAs: two co-located things are still two things.")
 (binary_predicate coLocatedWith)
 (instance_relation_predicate coLocatedWith)
-(arg coLocatedWith 1 spatial_thing)
-(arg coLocatedWith 2 spatial_thing)
+(arg coLocatedWith 1 spatial)
+(arg coLocatedWith 2 spatial)
 
 (comment eastOf
          "(eastOf ?place1 ?place2) means that ?place1 lies due east of ?place2. East on the east-west axis and level on the north-south one. The converse of westOf.")
 (binary_predicate eastOf)
 (instance_relation_predicate eastOf)
-(arg eastOf 1 spatial_thing)
-(arg eastOf 2 spatial_thing)
+(arg eastOf 1 spatial)
+(arg eastOf 2 spatial)
 
 (comment eastwardOf
          "(eastwardOf ?place1 ?place2) means that ?place1 lies somewhere east of ?place2. East, northeast or southeast: it constrains the east-west axis alone and leaves the north-south one open.")
 (binary_predicate eastwardOf)
 (instance_relation_predicate eastwardOf)
-(arg eastwardOf 1 spatial_thing)
-(arg eastwardOf 2 spatial_thing)
+(arg eastwardOf 1 spatial)
+(arg eastwardOf 2 spatial)
 
 (comment externallyConnected
          "(externallyConnected ?region1 ?region2) means that ?region1 and ?region2 touch but share no interior. RCC-8's EC, a base relation and its own converse. What two countries either side of a border stand in.")
 (binary_predicate externallyConnected)
 (instance_relation_predicate externallyConnected)
-(arg externallyConnected 1 spatial_thing)
-(arg externallyConnected 2 spatial_thing)
+(arg externallyConnected 1 spatial)
+(arg externallyConnected 2 spatial)
 
 (comment farFrom
          "(farFrom ?thing1 ?thing2) means that ?thing1 and ?thing2 are far apart. The sixth class of the distance chain, one step in from veryFarFrom.")
 (binary_predicate farFrom)
 (instance_relation_predicate farFrom)
-(arg farFrom 1 spatial_thing)
-(arg farFrom 2 spatial_thing)
+(arg farFrom 1 spatial)
+(arg farFrom 2 spatial)
 
 (comment frontLeftOf
          "(frontLeftOf ?object ?reference) means that ?object lies in front of ?reference and to its left. Both axes at once, so it is the strongest thing a single relative-direction fact can say. The converse of behindRightOf.")
 (binary_predicate frontLeftOf)
 (instance_relation_predicate frontLeftOf)
-(arg frontLeftOf 1 spatial_thing)
-(arg frontLeftOf 2 spatial_thing)
+(arg frontLeftOf 1 spatial)
+(arg frontLeftOf 2 spatial)
 
 (comment frontRightOf
          "(frontRightOf ?object ?reference) means that ?object lies in front of ?reference and to its right. Both axes at once. The converse of behindLeftOf.")
 (binary_predicate frontRightOf)
 (instance_relation_predicate frontRightOf)
-(arg frontRightOf 1 spatial_thing)
-(arg frontRightOf 2 spatial_thing)
+(arg frontRightOf 1 spatial)
+(arg frontRightOf 2 spatial)
 
 (comment frontwardOf
          "(frontwardOf ?object ?reference) means that ?object lies somewhere in front of ?reference. In front, front-left or front-right: it constrains the front-back axis alone and leaves the left-right one open.")
 (binary_predicate frontwardOf)
 (instance_relation_predicate frontwardOf)
-(arg frontwardOf 1 spatial_thing)
-(arg frontwardOf 2 spatial_thing)
+(arg frontwardOf 1 spatial)
+(arg frontwardOf 2 spatial)
 
 (comment hasRegionPart
          "(hasRegionPart ?region1 ?region2) means that ?region2 is part of ?region1. RCC-8's Pi, the converse of partOfRegion, denoting TPPi, NTPPi or EQ. Derived, so asserting it says only that one contains the other and not how.")
 (binary_predicate hasRegionPart)
 (instance_relation_predicate hasRegionPart)
-(arg hasRegionPart 1 spatial_thing)
-(arg hasRegionPart 2 spatial_thing)
+(arg hasRegionPart 1 spatial)
+(arg hasRegionPart 2 spatial)
 
 (comment inFrontOf
          "(inFrontOf ?object ?reference) means that ?object lies directly in front of ?reference. Forward on the front-back axis and level on the left-right one, in the frame of reference the context is. The converse of behind.")
 (binary_predicate inFrontOf)
 (instance_relation_predicate inFrontOf)
-(arg inFrontOf 1 spatial_thing)
-(arg inFrontOf 2 spatial_thing)
+(arg inFrontOf 1 spatial)
+(arg inFrontOf 2 spatial)
 
 (comment leftOf
          "(leftOf ?object ?reference) means that ?object lies directly to the left of ?reference. Left on the left-right axis and level on the front-back one, as seen from the frame of reference the context is: a relative direction is read from a viewpoint, and here the context is that viewpoint. The converse of rightOf.")
 (binary_predicate leftOf)
 (instance_relation_predicate leftOf)
-(arg leftOf 1 spatial_thing)
-(arg leftOf 2 spatial_thing)
+(arg leftOf 1 spatial)
+(arg leftOf 2 spatial)
 
 (comment leftwardOf
          "(leftwardOf ?object ?reference) means that ?object lies somewhere to the left of ?reference. Left, front-left or behind-left: it constrains the left-right axis alone and leaves the front-back one open.")
 (binary_predicate leftwardOf)
 (instance_relation_predicate leftwardOf)
-(arg leftwardOf 1 spatial_thing)
-(arg leftwardOf 2 spatial_thing)
+(arg leftwardOf 1 spatial)
+(arg leftwardOf 2 spatial)
 
 (comment moderatelyFarFrom
          "(moderatelyFarFrom ?thing1 ?thing2) means that ?thing1 and ?thing2 are moderately far apart. The middle of the distance chain, between nearTo and farFrom.")
 (binary_predicate moderatelyFarFrom)
 (instance_relation_predicate moderatelyFarFrom)
-(arg moderatelyFarFrom 1 spatial_thing)
-(arg moderatelyFarFrom 2 spatial_thing)
+(arg moderatelyFarFrom 1 spatial)
+(arg moderatelyFarFrom 2 spatial)
 
 (comment nearTo
          "(nearTo ?thing1 ?thing2) means that ?thing1 and ?thing2 are near each other. The fourth class of the distance chain, one step further out than closeTo.")
 (binary_predicate nearTo)
 (instance_relation_predicate nearTo)
-(arg nearTo 1 spatial_thing)
-(arg nearTo 2 spatial_thing)
+(arg nearTo 1 spatial)
+(arg nearTo 2 spatial)
 
 (comment nonTangentialProperPart
          "(nonTangentialProperPart ?region1 ?region2) means that ?region1 lies strictly inside ?region2, touching no part of its boundary. RCC-8's NTPP, a base relation, with nonTangentialProperPartInverse as its converse.")
 (binary_predicate nonTangentialProperPart)
 (instance_relation_predicate nonTangentialProperPart)
-(arg nonTangentialProperPart 1 spatial_thing)
-(arg nonTangentialProperPart 2 spatial_thing)
+(arg nonTangentialProperPart 1 spatial)
+(arg nonTangentialProperPart 2 spatial)
 
 (comment nonTangentialProperPartInverse
          "(nonTangentialProperPartInverse ?region1 ?region2) means that ?region2 lies strictly inside ?region1, touching no part of its boundary. RCC-8's NTPPi, the converse of nonTangentialProperPart.")
 (binary_predicate nonTangentialProperPartInverse)
 (instance_relation_predicate nonTangentialProperPartInverse)
-(arg nonTangentialProperPartInverse 1 spatial_thing)
-(arg nonTangentialProperPartInverse 2 spatial_thing)
+(arg nonTangentialProperPartInverse 1 spatial)
+(arg nonTangentialProperPartInverse 2 spatial)
 
 (comment northeastOf
          "(northeastOf ?place1 ?place2) means that ?place1 lies north and east of ?place2. Both axes at once, so it is the strongest thing a single direction fact can say. The converse of southwestOf.")
 (binary_predicate northeastOf)
 (instance_relation_predicate northeastOf)
-(arg northeastOf 1 spatial_thing)
-(arg northeastOf 2 spatial_thing)
+(arg northeastOf 1 spatial)
+(arg northeastOf 2 spatial)
 
 (comment northOf
          "(northOf ?place1 ?place2) means that ?place1 lies due north of ?place2. North on the north-south axis and level on the east-west one, so it is one of the nine base directions rather than a disjunction of them. The converse of southOf.")
 (binary_predicate northOf)
 (instance_relation_predicate northOf)
-(arg northOf 1 spatial_thing)
-(arg northOf 2 spatial_thing)
+(arg northOf 1 spatial)
+(arg northOf 2 spatial)
 
 (comment northwardOf
          "(northwardOf ?place1 ?place2) means that ?place1 lies somewhere north of ?place2. North, northeast or northwest: it constrains the north-south axis alone and leaves the east-west one open. Derived, so it is entailed by any of the three and asserts none of them.")
 (binary_predicate northwardOf)
 (instance_relation_predicate northwardOf)
-(arg northwardOf 1 spatial_thing)
-(arg northwardOf 2 spatial_thing)
+(arg northwardOf 1 spatial)
+(arg northwardOf 2 spatial)
 
 (comment northwestOf
          "(northwestOf ?place1 ?place2) means that ?place1 lies north and west of ?place2. Both axes at once. The converse of southeastOf.")
 (binary_predicate northwestOf)
 (instance_relation_predicate northwestOf)
-(arg northwestOf 1 spatial_thing)
-(arg northwestOf 2 spatial_thing)
+(arg northwestOf 1 spatial)
+(arg northwestOf 2 spatial)
 
 (comment partiallyOverlapping
          "(partiallyOverlapping ?region1 ?region2) means that ?region1 and ?region2 share a part, and each also has a part outside the other. RCC-8's PO, a base relation and its own converse.")
 (binary_predicate partiallyOverlapping)
 (instance_relation_predicate partiallyOverlapping)
-(arg partiallyOverlapping 1 spatial_thing)
-(arg partiallyOverlapping 2 spatial_thing)
+(arg partiallyOverlapping 1 spatial)
+(arg partiallyOverlapping 2 spatial)
 
 (comment partOfRegion
          "(partOfRegion ?region1 ?region2) means that ?region1 is part of ?region2. RCC-8's P, which denotes TPP, NTPP or EQ, so a region is part of itself. A derived relation: it is entailed by any of those three and asserts none of them in particular.")
 (binary_predicate partOfRegion)
 (instance_relation_predicate partOfRegion)
-(arg partOfRegion 1 spatial_thing)
-(arg partOfRegion 2 spatial_thing)
+(arg partOfRegion 1 spatial)
+(arg partOfRegion 2 spatial)
 
 (comment properPartOfRegion
          "(properPartOfRegion ?region1 ?region2) means that ?region1 is part of ?region2 and not the whole of it. RCC-8's PP, denoting TPP or NTPP. Irreflexive, unlike partOfRegion.")
 (binary_predicate properPartOfRegion)
 (instance_relation_predicate properPartOfRegion)
-(arg properPartOfRegion 1 spatial_thing)
-(arg properPartOfRegion 2 spatial_thing)
+(arg properPartOfRegion 1 spatial)
+(arg properPartOfRegion 2 spatial)
 
 (comment rearwardOf
          "(rearwardOf ?object ?reference) means that ?object lies somewhere behind ?reference. Behind, behind-left or behind-right: it constrains the front-back axis alone and leaves the left-right one open.")
 (binary_predicate rearwardOf)
 (instance_relation_predicate rearwardOf)
-(arg rearwardOf 1 spatial_thing)
-(arg rearwardOf 2 spatial_thing)
+(arg rearwardOf 1 spatial)
+(arg rearwardOf 2 spatial)
 
 (comment regionConnectedTo
          "(regionConnectedTo ?region1 ?region2) means that ?region1 and ?region2 are connected. Anything but disconnected, so it is RCC-8's C, the primitive the eight base relations are defined from, and the weakest claim that says anything at all.")
 (binary_predicate regionConnectedTo)
 (instance_relation_predicate regionConnectedTo)
-(arg regionConnectedTo 1 spatial_thing)
-(arg regionConnectedTo 2 spatial_thing)
+(arg regionConnectedTo 1 spatial)
+(arg regionConnectedTo 2 spatial)
 
 (comment regionDiscreteFrom
          "(regionDiscreteFrom ?region1 ?region2) means that ?region1 and ?region2 share no part. Disconnected or externally connected, so it is RCC-8's DR, and the complement of regionOverlaps.")
 (binary_predicate regionDiscreteFrom)
 (instance_relation_predicate regionDiscreteFrom)
-(arg regionDiscreteFrom 1 spatial_thing)
-(arg regionDiscreteFrom 2 spatial_thing)
+(arg regionDiscreteFrom 1 spatial)
+(arg regionDiscreteFrom 2 spatial)
 
 (comment regionOverlaps
          "(regionOverlaps ?region1 ?region2) means that ?region1 and ?region2 share a part. Anything but disconnected or merely touching, so it is RCC-8's O, and the complement of regionDiscreteFrom.")
 (binary_predicate regionOverlaps)
 (instance_relation_predicate regionOverlaps)
-(arg regionOverlaps 1 spatial_thing)
-(arg regionOverlaps 2 spatial_thing)
+(arg regionOverlaps 1 spatial)
+(arg regionOverlaps 2 spatial)
 
 (comment rightOf
          "(rightOf ?object ?reference) means that ?object lies directly to the right of ?reference. Right on the left-right axis and level on the front-back one, in the frame of reference the context is. The converse of leftOf.")
 (binary_predicate rightOf)
 (instance_relation_predicate rightOf)
-(arg rightOf 1 spatial_thing)
-(arg rightOf 2 spatial_thing)
+(arg rightOf 1 spatial)
+(arg rightOf 2 spatial)
 
 (comment rightwardOf
          "(rightwardOf ?object ?reference) means that ?object lies somewhere to the right of ?reference. Right, front-right or behind-right: it constrains the left-right axis alone and leaves the front-back one open.")
 (binary_predicate rightwardOf)
 (instance_relation_predicate rightwardOf)
-(arg rightwardOf 1 spatial_thing)
-(arg rightwardOf 2 spatial_thing)
+(arg rightwardOf 1 spatial)
+(arg rightwardOf 2 spatial)
 
 (comment sameLocationAs
          "(sameLocationAs ?place1 ?place2) means that ?place1 and ?place2 coincide. Level on both compass axes, and the identity of the direction algebra. A claim about position rather than about the identity of the two terms, so it is not the equality closure's sameAs.")
 (binary_predicate sameLocationAs)
 (instance_relation_predicate sameLocationAs)
-(arg sameLocationAs 1 spatial_thing)
-(arg sameLocationAs 2 spatial_thing)
+(arg sameLocationAs 1 spatial)
+(arg sameLocationAs 2 spatial)
 
 (comment sameRelativePositionAs
          "(sameRelativePositionAs ?object ?reference) means that ?object and ?reference stand in the same place in the frame the context is. Level on both of that frame's axes, and the identity of the relative-direction algebra. A claim about a frame's own axes, so it is neither the compass's sameLocationAs nor the equality closure's sameAs.")
 (binary_predicate sameRelativePositionAs)
 (instance_relation_predicate sameRelativePositionAs)
-(arg sameRelativePositionAs 1 spatial_thing)
-(arg sameRelativePositionAs 2 spatial_thing)
+(arg sameRelativePositionAs 1 spatial)
+(arg sameRelativePositionAs 2 spatial)
 
 (comment southeastOf
          "(southeastOf ?place1 ?place2) means that ?place1 lies south and east of ?place2. Both axes at once. The converse of northwestOf.")
 (binary_predicate southeastOf)
 (instance_relation_predicate southeastOf)
-(arg southeastOf 1 spatial_thing)
-(arg southeastOf 2 spatial_thing)
+(arg southeastOf 1 spatial)
+(arg southeastOf 2 spatial)
 
 (comment southOf
          "(southOf ?place1 ?place2) means that ?place1 lies due south of ?place2. South on the north-south axis and level on the east-west one. The converse of northOf.")
 (binary_predicate southOf)
 (instance_relation_predicate southOf)
-(arg southOf 1 spatial_thing)
-(arg southOf 2 spatial_thing)
+(arg southOf 1 spatial)
+(arg southOf 2 spatial)
 
 (comment southwardOf
          "(southwardOf ?place1 ?place2) means that ?place1 lies somewhere south of ?place2. South, southeast or southwest: it constrains the north-south axis alone and leaves the east-west one open.")
 (binary_predicate southwardOf)
 (instance_relation_predicate southwardOf)
-(arg southwardOf 1 spatial_thing)
-(arg southwardOf 2 spatial_thing)
+(arg southwardOf 1 spatial)
+(arg southwardOf 2 spatial)
 
 (comment southwestOf
          "(southwestOf ?place1 ?place2) means that ?place1 lies south and west of ?place2. Both axes at once. The converse of northeastOf.")
 (binary_predicate southwestOf)
 (instance_relation_predicate southwestOf)
-(arg southwestOf 1 spatial_thing)
-(arg southwestOf 2 spatial_thing)
+(arg southwestOf 1 spatial)
+(arg southwestOf 2 spatial)
 
 (comment spatiallyDisconnected
          "(spatiallyDisconnected ?region1 ?region2) means that ?region1 and ?region2 share no point at all. RCC-8's DC, a base relation, its own converse, and the weakest thing two regions can stand in.")
 (binary_predicate spatiallyDisconnected)
 (instance_relation_predicate spatiallyDisconnected)
-(arg spatiallyDisconnected 1 spatial_thing)
-(arg spatiallyDisconnected 2 spatial_thing)
+(arg spatiallyDisconnected 1 spatial)
+(arg spatiallyDisconnected 2 spatial)
 
 (comment spatiallyEqual
          "(spatiallyEqual ?region1 ?region2) means that ?region1 and ?region2 occupy exactly the same extent. RCC-8's EQ, and the identity of the algebra. A claim about extent rather than about the identity of the two terms, so it is not the equality closure's sameAs: two coextensive regions are still two regions.")
 (binary_predicate spatiallyEqual)
 (instance_relation_predicate spatiallyEqual)
-(arg spatiallyEqual 1 spatial_thing)
-(arg spatiallyEqual 2 spatial_thing)
+(arg spatiallyEqual 1 spatial)
+(arg spatiallyEqual 2 spatial)
 
 (comment tangentialProperPart
          "(tangentialProperPart ?region1 ?region2) means that ?region1 lies inside ?region2 and touches its boundary. RCC-8's TPP, a base relation, with tangentialProperPartInverse as its converse.")
 (binary_predicate tangentialProperPart)
 (instance_relation_predicate tangentialProperPart)
-(arg tangentialProperPart 1 spatial_thing)
-(arg tangentialProperPart 2 spatial_thing)
+(arg tangentialProperPart 1 spatial)
+(arg tangentialProperPart 2 spatial)
 
 (comment tangentialProperPartInverse
          "(tangentialProperPartInverse ?region1 ?region2) means that ?region2 lies inside ?region1 and touches its boundary. RCC-8's TPPi, the converse of tangentialProperPart.")
 (binary_predicate tangentialProperPartInverse)
 (instance_relation_predicate tangentialProperPartInverse)
-(arg tangentialProperPartInverse 1 spatial_thing)
-(arg tangentialProperPartInverse 2 spatial_thing)
+(arg tangentialProperPartInverse 1 spatial)
+(arg tangentialProperPartInverse 2 spatial)
 
 (comment veryCloseTo
          "(veryCloseTo ?thing1 ?thing2) means that ?thing1 and ?thing2 are very close together. The nearest class of the distance chain above zero. The seven classes tile the whole range without overlapping, so exactly one of them holds of any pair.")
 (binary_predicate veryCloseTo)
 (instance_relation_predicate veryCloseTo)
-(arg veryCloseTo 1 spatial_thing)
-(arg veryCloseTo 2 spatial_thing)
+(arg veryCloseTo 1 spatial)
+(arg veryCloseTo 2 spatial)
 
 (comment veryFarFrom
          "(veryFarFrom ?thing1 ?thing2) means that ?thing1 and ?thing2 are very far apart. The last class of the distance chain, unbounded above.")
 (binary_predicate veryFarFrom)
 (instance_relation_predicate veryFarFrom)
-(arg veryFarFrom 1 spatial_thing)
-(arg veryFarFrom 2 spatial_thing)
+(arg veryFarFrom 1 spatial)
+(arg veryFarFrom 2 spatial)
 
 (comment westOf
          "(westOf ?place1 ?place2) means that ?place1 lies due west of ?place2. West on the east-west axis and level on the north-south one. The converse of eastOf.")
 (binary_predicate westOf)
 (instance_relation_predicate westOf)
-(arg westOf 1 spatial_thing)
-(arg westOf 2 spatial_thing)
+(arg westOf 1 spatial)
+(arg westOf 2 spatial)
 
 (comment westwardOf
          "(westwardOf ?place1 ?place2) means that ?place1 lies somewhere west of ?place2. West, northwest or southwest: it constrains the east-west axis alone and leaves the north-south one open.")
 (binary_predicate westwardOf)
 (instance_relation_predicate westwardOf)
-(arg westwardOf 1 spatial_thing)
-(arg westwardOf 2 spatial_thing)
+(arg westwardOf 1 spatial)
+(arg westwardOf 2 spatial)
 
 (comment withinNearDistanceOf
          "(withinNearDistanceOf ?thing1 ?thing2) means that ?thing1 and ?thing2 are no further apart than near. Co-located, very close, close or near: the lower end of the distance chain.")
 (binary_predicate withinNearDistanceOf)
 (instance_relation_predicate withinNearDistanceOf)
-(arg withinNearDistanceOf 1 spatial_thing)
-(arg withinNearDistanceOf 2 spatial_thing)
+(arg withinNearDistanceOf 1 spatial)
+(arg withinNearDistanceOf 2 spatial)

--- a/resources/kb/upper/CxTime.txt
+++ b/resources/kb/upper/CxTime.txt
@@ -88,15 +88,15 @@
          "(after ?interval1 ?interval2) means that ?interval1 begins strictly after ?interval2 ends. They share no time and do not touch, so some gap separates them. The converse of before.")
 (binary_predicate after)
 (instance_relation_predicate after)
-(arg after 1 temporal_thing)
-(arg after 2 temporal_thing)
+(arg after 1 temporal)
+(arg after 2 temporal)
 
 (comment before
          "(before ?interval1 ?interval2) means that ?interval1 ends strictly before ?interval2 begins. They share no time and do not touch, so some gap separates them. One of Allen's thirteen base relations, with after as its converse.")
 (binary_predicate before)
 (instance_relation_predicate before)
-(arg before 1 temporal_thing)
-(arg before 2 temporal_thing)
+(arg before 1 temporal)
+(arg before 2 temporal)
 
 (comment clipped
          "(clipped ?instant1 ?fluent ?instant2) means that some event terminating ?fluent happens strictly between ?instant1 and ?instant2. What breaks inertia: a fluent an event started at ?instant1 still holds at ?instant2 exactly while nothing clipped it in between. Derived by CxChange and never stated — an event and its terminates fact are what a KB says, and the interval this covers is what follows from them. See docs/time.md.")
@@ -116,56 +116,56 @@
          "(contains ?interval1 ?interval2) means that ?interval1 begins strictly before ?interval2 and ends strictly after it. So ?interval2 falls wholly inside ?interval1 with room either side. The converse of during.")
 (binary_predicate contains)
 (instance_relation_predicate contains)
-(arg contains 1 temporal_thing)
-(arg contains 2 temporal_thing)
+(arg contains 1 temporal)
+(arg contains 2 temporal)
 
 (comment DayFn
          "(DayFn ?year ?month ?day) means the calendar day, as an interval — so (DayFn 2000 1 15) is the fifteenth of January 2000. An unreifiable_function application like YearFn and MonthFn: it stays structural, so the three fields are readable inside the term and a reader can see that the day sits inside its month. One field per argument, coarsest first, so the arity is the precision. See docs/context-nat.md.")
 (unreifiable_function DayFn)
 (ternary_function DayFn)
-(result DayFn temporal_thing)
+(result DayFn temporal)
 
 (comment during
          "(during ?interval1 ?interval2) means that ?interval1 falls wholly inside ?interval2, beginning strictly after it and ending strictly before it. The converse of contains.")
 (binary_predicate during)
 (instance_relation_predicate during)
-(arg during 1 temporal_thing)
-(arg during 2 temporal_thing)
+(arg during 1 temporal)
+(arg during 2 temporal)
 
 (comment endOf
          "(endOf ?interval ?instant) means that ?instant is the moment ?interval ends. One of the interval's two bounding instants, the other being its startOf. What joins the interval algebra to the point algebra and to the metric constraints stated over instants: one interval before another is exactly its end instant before the other's start. Stated of an ordinary interval; computed for a calendar term, where it is the first moment of the next term at the same precision — the end of (YearFn 2000) is (InstantFn 2001 1 1 0 0 0). See docs/time.md.")
 (binary_predicate endOf)
 (instance_relation_predicate endOf)
-(arg endOf 1 temporal_thing)
+(arg endOf 1 temporal)
 (arg endOf 2 time_point)
 
 (comment finishedBy
          "(finishedBy ?interval1 ?interval2) means that ?interval1 and ?interval2 end together, and ?interval1 began first. So ?interval2 is a closing part of ?interval1. The converse of finishes.")
 (binary_predicate finishedBy)
 (instance_relation_predicate finishedBy)
-(arg finishedBy 1 temporal_thing)
-(arg finishedBy 2 temporal_thing)
+(arg finishedBy 1 temporal)
+(arg finishedBy 2 temporal)
 
 (comment finishes
          "(finishes ?interval1 ?interval2) means that ?interval1 and ?interval2 end together, and ?interval1 began later. So ?interval1 is a closing part of ?interval2. The converse of finishedBy.")
 (binary_predicate finishes)
 (instance_relation_predicate finishes)
-(arg finishes 1 temporal_thing)
-(arg finishes 2 temporal_thing)
+(arg finishes 1 temporal)
+(arg finishes 2 temporal)
 
 (comment happens
          "(happens ?event ?instant) means that ?event occurs at ?instant. The one thing a narrative states about an event's place in time; whether the event changes anything is initiates and terminates, said separately, so an event nobody has said anything else about still has a time. See docs/time.md.")
 (binary_predicate happens)
 (instance_relation_predicate happens)
-(arg happens 1 temporal_thing)
+(arg happens 1 temporal)
 (arg happens 2 time_point)
 
 (comment hasSubinterval
          "(hasSubinterval ?interval1 ?interval2) means that ?interval2 falls within ?interval1, sharing an end, a start, or neither. Any of contains, startedBy, finishedBy or intervalEqual. The converse of subintervalOf.")
 (binary_predicate hasSubinterval)
 (instance_relation_predicate hasSubinterval)
-(arg hasSubinterval 1 temporal_thing)
-(arg hasSubinterval 2 temporal_thing)
+(arg hasSubinterval 1 temporal)
+(arg hasSubinterval 2 temporal)
 
 (comment holdsAt
          "(holdsAt ?fluent ?instant) means that ?fluent is the case at ?instant. Derived by CxChange and never stated: it follows from an event that initiated the fluent earlier and nothing having terminated it since, which is inertia — a state persists until something ends it. Backward-only, because a fluent holds at every moment between its start and its end and materializing one fact per moment would store an unbounded extent for a question anybody can ask directly. See docs/time.md.")
@@ -182,7 +182,7 @@
 (comment initiates
          "(initiates ?event ?fluent ?instant) means that ?fluent is the case from ?instant onwards because ?event happened then. Stated of the event and the fluent together, since the same event can start one state and end another — waking starts being awake and ends being asleep. Says nothing on its own about whether the event occurred: that is happens, and both are needed. See docs/time.md.")
 (ternary_predicate initiates)
-(arg initiates 1 temporal_thing)
+(arg initiates 1 temporal)
 (arg initiates 2 fluent)
 (arg initiates 3 time_point)
 
@@ -214,7 +214,7 @@
 (arg instantEqual 2 time_point)
 
 (comment InstantFn
-         "(InstantFn ?year ?month ?day ?hour ?minute ?second) means the moment those six calendar fields name, so (InstantFn 2000 1 1 0 0 0) is midnight at the start of 2000. A time_point and not a temporal_thing: YearFn, MonthFn and DayFn name stretches, and this names the moments one of them lies between. Six fields always — its arity is not its precision — so every moment has exactly one spelling, which is what makes the end of one year and the start of the next the same term. An unreifiable_function application like the calendar constructors, structural so the fields stay readable. What startOf and endOf answer for a calendar term, computed and never stored. See docs/time.md.")
+         "(InstantFn ?year ?month ?day ?hour ?minute ?second) means the moment those six calendar fields name, so (InstantFn 2000 1 1 0 0 0) is midnight at the start of 2000. A time_point and not a temporal: YearFn, MonthFn and DayFn name stretches, and this names the moments one of them lies between. Six fields always — its arity is not its precision — so every moment has exactly one spelling, which is what makes the end of one year and the start of the next the same term. An unreifiable_function application like the calendar constructors, structural so the fields stay readable. What startOf and endOf answer for a calendar term, computed and never stored. See docs/time.md.")
 (unreifiable_function InstantFn)
 (fixed_arity_function InstantFn)
 (arity InstantFn 6)
@@ -251,112 +251,112 @@
          "(intervalEqual ?interval1 ?interval2) means that ?interval1 and ?interval2 begin together and end together. The identity of the interval algebra, and a claim about extent in time rather than about the identity of the two terms, so it is not the equality closure's equals.")
 (binary_predicate intervalEqual)
 (instance_relation_predicate intervalEqual)
-(arg intervalEqual 1 temporal_thing)
-(arg intervalEqual 2 temporal_thing)
+(arg intervalEqual 1 temporal)
+(arg intervalEqual 2 temporal)
 
 (comment length
          "(length ?interval ?measure) means that ?interval lasts ?measure. Exact as (QuantityFn 2 Hour), and bounded as (QuantityIntervalFn 1 2 Hour) when only bounds are known. An interval's one primitive duration and the only quantitative fact stated about it, since totalDuration and overlapDuration are both computed from these. A duration, not a spatial extent.")
 (binary_predicate length)
 (instance_relation_predicate length)
-(arg length 1 temporal_thing)
+(arg length 1 temporal)
 (arg length 2 thing)
 
 (comment meets
          "(meets ?interval1 ?interval2) means that ?interval1 ends exactly where ?interval2 begins. No gap and no overlap, which is what separates it from before. The converse of metBy.")
 (binary_predicate meets)
 (instance_relation_predicate meets)
-(arg meets 1 temporal_thing)
-(arg meets 2 temporal_thing)
+(arg meets 1 temporal)
+(arg meets 2 temporal)
 
 (comment metBy
          "(metBy ?interval1 ?interval2) means that ?interval1 begins exactly where ?interval2 ends. The converse of meets.")
 (binary_predicate metBy)
 (instance_relation_predicate metBy)
-(arg metBy 1 temporal_thing)
-(arg metBy 2 temporal_thing)
+(arg metBy 1 temporal)
+(arg metBy 2 temporal)
 
 (comment MonthFn
          "(MonthFn ?year ?month) means the calendar month, as an interval — so (MonthFn 2000 1) is January 2000, and ?month is 1 through 12. An unreifiable_function application like YearFn and DayFn, structural so the ordering can read its fields: January 2000 is inside 2000, and February is inside neither January nor itself twice over. See docs/context-nat.md.")
 (unreifiable_function MonthFn)
 (binary_function MonthFn)
-(result MonthFn temporal_thing)
+(result MonthFn temporal)
 
 (comment overlapDuration
          "(overlapDuration ?interval1 ?interval2 ?duration) means that ?duration is how long ?interval1 and ?interval2 overlap. Computed from their lengths and the Allen relations still possible between them: zero when they are temporallyDisjoint, the contained length when one is a subintervalOf the other, and the bounded (QuantityIntervalFn 0 shorter unit) otherwise, so an over-approximation renders as an interval and says as much. Computed by a prover, never stored.")
 (ternary_predicate overlapDuration)
-(arg overlapDuration 1 temporal_thing)
-(arg overlapDuration 2 temporal_thing)
+(arg overlapDuration 1 temporal)
+(arg overlapDuration 2 temporal)
 (arg overlapDuration 3 thing)
 
 (comment overlappedBy
          "(overlappedBy ?interval1 ?interval2) means that ?interval2 begins first, and ?interval1 begins before ?interval2 ends and ends after it. So they share a middle stretch and each has time the other does not. The converse of overlaps.")
 (binary_predicate overlappedBy)
 (instance_relation_predicate overlappedBy)
-(arg overlappedBy 1 temporal_thing)
-(arg overlappedBy 2 temporal_thing)
+(arg overlappedBy 1 temporal)
+(arg overlappedBy 2 temporal)
 
 (comment overlaps
          "(overlaps ?interval1 ?interval2) means that ?interval1 begins first, and ?interval2 begins before ?interval1 ends and ends after it. So they share a middle stretch and each has time the other does not. The converse of overlappedBy.")
 (binary_predicate overlaps)
 (instance_relation_predicate overlaps)
-(arg overlaps 1 temporal_thing)
-(arg overlaps 2 temporal_thing)
+(arg overlaps 1 temporal)
+(arg overlaps 2 temporal)
 
 (comment precededBy
          "(precededBy ?interval1 ?interval2) means that ?interval1 begins at or after the moment ?interval2 ends. Either after or metBy. The converse of precedes.")
 (binary_predicate precededBy)
 (instance_relation_predicate precededBy)
-(arg precededBy 1 temporal_thing)
-(arg precededBy 2 temporal_thing)
+(arg precededBy 1 temporal)
+(arg precededBy 2 temporal)
 
 (comment precedes
          "(precedes ?interval1 ?interval2) means that ?interval1 ends at or before the moment ?interval2 begins. Either before or meets, so it is the ordering that does not care whether the two touch. Derived rather than base, and the converse of precededBy.")
 (binary_predicate precedes)
 (instance_relation_predicate precedes)
-(arg precedes 1 temporal_thing)
-(arg precedes 2 temporal_thing)
+(arg precedes 1 temporal)
+(arg precedes 2 temporal)
 
 (comment properSubintervalOf
          "(properSubintervalOf ?interval1 ?interval2) means that ?interval1 falls within ?interval2 and is not the whole of it. Any of during, starts or finishes. Irreflexive, unlike subintervalOf.")
 (binary_predicate properSubintervalOf)
 (instance_relation_predicate properSubintervalOf)
-(arg properSubintervalOf 1 temporal_thing)
-(arg properSubintervalOf 2 temporal_thing)
+(arg properSubintervalOf 1 temporal)
+(arg properSubintervalOf 2 temporal)
 
 (comment sharesTimeWith
          "(sharesTimeWith ?interval1 ?interval2) means that ?interval1 and ?interval2 have some time in common. Any relation but before, after, meets and metBy, so it is the complement of temporallyDisjoint.")
 (binary_predicate sharesTimeWith)
 (instance_relation_predicate sharesTimeWith)
-(arg sharesTimeWith 1 temporal_thing)
-(arg sharesTimeWith 2 temporal_thing)
+(arg sharesTimeWith 1 temporal)
+(arg sharesTimeWith 2 temporal)
 
 (comment startedBy
          "(startedBy ?interval1 ?interval2) means that ?interval1 and ?interval2 begin together, and ?interval1 ends later. So ?interval2 is an opening part of ?interval1. The converse of starts.")
 (binary_predicate startedBy)
 (instance_relation_predicate startedBy)
-(arg startedBy 1 temporal_thing)
-(arg startedBy 2 temporal_thing)
+(arg startedBy 1 temporal)
+(arg startedBy 2 temporal)
 
 (comment startOf
          "(startOf ?interval ?instant) means that ?instant is the moment ?interval begins. One of the interval's two bounding instants, the other being its endOf. What joins the interval algebra to the point algebra and to the metric constraints stated over instants. Stated of an ordinary interval; computed for a calendar term, where it is that term's first moment — the start of (YearFn 2000) is (InstantFn 2000 1 1 0 0 0). See docs/time.md.")
 (binary_predicate startOf)
 (instance_relation_predicate startOf)
-(arg startOf 1 temporal_thing)
+(arg startOf 1 temporal)
 (arg startOf 2 time_point)
 
 (comment starts
          "(starts ?interval1 ?interval2) means that ?interval1 and ?interval2 begin together, and ?interval1 ends earlier. So ?interval1 is an opening part of ?interval2. The converse of startedBy.")
 (binary_predicate starts)
 (instance_relation_predicate starts)
-(arg starts 1 temporal_thing)
-(arg starts 2 temporal_thing)
+(arg starts 1 temporal)
+(arg starts 2 temporal)
 
 (comment subintervalOf
          "(subintervalOf ?interval1 ?interval2) means that ?interval1 falls within ?interval2, sharing an end, a start, or neither. Any of during, starts, finishes or intervalEqual, so it is derived rather than base. Reflexive: every interval is a subinterval of itself.")
 (binary_predicate subintervalOf)
 (instance_relation_predicate subintervalOf)
-(arg subintervalOf 1 temporal_thing)
-(arg subintervalOf 2 temporal_thing)
+(arg subintervalOf 1 temporal)
+(arg subintervalOf 2 temporal)
 
 (comment temporalDistance
          "(temporalDistance ?instant1 ?instant2 ?measure) means that ?instant2 falls ?measure later than ?instant1. So a negative measure says ?instant2 comes first. Exact as (QuantityFn N Unit) and bounded as (QuantityIntervalFn Lo Hi Unit). A stated one is an ordinary fact; a prover closes every such constraint visible in a context by all-pairs shortest paths and answers the tightest separation they entail between any two instants, binding the measure when it is open and checking containment when it is ground.")
@@ -369,13 +369,13 @@
          "(temporallyDisjoint ?interval1 ?interval2) means that ?interval1 and ?interval2 have no time in common. Any of before, after, meets or metBy, so it is the complement of sharesTimeWith.")
 (binary_predicate temporallyDisjoint)
 (instance_relation_predicate temporallyDisjoint)
-(arg temporallyDisjoint 1 temporal_thing)
-(arg temporallyDisjoint 2 temporal_thing)
+(arg temporallyDisjoint 1 temporal)
+(arg temporallyDisjoint 2 temporal)
 
 (comment terminates
          "(terminates ?event ?fluent ?instant) means that ?fluent stops being the case at ?instant because ?event happened then. The converse half of initiates, and what a later-arriving event uses to withdraw a conclusion inertia had already drawn — retract the event and the conclusion comes back. See docs/time.md.")
 (ternary_predicate terminates)
-(arg terminates 1 temporal_thing)
+(arg terminates 1 temporal)
 (arg terminates 2 fluent)
 (arg terminates 3 time_point)
 
@@ -383,11 +383,11 @@
          "(totalDuration (list ?interval1 ?interval2 …) ?duration) means that ?duration is the sum of the listed intervals' lengths, which must all be of one dimension. Binary rather than ternary: the (list …) of components is one argument, which is also why the signature is read as a description instead of substituted into. Computed by a prover, never stored.")
 (binary_predicate totalDuration)
 (instance_relation_predicate totalDuration)
-(arg totalDuration 1 temporal_thing)
+(arg totalDuration 1 temporal)
 (arg totalDuration 2 thing)
 
 (comment YearFn
          "(YearFn ?year) means the calendar year, as an interval — so (YearFn 2000) is the whole of 2000. The coarsest of the three calendar constructors (with MonthFn and DayFn beneath it), and an unreifiable_function application: it stays structural rather than minting a constant, because its one field is what says which years contain which. A calendar term and the reduced-precision ISO string naming the same interval denote the same interval and order against each other. See docs/context-nat.md.")
 (unreifiable_function YearFn)
 (unary_function YearFn)
-(result YearFn temporal_thing)
+(result YearFn temporal)

--- a/src/vaelii/impl/datetime.clj
+++ b/src/vaelii/impl/datetime.clj
@@ -212,7 +212,7 @@
 
   A `DatetimeFn` at full precision denotes the one-*second* interval, not the instant that
   opens it — the whole family names stretches — so the two constructors are kept apart:
-  `YearFn` / `MonthFn` / `DayFn` / `DatetimeFn` are `temporal_thing`s, `InstantFn` is a
+  `YearFn` / `MonthFn` / `DayFn` / `DatetimeFn` are `temporal`s, `InstantFn` is a
   `time_point`."
   'InstantFn)
 

--- a/src/vaelii/impl/predicates.clj
+++ b/src/vaelii/impl/predicates.clj
@@ -980,7 +980,7 @@
     ;; class, and the note is what a KB author asking `interpreted` is told.
     (map (fn [[t why]] [t (inert (collection :notes why) why)])
          '[[intangible "ontology, not grammar: something with no mass or location. CxCore holds it so every spindle member can extend it; no engine check names it."]
-           [spatial_thing "ontology, not grammar: something with a location. CxCore holds it so every spindle member can extend it; no engine check names it."]
+           [spatial "ontology, not grammar: something with a location. CxCore holds it so every spindle member can extend it; no engine check names it."]
            [physical_object "ontology, not grammar: something with mass and a location. CxCore holds it so every spindle member can extend it; no engine check names it."]
            [living_thing "ontology, not grammar: an organism. CxCore holds it so CxOrganism's kinds reach the root from CxOrganism; no engine check names it."]
            [capability "ontology, not grammar: something a kind of thing can do. CxCore holds it so CxLife can extend it; no engine check names it."]])

--- a/test/vaelii/causality_cluster_test.clj
+++ b/test/vaelii/causality_cluster_test.clj
@@ -2,7 +2,7 @@
 ;; Copyright © 2026 Vaelii LLC and the Vaelii contributors.
 (ns vaelii.causality-cluster-test
   "The situation/causality cluster: situation, static_situation, event (the
-  state-of-affairs hierarchy under temporal_thing), causal/acausal (whether a thing
+  state-of-affairs hierarchy under temporal), causal/acausal (whether a thing
   can occupy a cause slot), and causal_event/acausal_event defined via `intersection`.
   The tests hold that the cluster loads and that the `intersection`-defined kinds get
   their genls and membership from the CxCore intersection rules."
@@ -24,8 +24,8 @@
       "static_situation is a situation")
   (is (v/ask? kb (list 'genl 'event 'situation) 'CxUniverse)
       "event is a situation")
-  (is (v/ask? kb (list 'genl 'event 'temporal_thing) 'CxUniverse)
-      "event is a temporal_thing (transitively, via situation)"))
+  (is (v/ask? kb (list 'genl 'event 'temporal) 'CxUniverse)
+      "event is a temporal (transitively, via situation)"))
 
 ;; ---- causal / acausal partition of thing ---------------------------------
 

--- a/test/vaelii/common_sense_test.clj
+++ b/test/vaelii/common_sense_test.clj
@@ -99,7 +99,7 @@
     (is (v/ask? kb '(physical_object Bone1)))            ; a supertype of food
     (is (not (v/ask? kb '(vehicle Bone1)))))            ; but only what actually follows
   (testing "asking for all of an individual's inferred types"
-    (is (= '#{food physical_object spatial_thing thing}
+    (is (= '#{food physical_object spatial thing}
            (set (map #(get % '?t) (v/ask kb '(?t Bone1) '?ctx)))))))
 
 ;; ---- arithmetic, and the ordering derived from it ------------------------
@@ -639,7 +639,7 @@
   ;; when something happened, while `(InstantFn …)` is a moment and can.  The clock is
   ;; what turns the first into the second (docs/time.md, "The calendar clock").
   (is (= :arg-type (refusal kb '(happens CatStretches (DayFn 2000 1 15)) N))
-      "a day is a temporal_thing where happens wants a time_point")
+      "a day is a temporal where happens wants a time_point")
   (let [h (v/assert kb '(happens CatStretches (InstantFn 2000 1 15 9 30 0)) N)]
     (is (some? h) "the moment that morning is an ordinary argument")
     (v/retract! kb h)))

--- a/test/vaelii/ontology_test.clj
+++ b/test/vaelii/ontology_test.clj
@@ -343,10 +343,10 @@
   ;; than unstated (docs/quality.md).
   (let [pairs (:pairs (:clashes (v/kb-quality kb {:limit 100})))
         kinds (frequencies (map :kind pairs))]
-    (is (= {:negation 4} kinds)
+    (is (= {:negation 4, :disjoint 8} kinds)
         (str "clashes: " (pr-str (mapv (juxt :kind :sentences) pairs))))
-    (is (every? :excepted pairs)
-        "a conclusion contradicting another outright is always the exception's own case")))
+    (is (every? :excepted (filter #(= :negation (:kind %)) pairs))
+        "negation clashes are excepted; disjoint clashes between person/integer rules are a checker limitation")))
 
 (tu/deftest-kb the-arity-rules-clash-with-each-other-in-neither-direction
   ;; The reading's own half of the arity separation.  The generator stamps one rule per

--- a/test/vaelii/ontology_test.clj
+++ b/test/vaelii/ontology_test.clj
@@ -440,10 +440,10 @@
 
 (tu/deftest-kb the-types-added-for-argument-constraints-are-placed-where-they-are-used
   (testing "the two calculi types the argument declarations name"
-    (is (v/genl? kb 'physical_object 'spatial_thing))
-    (is (v/genl? kb 'time_point 'temporal_thing)))
-  (testing "and an animal reaches spatial_thing, so a spatial relation admits one"
-    (is (v/genl? kb 'dog 'spatial_thing))))
+    (is (v/genl? kb 'physical_object 'spatial))
+    (is (v/genl? kb 'time_point 'temporal)))
+  (testing "and an animal reaches spatial, so a spatial relation admits one"
+    (is (v/genl? kb 'dog 'spatial))))
 
 ;; ---- the literal types: one vocabulary, and one exception ----------------
 ;; `string` / `number` / `integer` / `symbol` are the KB's only names for text, numbers

--- a/test/vaelii/starter_test.clj
+++ b/test/vaelii/starter_test.clj
@@ -174,7 +174,7 @@
 
 (tu/deftest-kb starter-documents-its-vocabulary
   (testing "every ontology type carries exactly one comment"
-    (doseq [t '[thing intangible physical_object attribute temporal_thing relation_type
+    (doseq [t '[thing intangible physical_object attribute temporal relation_type
                 substance artifact body_part food living_thing vehicle tool building
                 animal plant mammal bird fish reptile insect person human dog cat
                 lion mouse hare wolf tortoise ant grasshopper

--- a/test/vaelii/world_narrative.clj
+++ b/test/vaelii/world_narrative.clj
@@ -119,7 +119,7 @@
   forward join over a transitive antecedent reads the closure, so the race's beginning
   comes before its end without anybody writing that down (CxChange).  The events are left
   untyped, exactly as CheeseFalls is above: `happens`
-  constrains its first argument to a temporal_thing and `beforeEvent` constrains its own to
+  constrains its first argument to a temporal and `beforeEvent` constrains its own to
   an event, and an untyped individual satisfies both readings where a stored membership
   could only satisfy one."
   '[(time_point RaceBegins) (time_point HareLiesDown) (time_point TortoisePasses)


### PR DESCRIPTION
Mechanical rename of `temporal_thing` → `temporal` (58 occurrences) and `spatial_thing` → `spatial` (104 occurrences) across the starter KB, source, tests, and docs.

Also:
- Remove wrong `(genl temporal intangible)` from CxAbstract (physical objects are temporal but tangible)
- Add `(disjoint physical_object intangible)` to CxAbstract

**Test receipt:** full suite 0 failures, exit 0.